### PR TITLE
fix(rdb): update endpoints handling

### DIFF
--- a/docs/resources/rdb_instance.md
+++ b/docs/resources/rdb_instance.md
@@ -24,25 +24,6 @@ resource "scaleway_rdb_instance" "main" {
 }
 ```
 
-### Example With IPAM
-
-```hcl
-resource "scaleway_vpc_private_network" "pn" {}
-
-resource "scaleway_rdb_instance" "main" {
-  name           = "test-rdb"
-  node_type      = "DB-DEV-S"
-  engine         = "PostgreSQL-11"
-  is_ha_cluster  = true
-  disable_backup = true
-  user_name      = "my_initial_user"
-  password       = "thiZ_is_v&ry_s3cret"
-  private_network {
-    pn_id = scaleway_vpc_private_network.pn.id
-  }
-}
-```
-
 ### Example with Settings
 
 ```hcl
@@ -79,37 +60,56 @@ resource "scaleway_rdb_instance" "main" {
 }
 ```
 
-### Example with custom private network
+### Examples of endpoints configuration
+
+RDB Instances can have a maximum of 1 public endpoint and 1 private endpoint. It can have both, or none.
+
+#### 1 static private network endpoint
 
 ```hcl
-# VPC PRIVATE NETWORK
 resource "scaleway_vpc_private_network" "pn" {
-  name = "my_private_network"
   ipv4_subnet {
     subnet = "172.16.20.0/22"
   }
 }
 
-# RDB INSTANCE CONNECTED ON A CUSTOM PRIVATE NETWORK
 resource "scaleway_rdb_instance" "main" {
-  name              = "test-rdb"
   node_type         = "db-dev-s"
   engine            = "PostgreSQL-11"
-  is_ha_cluster     = false
-  disable_backup    = true
-  user_name         = "my_initial_user"
-  password          = "thiZ_is_v&ry_s3cret"
-  region            = "fr-par"
-  tags              = ["terraform-test", "scaleway_rdb_instance", "volume", "rdb_pn"]
-  volume_type       = "bssd"
-  volume_size_in_gb = 10
   private_network {
-    ip_net = "172.16.20.4/22" # IP address within a given IP network
     pn_id  = scaleway_vpc_private_network.pn.id
+    ip_net = "172.16.20.4/22"   # IP address within a given IP network
+    (enable_ipam = false)
   }
-  disable_public_endpoint = true
 }
 ```
+
+#### 1 IPAM private network endpoint + 1 public endpoint
+
+```hcl
+resource "scaleway_vpc_private_network" "pn" {}
+
+resource "scaleway_rdb_instance" "main" {
+  node_type      = "DB-DEV-S"
+  engine         = "PostgreSQL-11"
+  private_network {
+    pn_id = scaleway_vpc_private_network.pn.id
+    (enable_ipam = true)
+  }
+  load_balancer {}
+}
+```
+
+#### Default: 1 public endpoint
+
+```hcl
+resource "scaleway_rdb_instance" "main" {
+  node_type         = "db-dev-s"
+  engine            = "PostgreSQL-11"
+}  
+```
+
+-> If nothing is defined, your instance will have a default public load-balancer endpoint
 
 ## Arguments Reference
 
@@ -145,6 +145,16 @@ and if you are using `bssd` storage, you should increase the volume size before 
 
 - `name` - (Optional) The name of the Database Instance.
 
+- `tags` - (Optional) The tags associated with the Database Instance.
+
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`) The [region](../guides/regions_and_zones.md#regions)
+  in which the Database Instance should be created.
+
+- `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the project the Database
+  Instance is associated with.
+
+### Backups
+
 - `disable_backup` - (Optional) Disable automated backup for the database instance.
 
 - `backup_schedule_frequency` - (Optional) Backup schedule frequency in hours.
@@ -153,40 +163,32 @@ and if you are using `bssd` storage, you should increase the volume size before 
 
 - `backup_same_region` - (Optional) Boolean to store logical backups in the same region as the database instance.
 
+### Settings
+
+- `settings` - (Optional) Map of engine settings to be set. Using this option will override default config.
+
 - `init_settings` - (Optional) Map of engine settings to be set at database initialisation.
 
 ~> **Important:** Updates to `init_settings` will recreate the Database Instance.
 
-- `settings` - (Optional) Map of engine settings to be set. Using this option will override default config.
+Please consult the [GoDoc](https://pkg.go.dev/github.com/scaleway/scaleway-sdk-go@v1.0.0-beta.9/api/rdb/v1#EngineVersion) to list all available `settings` and `init_settings` for the `node_type` of your convenience.
 
-- `tags` - (Optional) The tags associated with the Database Instance.
+### Endpoints
 
-- `disable_public_endpoint` - (Optional) Disable the default public endpoint
+- `private_network` - List of private networks endpoints of the database instance.
 
-- `region` - (Defaults to [provider](../index.md#region) `region`) The [region](../guides/regions_and_zones.md#regions)
-  in which the Database Instance should be created.
-
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the Database
-  Instance is associated with.
-
-## Settings
-
-Please consult
-the [GoDoc](https://pkg.go.dev/github.com/scaleway/scaleway-sdk-go@v1.0.0-beta.9/api/rdb/v1#EngineVersion) to list all
-available `settings` and `init_settings` on your `node_type` of your convenient.
-
-## Private Network
-
-~> **Important:** Updates to `private_network` will recreate the attachment Instance.
-
-~> **NOTE:** Please calculate your host IP.
-using [cirhost](https://developer.hashicorp.com/terraform/language/functions/cidrhost). Otherwise, lets IPAM service
+    - `pn_id` - (Required) The ID of the private network.
+    - `enable_ipam` - (Optional) Whether the endpoint should be configured with IPAM. Defaults to `false` if `ip_net` is defined, `true` otherwise.
+    - `ip_net` - (Optional) The IP network address within the private subnet. This must be an IPv4 address with a CIDR notation.
+    The IP network address within the private subnet is determined by the IP Address Management (IPAM) service if not set.
+  
+~> **NOTE:** Please calculate your host IP using [cidrhost](https://developer.hashicorp.com/terraform/language/functions/cidrhost). Otherwise, let IPAM service
 handle the host IP on the network.
 
-- `ip_net` - (Optional) The IP network address within the private subnet. This must be an IPv4 address with a
-  CIDR notation. The IP network address within the private subnet is determined by the IP Address Management (IPAM)
-  service if not set.
-- `pn_id` - (Required) The ID of the private network.
+~> **Important:** Updates to `private_network` will recreate the Instance's endpoint
+
+- `load_balancer` - (Optional) List of load balancer endpoints of the database instance. A load-balancer endpoint will be set by default if no private network is.
+This block must be defined if you want a public endpoint in addition to your private endpoint.
 
 ## Attributes Reference
 

--- a/scaleway/data_source_ipam_ip_test.go
+++ b/scaleway/data_source_ipam_ip_test.go
@@ -139,7 +139,7 @@ func TestAccScalewayDataSourceIPAMIP_RDB(t *testing.T) {
 					}
 
 					resource scaleway_rdb_instance main {
-						name = "test-rdb"
+						name = "test-ipam-ip-rdb"
 						node_type = "db-dev-s"
 						engine = "PostgreSQL-14"
 						is_ha_cluster = false

--- a/scaleway/resource_rdb_instance.go
+++ b/scaleway/resource_rdb_instance.go
@@ -147,6 +147,12 @@ func resourceScalewayRdbInstance() *schema.Resource {
 							DiffSuppressFunc: diffSuppressFuncLocality,
 							Description:      "The private network ID",
 						},
+						"enable_ipam": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							Description: "Whether or not the private network endpoint should be configured with IPAM",
+						},
 						// Computed
 						"endpoint_id": {
 							Type:        schema.TypeString,
@@ -185,12 +191,6 @@ func resourceScalewayRdbInstance() *schema.Resource {
 						"zone": zoneSchema(),
 					},
 				},
-			},
-			"disable_public_endpoint": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "Whether the instance should have a public endpoint if it has a Private Network attached",
 			},
 			// Computed
 			"endpoint_ip": {
@@ -235,6 +235,7 @@ func resourceScalewayRdbInstance() *schema.Resource {
 			},
 			"load_balancer": {
 				Type:        schema.TypeList,
+				Optional:    true,
 				Computed:    true,
 				Description: "Load balancer of the database instance",
 				Elem: &schema.Resource{
@@ -307,13 +308,17 @@ func resourceScalewayRdbInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	// Init Endpoints
-	pn, pnExist := d.GetOk("private_network")
-	if pnExist {
-		createReq.InitEndpoints, err = expandPrivateNetwork(pn, pnExist)
+	if pn, pnExist := d.GetOk("private_network"); pnExist {
+		enableIpam := true
+		if _, ipNetSet := d.GetOk("private_network.0.ip_net"); ipNetSet {
+			enableIpam = false
+		}
+		createReq.InitEndpoints, err = expandPrivateNetwork(pn, pnExist, enableIpam)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-	} else {
+	}
+	if _, lbExists := d.GetOk("load_balancer"); lbExists {
 		createReq.InitEndpoints = append(createReq.InitEndpoints, expandLoadBalancer())
 	}
 
@@ -373,27 +378,6 @@ func resourceScalewayRdbInstanceCreate(ctx context.Context, d *schema.ResourceDa
 		})
 		if err != nil {
 			return diag.FromErr(err)
-		}
-	}
-
-	// Remove public endpoint if disabled
-	if disabled := d.Get("disable_public_endpoint"); disabled.(bool) {
-		// retrieve state
-		res, err := waitForRDBInstance(ctx, rdbAPI, region, res.ID, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		for _, endpoint := range res.Endpoints {
-			if endpoint.LoadBalancer == nil {
-				continue
-			}
-			err = rdbAPI.DeleteEndpoint(&rdb.DeleteEndpointRequest{
-				Region:     region,
-				EndpointID: endpoint.ID,
-			}, scw.WithContext(ctx))
-			if err != nil {
-				return diag.FromErr(err)
-			}
 		}
 	}
 
@@ -480,13 +464,16 @@ func resourceScalewayRdbInstanceRead(ctx context.Context, d *schema.ResourceData
 	_ = d.Set("init_settings", flattenInstanceSettings(res.InitSettings))
 
 	// set endpoints
-	pnI, pnExist := flattenPrivateNetwork(res.Endpoints)
-	if pnExist {
+	enableIpam, err := isIpamEndpoint(res, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if pnI, pnExist := flattenPrivateNetwork(res.Endpoints, enableIpam); pnExist {
 		_ = d.Set("private_network", pnI)
 	}
-	lbI, lbExists := flattenLoadBalancer(res.Endpoints)
-	_ = d.Set("load_balancer", lbI)
-	_ = d.Set("disable_public_endpoint", !lbExists)
+	if lbI, lbExists := flattenLoadBalancer(res.Endpoints); lbExists {
+		_ = d.Set("load_balancer", lbI)
+	}
 
 	return nil
 }
@@ -699,6 +686,7 @@ func resourceScalewayRdbInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 			return diag.FromErr(err)
 		}
 
+		// delete old endpoint
 		for _, e := range res.Endpoints {
 			if e.PrivateNetwork != nil {
 				err := rdbAPI.DeleteEndpoint(
@@ -711,17 +699,25 @@ func resourceScalewayRdbInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 				}
 			}
 		}
-
 		// retrieve state
 		_, err = waitForRDBInstance(ctx, rdbAPI, region, ID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
-
-		// set new endpoints
+		// set new endpoint
 		pn, pnExist := d.GetOk("private_network")
 		if pnExist {
-			privateEndpoints, err := expandPrivateNetwork(pn, pnExist)
+			// "enable_ipam" is not readable from the API, so we just read the user's config
+			enableIpam := true
+			if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
+				pnRawConfig := rawConfig.AsValueMap()["private_network"].AsValueSlice()[0].AsValueMap()
+				if !pnRawConfig["enable_ipam"].IsNull() && pnRawConfig["enable_ipam"].False() ||
+					!pnRawConfig["ip_net"].IsNull() {
+					enableIpam = false
+				}
+			}
+
+			privateEndpoints, err := expandPrivateNetwork(pn, pnExist, enableIpam)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -735,37 +731,38 @@ func resourceScalewayRdbInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 			}
 		}
 	}
-
-	// Remove public endpoint if disabled
-	if d.HasChanges("disable_public_endpoint") {
+	if d.HasChanges("load_balancer") {
 		// retrieve state
 		res, err := waitForRDBInstance(ctx, rdbAPI, region, ID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		disabled, set := d.GetOk("disable_public_endpoint")
-
-		if !disabled.(bool) || !set {
-			_, err = rdbAPI.CreateEndpoint(&rdb.CreateEndpointRequest{
+		// delete old endpoint
+		for _, e := range res.Endpoints {
+			if e.LoadBalancer != nil {
+				err := rdbAPI.DeleteEndpoint(&rdb.DeleteEndpointRequest{
+					EndpointID: e.ID,
+					Region:     region,
+				}, scw.WithContext(ctx))
+				if err != nil {
+					diag.FromErr(err)
+				}
+			}
+		}
+		// retrieve state
+		_, err = waitForRDBInstance(ctx, rdbAPI, region, ID, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// set new endpoint
+		if _, lbExists := d.GetOk("load_balancer"); lbExists {
+			_, err := rdbAPI.CreateEndpoint(&rdb.CreateEndpointRequest{
 				Region:       region,
 				InstanceID:   ID,
 				EndpointSpec: expandLoadBalancer(),
 			}, scw.WithContext(ctx))
 			if err != nil {
 				return diag.FromErr(err)
-			}
-		} else {
-			for _, endpoint := range res.Endpoints {
-				if endpoint.LoadBalancer == nil {
-					continue
-				}
-				err = rdbAPI.DeleteEndpoint(&rdb.DeleteEndpointRequest{
-					Region:     region,
-					EndpointID: endpoint.ID,
-				}, scw.WithContext(ctx))
-				if err != nil {
-					return diag.FromErr(err)
-				}
 			}
 		}
 	}

--- a/scaleway/testdata/data-source-ipamiprdb.cassette.yaml
+++ b/scaleway/testdata/data-source-ipamiprdb.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-rdb","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-rdb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
     method: POST
   response:
-    body: '{"created_at":"2023-10-24T16:05:34.390690Z","id":"0ebfe916-e608-4927-850a-7014f5ef6438","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:05:34.390690Z"}'
+    body: '{"created_at":"2023-12-18T12:46:03.378119Z","id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-12-18T12:46:03.378119Z"}'
     headers:
       Content-Length:
       - "354"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:05:34 GMT
+      - Mon, 18 Dec 2023 12:46:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0d56b0f-80a5-4dab-9a44-4716fb5895d1
+      - 6c4184c9-4a4e-4376-b97e-bca5160e9021
     status: 200 OK
     code: 200
     duration: ""
@@ -41,12 +41,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0ebfe916-e608-4927-850a-7014f5ef6438
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/42a964fd-008a-4389-9d1d-1e60f3ed22bc
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:05:34.390690Z","id":"0ebfe916-e608-4927-850a-7014f5ef6438","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:05:34.390690Z"}'
+    body: '{"created_at":"2023-12-18T12:46:03.378119Z","id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-12-18T12:46:03.378119Z"}'
     headers:
       Content-Length:
       - "354"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:05:34 GMT
+      - Mon, 18 Dec 2023 12:46:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -65,23 +65,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f8c9e54-836d-4a0d-a19f-6b24eb5d2af4
+      - da0696c2-c040-4dec-b4a1-8f9a42f8aed4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-rdb","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":["172.16.0.0/22"],"vpc_id":"0ebfe916-e608-4927-850a-7014f5ef6438"}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-rdb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":["172.16.0.0/22"],"vpc_id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-24T16:05:34.577065Z","dhcp_enabled":true,"id":"57f41753-dfdf-47b9-8130-6e1c69152322","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:05:34.577065Z","id":"b1824d87-f76d-4996-845e-1d87ff059d88","subnet":"172.16.0.0/22","updated_at":"2023-10-24T16:05:34.577065Z"},{"created_at":"2023-10-24T16:05:34.577065Z","id":"9db26f76-b6c4-4b02-9c84-0a6b5cc9bbf8","subnet":"fd46:78ab:30b8:4ab5::/64","updated_at":"2023-10-24T16:05:34.577065Z"}],"tags":[],"updated_at":"2023-10-24T16:05:34.577065Z","vpc_id":"0ebfe916-e608-4927-850a-7014f5ef6438"}'
+    body: '{"created_at":"2023-12-18T12:46:03.672007Z","dhcp_enabled":true,"id":"6f74ab79-2409-4233-a401-b7877b374a49","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:46:03.672007Z","id":"49a10f5a-c23a-4410-8958-f170775c7f2f","subnet":"172.16.0.0/22","updated_at":"2023-12-18T12:46:03.672007Z"},{"created_at":"2023-12-18T12:46:03.672007Z","id":"107c89b2-1bac-4527-962e-74b829800374","subnet":"fd5f:519c:6d46:34f4::/64","updated_at":"2023-12-18T12:46:03.672007Z"}],"tags":[],"updated_at":"2023-12-18T12:46:03.672007Z","vpc_id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc"}'
     headers:
       Content-Length:
       - "714"
@@ -90,7 +90,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:05:35 GMT
+      - Mon, 18 Dec 2023 12:46:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 332b35e1-5163-4ce8-8918-03e09b82e1fc
+      - 9f98b1b5-9e4c-4dc3-953c-d1a3c8f1b28c
     status: 200 OK
     code: 200
     duration: ""
@@ -109,12 +109,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57f41753-dfdf-47b9-8130-6e1c69152322
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6f74ab79-2409-4233-a401-b7877b374a49
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:05:34.577065Z","dhcp_enabled":true,"id":"57f41753-dfdf-47b9-8130-6e1c69152322","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:05:34.577065Z","id":"b1824d87-f76d-4996-845e-1d87ff059d88","subnet":"172.16.0.0/22","updated_at":"2023-10-24T16:05:34.577065Z"},{"created_at":"2023-10-24T16:05:34.577065Z","id":"9db26f76-b6c4-4b02-9c84-0a6b5cc9bbf8","subnet":"fd46:78ab:30b8:4ab5::/64","updated_at":"2023-10-24T16:05:34.577065Z"}],"tags":[],"updated_at":"2023-10-24T16:05:34.577065Z","vpc_id":"0ebfe916-e608-4927-850a-7014f5ef6438"}'
+    body: '{"created_at":"2023-12-18T12:46:03.672007Z","dhcp_enabled":true,"id":"6f74ab79-2409-4233-a401-b7877b374a49","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:46:03.672007Z","id":"49a10f5a-c23a-4410-8958-f170775c7f2f","subnet":"172.16.0.0/22","updated_at":"2023-12-18T12:46:03.672007Z"},{"created_at":"2023-12-18T12:46:03.672007Z","id":"107c89b2-1bac-4527-962e-74b829800374","subnet":"fd5f:519c:6d46:34f4::/64","updated_at":"2023-12-18T12:46:03.672007Z"}],"tags":[],"updated_at":"2023-12-18T12:46:03.672007Z","vpc_id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc"}'
     headers:
       Content-Length:
       - "714"
@@ -123,7 +123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:05:35 GMT
+      - Mon, 18 Dec 2023 12:46:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,32 +133,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99e4289b-3678-460a-a88c-745bc751e7ac
+      - be89a3d9-f688-4b09-9f38-5cf6c0b47bbb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"test-rdb","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","ipam_config":{}}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-ipam-ip-rdb","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","ipam_config":{}}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":null,"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1077"
+      - "1085"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:05:36 GMT
+      - Mon, 18 Dec 2023 12:46:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7ed48d0-978f-4448-a2bd-113f748d635e
+      - be964aed-de80-432d-9949-60fc145a3332
     status: 200 OK
     code: 200
     duration: ""
@@ -177,21 +177,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":null,"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1077"
+      - "1085"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:05:36 GMT
+      - Mon, 18 Dec 2023 12:46:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c97e164e-f129-4451-9437-eb5687acab7c
+      - b609cada-71cb-49be-99b2-666321a16d62
     status: 200 OK
     code: 200
     duration: ""
@@ -210,21 +210,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":null,"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1077"
+      - "1085"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:06:06 GMT
+      - Mon, 18 Dec 2023 12:46:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26b471e3-f9b4-4114-8e1b-85b8c433efe2
+      - 22ef2b35-74a7-407d-952d-9476f1b92855
     status: 200 OK
     code: 200
     duration: ""
@@ -243,21 +243,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":null,"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1077"
+      - "1085"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:06:36 GMT
+      - Mon, 18 Dec 2023 12:47:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4a22626-e073-483a-8338-8294336ff5f9
+      - 62e9fe33-3a6e-4c6e-8117-fb0aa3b6f1b2
     status: 200 OK
     code: 200
     duration: ""
@@ -276,21 +276,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":null,"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1077"
+      - "1085"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:07:06 GMT
+      - Mon, 18 Dec 2023 12:47:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -300,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b54a9a69-cb9b-4bd8-a093-2d1f29faa543
+      - 2d4cb243-1a1e-467e-86f6-5c1ac4d46a6d
     status: 200 OK
     code: 200
     duration: ""
@@ -309,21 +309,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":null,"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1077"
+      - "1085"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:07:36 GMT
+      - Mon, 18 Dec 2023 12:48:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -333,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 645ac3c1-f289-4f48-ade2-9bf1bdfcd977
+      - 59222eda-d273-4335-a0e7-8f554dddea87
     status: 200 OK
     code: 200
     duration: ""
@@ -342,21 +342,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":null,"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1077"
+      - "1085"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:07 GMT
+      - Mon, 18 Dec 2023 12:48:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e79b295a-6085-4f1a-b16b-d31e4da90a2e
+      - 6b10295a-722a-43bf-98b0-bc37da7bf5ce
     status: 200 OK
     code: 200
     duration: ""
@@ -375,21 +375,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764},"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}},{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1551"
+      - "1342"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:37 GMT
+      - Mon, 18 Dec 2023 12:49:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23120987-e0ea-4003-99d1-abc513c922e2
+      - 0b67cdee-28f7-4e66-a9eb-4ddc9961c525
     status: 200 OK
     code: 200
     duration: ""
@@ -408,21 +408,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzRENDQXBpZ0F3SUJBZ0lVU3JIRXdDZ01JdHRLYms4VUk5UW4xejJLSlI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTR3TGpJd0hoY05Nak14Ck1ESTBNVFl3TmpVd1doY05Nek14TURJeE1UWXdOalV3V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpBdU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFON01QLy9qNUlycWNiUUNrRHd2Y1VqNGZOK2JkRTR3TGhtNm1odEtVVUw0RTFJZmYzQzk1U240OFd3M0d0TTgKdG5wNzE2eG52bitld2ZNVzlYbTF5LzdPVzBmVnFJM3lzSTYxRG9ocGhVUDk3d3kwQWwwL1lVd1hXVU43L3VHUwpNcnhFZEpjMUxSaU1wRDhJbVIxL1dkaXJFYjJBZWRKTHl0Z2VqOE1MbDRMRldCUW5sS3ozODlnZnVqa0pyVCtVCld0bThpL004T3UzWlhGd0pOQ0M1L1hYeWxNS3FGd0d0WWVtbUdIcUxrdCs0dmZmL0dONTNRRDBzbGNPVDdYSUcKRjg5NDNXcUdmSHVIampLakJsdTloRWUzUkNhMFVNLzMzdWdFZ0NmUU91NUZZTE9wMVFocVRjNXhBQVJ0dUxLZwpYNHZONFJBcTFYWEJlMzdzd1RwalpiTUNBd0VBQWFONE1IWXdkQVlEVlIwUkJHMHdhNElLTVRjeUxqRTJMakF1Ck1vSU5OVEV1TVRVNUxqSTJMakUwT0lJOGNuY3RNekptTVdVNU5UWXROekJrWXkwMFpqSTBMVGsxTkRRdFpUa3kKTXpkbVpHSTNOek0xTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK2tYaHdTc0VBQUNod1F6bnhxVQpNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFJdnk4NnA4bnQybnVSUXRManJRWXhMQ2UveVBXOHdMaUUrZHJ2CjArWC9tZk9TOWZ1dEUvR2FKSEc4MHVOVk9Pdlkwa291a0xGTCtFTnV5WVBuRGZxVmF5NWg2eTd5WXVYQUY1TE0KcXpJa01xV3hRWkNpTXBUKzBqNW9jRzllSXJhRVRETVlZWm9OaHJRNlNVci9TOHMrMEt4WFdJOWNmZmhKLzZEagpUendRMEN1aWNPb25QSlRqbm5YT1J3U1pHc1Y3OVZ2Q0ZNbitrUk1SNDh1aXRWSWo5LytkWW1KN1hYSEtBamc0ClBlQ2Z4dEVib0FxTVpSTkljWExndVZHejJuc0g2enJKVzZnQTZBaXlJT29PUytzczB1dWV6T05uUUs1OXFrOUIKN3pGZE4yelJEMWdBNDN4WXpoVS8weFphZ0gwcEo3cXk0REtCaTBjczZlZWtGRW9hCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYVENDQWtXZ0F3SUJBZ0lVVW4zZWc3T3YydCs0Wm5laHp5VFk5UU55S0xnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTR3TGpJd0hoY05Nak14Ck1qRTRNVEkwTnpJd1doY05Nek14TWpFMU1USTBOekl3V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpBdU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFQT2U3ei9RWThnM0NVSHVBSnFPY2xDVjY4aVVYWU10RFRHY0hCMGZCSUo2UkdzQUdSQm5zUlhtWS95RzlTZVAKUDEwSU15QTFWZHlRZHhVMVhCaXhjVVROa1haNFdWR3M2a0dRblRNVmVONzRhL2lJdWN4QnZXaWtPckROVG41NAowWFdsWTJnQjNDYUF5ZkxBQ1g4V1J3NnNRM3JDRnl3Z1pwWTA0My9TMkpqZWRqVHhEaFZRcTRRaHlFMWsxY3NPCjhWMjR2VUJwdVdvc055TWliWGt1V28vbDFMS2paQ2hjcFUvU0VGZ3EwdFd1S0QrRVdmcXMzaUxqczh5N3hPcUYKZVZHMFhWQXN2REZCclFZckptQ3B5ZEkxL21ZL3ZlY1NoaFZwUTZlTU1hdE1jSWg5RUlnR1BQa0hUUTNUWUQ5aQpqbSt1eGF1b3ZNam1lTGpYUlZHdFRFVUNBd0VBQWFNbE1DTXdJUVlEVlIwUkJCb3dHSUlLTVRjeUxqRTJMakF1Ck1vY0VNdytNa0ljRXJCQUFBakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBbnZGeW0vMDlVY3RkdnByeXJabkgKMllTK1ZXWmhEYkRRMnh3TjZwUHo5Nm13Qmpka0owU0Ivb3Q2UWR2OUxuUmFtQmJIdk5yZmxhZ3FTZkxtQmNENgpjVGtweG5SaGYrdHRiODQ4NzZCMkhhR3IyWHZDM2QwbjdkQ2tjbGVpUFR0OVluNk9PcWhOSHU2NXg3MEgzbUhZCllYQjF2TXdkUVVoNStxbWVBQjE5N1puc0ZSQWpqWDBEUWdpcWEveXVqTjhsLzJCUFZzWHJwbVprdUNNNGk3dDkKZGh5QTlmYVd3dEkyUzF2SUdvZmdia3FJS2VsS0dWdEM4amF1Y09lV1NQMXlSSXE1S2ZRTG1VekNJbWhQVnVGawpVYm5LQkRQTGlpS0tPYytrd28yV2FIMElFRVQxWU9FQ1drUnA3OHlvWUQrMXAxVXp2UnV4MkszeGNPUFRKNFlYCi9nPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1863"
+      - "1719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:37 GMT
+      - Mon, 18 Dec 2023 12:49:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23c05c42-9804-44fc-a287-a9394733bd91
+      - 8514a20a-75c2-4815-b256-7e8e21ae7446
     status: 200 OK
     code: 200
     duration: ""
@@ -441,21 +441,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-rdb&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-10-24T16:05:35.889409Z","id":"a82db0fa-4ec5-4946-8085-4c5d42776258","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"32f1e956-70dc-4f24-9544-e9237fdb7735","mac_address":"02:00:00:14:68:5B","name":"test-rdb","type":"rdb_instance"},"source":{"subnet_id":"b1824d87-f76d-4996-845e-1d87ff059d88"},"tags":["managed","scwdbaas"],"updated_at":"2023-10-24T16:06:09.784361Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "504"
+      - "512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:37 GMT
+      - Mon, 18 Dec 2023 12:49:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0f25536-5772-4431-9279-89815addaadd
+      - ecb4f360-d940-43b0-b6ae-2284aa9a3d63
     status: 200 OK
     code: 200
     duration: ""
@@ -474,21 +474,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-rdb&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-ipam-ip-rdb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-10-24T16:05:35.889409Z","id":"a82db0fa-4ec5-4946-8085-4c5d42776258","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"32f1e956-70dc-4f24-9544-e9237fdb7735","mac_address":"02:00:00:14:68:5B","name":"test-rdb","type":"rdb_instance"},"source":{"subnet_id":"b1824d87-f76d-4996-845e-1d87ff059d88"},"tags":["managed","scwdbaas"],"updated_at":"2023-10-24T16:06:09.784361Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "504"
+      - "512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:37 GMT
+      - Mon, 18 Dec 2023 12:49:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29fab62d-abec-476d-961f-cc1281eff88a
+      - a2a69ebf-0bc2-4dc7-af0c-c4d7856cf8dd
     status: 200 OK
     code: 200
     duration: ""
@@ -507,12 +507,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0ebfe916-e608-4927-850a-7014f5ef6438
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-ipam-ip-rdb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:05:34.390690Z","id":"0ebfe916-e608-4927-850a-7014f5ef6438","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:05:34.390690Z"}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "512"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 12:49:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 810923e8-09dc-421c-8c89-560acdd0b4be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/42a964fd-008a-4389-9d1d-1e60f3ed22bc
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T12:46:03.378119Z","id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-12-18T12:46:03.378119Z"}'
     headers:
       Content-Length:
       - "354"
@@ -521,7 +554,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:37 GMT
+      - Mon, 18 Dec 2023 12:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6234f841-7418-4c3d-9bde-71808a5179d1
+      - 5507977e-fe93-4ee0-9505-f94aeeccca90
     status: 200 OK
     code: 200
     duration: ""
@@ -540,12 +573,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57f41753-dfdf-47b9-8130-6e1c69152322
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6f74ab79-2409-4233-a401-b7877b374a49
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:05:34.577065Z","dhcp_enabled":true,"id":"57f41753-dfdf-47b9-8130-6e1c69152322","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:05:34.577065Z","id":"b1824d87-f76d-4996-845e-1d87ff059d88","subnet":"172.16.0.0/22","updated_at":"2023-10-24T16:05:34.577065Z"},{"created_at":"2023-10-24T16:05:34.577065Z","id":"9db26f76-b6c4-4b02-9c84-0a6b5cc9bbf8","subnet":"fd46:78ab:30b8:4ab5::/64","updated_at":"2023-10-24T16:05:34.577065Z"}],"tags":[],"updated_at":"2023-10-24T16:05:34.577065Z","vpc_id":"0ebfe916-e608-4927-850a-7014f5ef6438"}'
+    body: '{"created_at":"2023-12-18T12:46:03.672007Z","dhcp_enabled":true,"id":"6f74ab79-2409-4233-a401-b7877b374a49","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:46:03.672007Z","id":"49a10f5a-c23a-4410-8958-f170775c7f2f","subnet":"172.16.0.0/22","updated_at":"2023-12-18T12:46:03.672007Z"},{"created_at":"2023-12-18T12:46:03.672007Z","id":"107c89b2-1bac-4527-962e-74b829800374","subnet":"fd5f:519c:6d46:34f4::/64","updated_at":"2023-12-18T12:46:03.672007Z"}],"tags":[],"updated_at":"2023-12-18T12:46:03.672007Z","vpc_id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc"}'
     headers:
       Content-Length:
       - "714"
@@ -554,7 +587,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:37 GMT
+      - Mon, 18 Dec 2023 12:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c38554b-899b-43b0-8da5-8c5cb5245a18
+      - 005e6628-4a29-4b32-8101-1dd62feb8b94
     status: 200 OK
     code: 200
     duration: ""
@@ -573,21 +606,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764},"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}},{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1551"
+      - "1342"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:38 GMT
+      - Mon, 18 Dec 2023 12:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d2e7412-5f31-4002-9541-d5e19cd094cf
+      - 2d55da51-6b1c-45f9-aed3-1f3d9e650243
     status: 200 OK
     code: 200
     duration: ""
@@ -606,21 +639,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURzRENDQXBpZ0F3SUJBZ0lVU3JIRXdDZ01JdHRLYms4VUk5UW4xejJLSlI4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTR3TGpJd0hoY05Nak14Ck1ESTBNVFl3TmpVd1doY05Nek14TURJeE1UWXdOalV3V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpBdU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFON01QLy9qNUlycWNiUUNrRHd2Y1VqNGZOK2JkRTR3TGhtNm1odEtVVUw0RTFJZmYzQzk1U240OFd3M0d0TTgKdG5wNzE2eG52bitld2ZNVzlYbTF5LzdPVzBmVnFJM3lzSTYxRG9ocGhVUDk3d3kwQWwwL1lVd1hXVU43L3VHUwpNcnhFZEpjMUxSaU1wRDhJbVIxL1dkaXJFYjJBZWRKTHl0Z2VqOE1MbDRMRldCUW5sS3ozODlnZnVqa0pyVCtVCld0bThpL004T3UzWlhGd0pOQ0M1L1hYeWxNS3FGd0d0WWVtbUdIcUxrdCs0dmZmL0dONTNRRDBzbGNPVDdYSUcKRjg5NDNXcUdmSHVIampLakJsdTloRWUzUkNhMFVNLzMzdWdFZ0NmUU91NUZZTE9wMVFocVRjNXhBQVJ0dUxLZwpYNHZONFJBcTFYWEJlMzdzd1RwalpiTUNBd0VBQWFONE1IWXdkQVlEVlIwUkJHMHdhNElLTVRjeUxqRTJMakF1Ck1vSU5OVEV1TVRVNUxqSTJMakUwT0lJOGNuY3RNekptTVdVNU5UWXROekJrWXkwMFpqSTBMVGsxTkRRdFpUa3kKTXpkbVpHSTNOek0xTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK2tYaHdTc0VBQUNod1F6bnhxVQpNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUFJdnk4NnA4bnQybnVSUXRManJRWXhMQ2UveVBXOHdMaUUrZHJ2CjArWC9tZk9TOWZ1dEUvR2FKSEc4MHVOVk9Pdlkwa291a0xGTCtFTnV5WVBuRGZxVmF5NWg2eTd5WXVYQUY1TE0KcXpJa01xV3hRWkNpTXBUKzBqNW9jRzllSXJhRVRETVlZWm9OaHJRNlNVci9TOHMrMEt4WFdJOWNmZmhKLzZEagpUendRMEN1aWNPb25QSlRqbm5YT1J3U1pHc1Y3OVZ2Q0ZNbitrUk1SNDh1aXRWSWo5LytkWW1KN1hYSEtBamc0ClBlQ2Z4dEVib0FxTVpSTkljWExndVZHejJuc0g2enJKVzZnQTZBaXlJT29PUytzczB1dWV6T05uUUs1OXFrOUIKN3pGZE4yelJEMWdBNDN4WXpoVS8weFphZ0gwcEo3cXk0REtCaTBjczZlZWtGRW9hCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYVENDQWtXZ0F3SUJBZ0lVVW4zZWc3T3YydCs0Wm5laHp5VFk5UU55S0xnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTR3TGpJd0hoY05Nak14Ck1qRTRNVEkwTnpJd1doY05Nek14TWpFMU1USTBOekl3V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpBdU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFQT2U3ei9RWThnM0NVSHVBSnFPY2xDVjY4aVVYWU10RFRHY0hCMGZCSUo2UkdzQUdSQm5zUlhtWS95RzlTZVAKUDEwSU15QTFWZHlRZHhVMVhCaXhjVVROa1haNFdWR3M2a0dRblRNVmVONzRhL2lJdWN4QnZXaWtPckROVG41NAowWFdsWTJnQjNDYUF5ZkxBQ1g4V1J3NnNRM3JDRnl3Z1pwWTA0My9TMkpqZWRqVHhEaFZRcTRRaHlFMWsxY3NPCjhWMjR2VUJwdVdvc055TWliWGt1V28vbDFMS2paQ2hjcFUvU0VGZ3EwdFd1S0QrRVdmcXMzaUxqczh5N3hPcUYKZVZHMFhWQXN2REZCclFZckptQ3B5ZEkxL21ZL3ZlY1NoaFZwUTZlTU1hdE1jSWg5RUlnR1BQa0hUUTNUWUQ5aQpqbSt1eGF1b3ZNam1lTGpYUlZHdFRFVUNBd0VBQWFNbE1DTXdJUVlEVlIwUkJCb3dHSUlLTVRjeUxqRTJMakF1Ck1vY0VNdytNa0ljRXJCQUFBakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBbnZGeW0vMDlVY3RkdnByeXJabkgKMllTK1ZXWmhEYkRRMnh3TjZwUHo5Nm13Qmpka0owU0Ivb3Q2UWR2OUxuUmFtQmJIdk5yZmxhZ3FTZkxtQmNENgpjVGtweG5SaGYrdHRiODQ4NzZCMkhhR3IyWHZDM2QwbjdkQ2tjbGVpUFR0OVluNk9PcWhOSHU2NXg3MEgzbUhZCllYQjF2TXdkUVVoNStxbWVBQjE5N1puc0ZSQWpqWDBEUWdpcWEveXVqTjhsLzJCUFZzWHJwbVprdUNNNGk3dDkKZGh5QTlmYVd3dEkyUzF2SUdvZmdia3FJS2VsS0dWdEM4amF1Y09lV1NQMXlSSXE1S2ZRTG1VekNJbWhQVnVGawpVYm5LQkRQTGlpS0tPYytrd28yV2FIMElFRVQxWU9FQ1drUnA3OHlvWUQrMXAxVXp2UnV4MkszeGNPUFRKNFlYCi9nPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1863"
+      - "1719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:38 GMT
+      - Mon, 18 Dec 2023 12:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5c0b8dc-3334-44e9-9e09-0131440aff06
+      - e0453534-6c01-4165-96ae-4e5ba7ffcb4a
     status: 200 OK
     code: 200
     duration: ""
@@ -639,21 +672,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-rdb&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-10-24T16:05:35.889409Z","id":"a82db0fa-4ec5-4946-8085-4c5d42776258","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"32f1e956-70dc-4f24-9544-e9237fdb7735","mac_address":"02:00:00:14:68:5B","name":"test-rdb","type":"rdb_instance"},"source":{"subnet_id":"b1824d87-f76d-4996-845e-1d87ff059d88"},"tags":["managed","scwdbaas"],"updated_at":"2023-10-24T16:06:09.784361Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "504"
+      - "512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:38 GMT
+      - Mon, 18 Dec 2023 12:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd1e9e40-ad7e-4a77-abb4-2f2b5a4781c1
+      - a537215e-ccab-4009-ac12-f8cb72724ce7
     status: 200 OK
     code: 200
     duration: ""
@@ -672,21 +705,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-rdb&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-ipam-ip-rdb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-10-24T16:05:35.889409Z","id":"a82db0fa-4ec5-4946-8085-4c5d42776258","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"32f1e956-70dc-4f24-9544-e9237fdb7735","mac_address":"02:00:00:14:68:5B","name":"test-rdb","type":"rdb_instance"},"source":{"subnet_id":"b1824d87-f76d-4996-845e-1d87ff059d88"},"tags":["managed","scwdbaas"],"updated_at":"2023-10-24T16:06:09.784361Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "504"
+      - "512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:39 GMT
+      - Mon, 18 Dec 2023 12:49:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5060d884-4d91-4d34-8c3f-2049d1325aff
+      - b5b334e8-f5d3-455b-bc84-b461cc2e65a6
     status: 200 OK
     code: 200
     duration: ""
@@ -705,21 +738,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-ipam-ip-rdb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764},"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}},{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1551"
+      - "512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:40 GMT
+      - Mon, 18 Dec 2023 12:49:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa9ba2a8-b6d3-4188-9dc2-df64b8910e65
+      - d37c15bd-675c-4604-a61b-b03818466141
     status: 200 OK
     code: 200
     duration: ""
@@ -738,21 +771,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1342"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 12:49:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0547a1a3-4def-4176-916b-558246aec9b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764},"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}},{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1554"
+      - "1345"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:40 GMT
+      - Mon, 18 Dec 2023 12:49:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -762,7 +828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed1f95f8-146d-4daf-98be-07be8d67a5e8
+      - 98b18d7a-4f84-4240-bff4-b823653bcf35
     status: 200 OK
     code: 200
     duration: ""
@@ -771,21 +837,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-24T16:05:35.521503Z","endpoint":{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764},"endpoints":[{"id":"d3901c2c-12c2-4f47-b2bf-26abad5c2c76","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"57f41753-dfdf-47b9-8130-6e1c69152322","service_ip":"172.16.0.2/22","zone":"fr-par-1"}},{"id":"a94d2107-9d37-4389-9ef5-f3474c6adc72","ip":"51.159.26.148","load_balancer":{},"name":null,"port":25764}],"engine":"PostgreSQL-14","id":"32f1e956-70dc-4f24-9544-e9237fdb7735","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1554"
+      - "1345"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:08:40 GMT
+      - Mon, 18 Dec 2023 12:49:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -795,7 +861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dd6eedf-e51b-41da-9198-703bddc6b8a9
+      - fb92c769-c018-4ce1-b52b-95fef0b6d0ca
     status: 200 OK
     code: 200
     duration: ""
@@ -804,12 +870,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"32f1e956-70dc-4f24-9544-e9237fdb7735","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -818,7 +884,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:09:11 GMT
+      - Mon, 18 Dec 2023 12:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -828,7 +894,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5fc3cf3-501e-4889-be13-495349a227e2
+      - fbc78e10-c72c-4ea0-8819-c105208de5c9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -837,9 +903,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57f41753-dfdf-47b9-8130-6e1c69152322
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6f74ab79-2409-4233-a401-b7877b374a49
     method: DELETE
   response:
     body: ""
@@ -849,7 +915,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:09:11 GMT
+      - Mon, 18 Dec 2023 12:49:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -859,7 +925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d2647cb-12ed-48eb-b0ce-3d14b318372e
+      - f6a1c9a2-6d64-43c4-a905-9838e8110790
     status: 204 No Content
     code: 204
     duration: ""
@@ -868,9 +934,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/0ebfe916-e608-4927-850a-7014f5ef6438
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/42a964fd-008a-4389-9d1d-1e60f3ed22bc
     method: DELETE
   response:
     body: ""
@@ -880,7 +946,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:09:11 GMT
+      - Mon, 18 Dec 2023 12:49:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -890,7 +956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eddb689e-9581-4314-8e76-c26b5d0e36d3
+      - ca264044-9b8c-420a-bce5-e8fa160d6846
     status: 204 No Content
     code: 204
     duration: ""
@@ -899,12 +965,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/32f1e956-70dc-4f24-9544-e9237fdb7735
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"32f1e956-70dc-4f24-9544-e9237fdb7735","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -913,7 +979,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:09:11 GMT
+      - Mon, 18 Dec 2023 12:49:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -923,7 +989,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b849c76f-1ac7-4c0c-8d2e-7fa687f6fe2c
+      - 8633a68c-bd18-437d-a352-e08d32104422
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-acl-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-acl-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:55:22 GMT
+      - Mon, 18 Dec 2023 16:43:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a6b7312-f33a-4f71-94ed-224f9c1ac090
+      - d1e2522e-5279-43b1-8ddf-9a48c6f73f52
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayDataSourceRDBAcl_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"TestAccScalewayDataSourceRDBAcl_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "919"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:55:23 GMT
+      - Mon, 18 Dec 2023 16:43:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d31f562-0223-4991-b869-4565e8d6901c
+      - 5eadd504-7364-49c7-aa2b-0b05b8b81868
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "919"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:55:24 GMT
+      - Mon, 18 Dec 2023 16:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fbe624a-2a3b-4a47-b550-9eb36af0fa4b
+      - 62dd7c14-5313-45e6-8536-c828dbffb2f5
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "919"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:55:54 GMT
+      - Mon, 18 Dec 2023 16:44:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee60dc75-68fb-40bb-9f7a-b670c65df4a2
+      - 62d6a181-9fb2-47f7-b2dd-ab177ec0a301
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "919"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:56:24 GMT
+      - Mon, 18 Dec 2023 16:44:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb16f23f-71cb-4f7b-a32f-be0e4a3260cf
+      - 818fb906-70f0-4899-b4fe-85b986a7dac2
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "919"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:56:54 GMT
+      - Mon, 18 Dec 2023 16:45:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb12ed19-e60d-40eb-a3ed-68340a050a4c
+      - a31348b9-63aa-437f-90c4-58daffa5c8de
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "919"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:57:25 GMT
+      - Mon, 18 Dec 2023 16:45:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d72c7df4-ffb6-4270-9bb5-f4bd0d04f176
+      - e2f1fed1-b8c9-42e3-908e-cab9e4de55f5
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "919"
+      - "1183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:57:56 GMT
+      - Mon, 18 Dec 2023 16:46:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33bca5f7-8be7-4ec6-8725-8ca54fbbcc41
+      - d440d543-30a6-4e50-ba7f-e0d0593174b7
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:31 GMT
+      - Mon, 18 Dec 2023 16:46:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a5104fc-82a8-4945-9b58-0f08d27cf2cb
+      - fad5c1b7-f732-4539-9996-e5fc6617ac92
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:31 GMT
+      - Mon, 18 Dec 2023 16:46:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99405695-7dcb-429a-bba9-63975c432762
+      - b772603c-d237-49f4-83d3-9d50c20961c4
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:32 GMT
+      - Mon, 18 Dec 2023 16:46:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de2da485-7fae-4149-bd53-d8a102834c73
+      - 880d9ec1-4b2d-4620-93a2-86f816b4d056
     status: 200 OK
     code: 200
     duration: ""
@@ -673,7 +673,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -685,7 +685,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:33 GMT
+      - Mon, 18 Dec 2023 16:46:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 425f8763-e67c-4ae4-b33d-08374125205a
+      - de955298-acf0-4e18-9fcc-8af99427276e
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVQkF2TmNzT2ZXY3R0R3pnbG8rMGZueldtSUZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRVNE1USmFGdzB6TXpFeU1UVXhORFU0TVRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURjL3VQMkFCZFRjRkxmVFNYOUxOc0Q3UGV0d01SUnZ1U1RqZitOcEh1YVB0Qk9yeEhFamlmeEpCanUKdWh3eTNJNmR6ME5CWmRHQ2dxWTg5U0tPc1ZwczNaeUJId2FXcGFFZUp5Y1hDZ1cvNjJrQThIeVFrUDNoY2Roegp4eFAyTFZTMkJ0dmVxd2pjNFI3amowTjBBR2RXc3hyQnU4UHVpZmlBN0xpMWhiY01tNHprQnBQZEdBNUloZk5CCmlqc3N2QkVXRDQxWXpDbnZYTmpvbHlDK2hEMFVlNGoyWFpRSHB0ZWl3TDJnZy9KYU50ZFBaTHBxTXJBWURRcGkKN24yNDJGQUNEaUhUNFlReHVvZFIxT1k5WGdOZVFQdXp4T0pSbC9sV1IreU04Zjd6WlltdWswZThPcGpvVEhrVgpBSlVQYW9uOXV5LzhFczN1djRZbFJnQXh2RGtkQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkxbFpUVTJZVGRrT1MxbE1HUmhMVFE1TVRndFlXUTRaaTFqWm1ReVl6VTQKTVRGbE5UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0WldVMQpObUUzWkRrdFpUQmtZUzAwT1RFNExXRmtPR1l0WTJaa01tTTFPREV4WlRVekxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdRekQ5ZEhod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBU2lTbFkKaUgwNmswY2hqUVhETSswb0RaMjFadDBHSXF4d2lET2dFdmlYQ1ZFNkhKeTlKZWErZzQ3aWpiVnhhMENZWEo5Zwo2cFNjejJCWTI1RlRxVlprTHhjTGVud1RKYWxQY0lWRXdOR05SdVpNS2VTWXE2L0NSZk1seWl5T0FReHVnUS9xCmp5M1VNMHQ1Z0RVWVc3TXN2ZkU3cTBYemJPbzZ2QjhJOWR2NFlTUDNUdFlwYVVKVzFrR3BLSW5UU1ZDWCtBcmIKWUpEUzFMZE9zMU9LU2d2enBaeHJlTUZVU1hTaHQ0TTZNdWhOcENpcFdXcUFnN0wwU21RUERvcWMzR1hvelZUYwpoV093cnF0Qmc4K281WmJ4OWxCb1NZaFlnamFBYXdUNGRPNnJiMFJlVUtJN2pQS2h4TllPdkdneWlNS2ZIeGtNCkJEOHFlOXZrVE5lQnJKNksKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVY1RQOFdHbmFwNDdkMmIzeTlNNFBKU1BTTWN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EVTFObG9YRFRNek1USXhOVEUyTkRVMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJmUHdTZy9ibEQzbGJZTm9jcnlrRm5GSGdjeGFFRWkvRFAva090SzJ5OTFNV2xkekZIcHkKdWxxMjk3MjhVbXpxVnhoemNhVHJWZjdLM3owR3pkWFUzRzFORWZTcHltaUxLby9zNXZiTFoxRmtGWWtoTUZZeAoxT2s3eDBHSEsxMVhjOEFRK1k2QnZNUWhWbThkMmNGczBnaGZtczZwd3NHbDhLbGw0aDFtUW8rY21TZXFrb1MvCi9MZGJjN0NWaG1KYjNQbFVmKzF5VHZaL3Fad01VSW5lSE5rUDNrOTAweFI3Ujk2M0JIby9lZ1Qrdm84SEVOcm0KUUJrMUh1ZldoTnRBYisxcXVsSERJOHMwM0tWMDNEbDRWUFZ4Z1BrcUNRSS9iQ2VwZjJJWERkZFdRc3RJQ1VvKwprQWVUWjVjUkdXNi9nRmkyQkxRbTZENDlmUVFUQTJLUjdRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAwT0RVeFltSmhZUzFrTUdFekxUUXpaREV0WWpCbE9TMHoKWVdVNVkyRmlNR1ZoTXpRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwME9EVXhZbUpoWVMxa01HRXpMVFF6WkRFdFlqQmxPUzB6WVdVNVkyRmlNR1ZoTXpRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDeUNWK0hQQjZlL2xOOXNXV0J5aU1ka0tIdlFWSWwrWHI5eGtLYkVNWVFTMytSNmtuMzBQRUVOVWcrVQp3bFVYVXVLU1FHNU5JK3N0UHB2VjdFYzUwV0sxRXVXRHUrakhFeG9IaGIyM2hmbzZLUzUyQTM3WWdjVlpJdm85CnhkSWVzY0YvQ05Obk9Ea3F5YTd0NjViM2N5ZkFOVjhkMzNuUFJLdWVjb3hkR0ZmRFJvaUQvZC8xSnEvaGpJTHgKa1ROdTJhaUZ3MjlFaDhkd2xodU9TL3VSU0g3WkNDeGNYaWQ3U2wwY3RXN0NDUzFUZ1pGRmx2ZEhYNmVjSnBFegpwV3p0UmJibWFad01BRHhIbXdJQXpqU1RURXl4QWZGdzcza2xyTHRRMGFQTFoxa0pmVlVvY2pIVzdwd0NRZGRLCk5MYnYxWTh0VC91UDNHUGhpUHlUc1dYSnVnRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:33 GMT
+      - Mon, 18 Dec 2023 16:46:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad1df0bf-ee25-4240-b072-160331d2a7a3
+      - 131797e5-5387-4ebd-847f-5930303b365c
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1224"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:34 GMT
+      - Mon, 18 Dec 2023 16:46:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1893efc6-9451-4a21-a215-c4b90bb8705f
+      - d3065531-0cbd-40ff-bbfc-f9a844ce4c44
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1226"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:46:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4cadb8d4-eb31-4985-86a4-ca805e178d08
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "229"
+      - "227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:34 GMT
+      - Mon, 18 Dec 2023 16:46:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c99215e2-83ff-4735-a996-3278c8d2de90
+      - 32f20e28-b069-4e05-9e84-c1e4b079df37
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:34 GMT
+      - Mon, 18 Dec 2023 16:46:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa0af07c-f472-4e1e-b104-8846bbe4ab09
+      - 633d3345-e51f-4ed5-85b6-6e9f3fc24f02
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:04 GMT
+      - Mon, 18 Dec 2023 16:47:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e107b40-d5fe-4992-9bb1-7c4896888242
+      - d3c170df-b68c-4cac-8cf3-f74dacd7e241
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:05 GMT
+      - Mon, 18 Dec 2023 16:47:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec697304-9291-42a9-b681-881496c284a6
+      - d7e06b3a-27b5-42b3-aa03-969a6d2d792b
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:05 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6a920c4-a9a8-4906-8919-466054407746
+      - a0e5cc3e-66a7-4d8b-bede-3d046911a913
     status: 200 OK
     code: 200
     duration: ""
@@ -939,172 +972,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/users?order_by=name_asc&page=1
-    method: GET
-  response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ea554c6a-b05a-4804-93f2-f3a7987db423
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVQkF2TmNzT2ZXY3R0R3pnbG8rMGZueldtSUZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRVNE1USmFGdzB6TXpFeU1UVXhORFU0TVRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURjL3VQMkFCZFRjRkxmVFNYOUxOc0Q3UGV0d01SUnZ1U1RqZitOcEh1YVB0Qk9yeEhFamlmeEpCanUKdWh3eTNJNmR6ME5CWmRHQ2dxWTg5U0tPc1ZwczNaeUJId2FXcGFFZUp5Y1hDZ1cvNjJrQThIeVFrUDNoY2Roegp4eFAyTFZTMkJ0dmVxd2pjNFI3amowTjBBR2RXc3hyQnU4UHVpZmlBN0xpMWhiY01tNHprQnBQZEdBNUloZk5CCmlqc3N2QkVXRDQxWXpDbnZYTmpvbHlDK2hEMFVlNGoyWFpRSHB0ZWl3TDJnZy9KYU50ZFBaTHBxTXJBWURRcGkKN24yNDJGQUNEaUhUNFlReHVvZFIxT1k5WGdOZVFQdXp4T0pSbC9sV1IreU04Zjd6WlltdWswZThPcGpvVEhrVgpBSlVQYW9uOXV5LzhFczN1djRZbFJnQXh2RGtkQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkxbFpUVTJZVGRrT1MxbE1HUmhMVFE1TVRndFlXUTRaaTFqWm1ReVl6VTQKTVRGbE5UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0WldVMQpObUUzWkRrdFpUQmtZUzAwT1RFNExXRmtPR1l0WTJaa01tTTFPREV4WlRVekxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdRekQ5ZEhod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBU2lTbFkKaUgwNmswY2hqUVhETSswb0RaMjFadDBHSXF4d2lET2dFdmlYQ1ZFNkhKeTlKZWErZzQ3aWpiVnhhMENZWEo5Zwo2cFNjejJCWTI1RlRxVlprTHhjTGVud1RKYWxQY0lWRXdOR05SdVpNS2VTWXE2L0NSZk1seWl5T0FReHVnUS9xCmp5M1VNMHQ1Z0RVWVc3TXN2ZkU3cTBYemJPbzZ2QjhJOWR2NFlTUDNUdFlwYVVKVzFrR3BLSW5UU1ZDWCtBcmIKWUpEUzFMZE9zMU9LU2d2enBaeHJlTUZVU1hTaHQ0TTZNdWhOcENpcFdXcUFnN0wwU21RUERvcWMzR1hvelZUYwpoV093cnF0Qmc4K281WmJ4OWxCb1NZaFlnamFBYXdUNGRPNnJiMFJlVUtJN2pQS2h4TllPdkdneWlNS2ZIeGtNCkJEOHFlOXZrVE5lQnJKNksKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1995"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08c28ce1-2d4f-44ea-8e56-e10c9ba09e2e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1224"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dfdc9a8b-79b0-4156-ae3e-469e2e724439
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
-    method: GET
-  response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 730c3ddf-757a-4cf6-8430-43f280813ea4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1224"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a0d86ba-5bca-435c-8144-9c3045b94ff9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -1116,7 +984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:06 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8b19407-7628-4418-b894-a8a6ef4af3f0
+      - 9c501cbd-bd65-4d19-89ec-bdecac828ac2
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVQkF2TmNzT2ZXY3R0R3pnbG8rMGZueldtSUZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRVNE1USmFGdzB6TXpFeU1UVXhORFU0TVRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURjL3VQMkFCZFRjRkxmVFNYOUxOc0Q3UGV0d01SUnZ1U1RqZitOcEh1YVB0Qk9yeEhFamlmeEpCanUKdWh3eTNJNmR6ME5CWmRHQ2dxWTg5U0tPc1ZwczNaeUJId2FXcGFFZUp5Y1hDZ1cvNjJrQThIeVFrUDNoY2Roegp4eFAyTFZTMkJ0dmVxd2pjNFI3amowTjBBR2RXc3hyQnU4UHVpZmlBN0xpMWhiY01tNHprQnBQZEdBNUloZk5CCmlqc3N2QkVXRDQxWXpDbnZYTmpvbHlDK2hEMFVlNGoyWFpRSHB0ZWl3TDJnZy9KYU50ZFBaTHBxTXJBWURRcGkKN24yNDJGQUNEaUhUNFlReHVvZFIxT1k5WGdOZVFQdXp4T0pSbC9sV1IreU04Zjd6WlltdWswZThPcGpvVEhrVgpBSlVQYW9uOXV5LzhFczN1djRZbFJnQXh2RGtkQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkxbFpUVTJZVGRrT1MxbE1HUmhMVFE1TVRndFlXUTRaaTFqWm1ReVl6VTQKTVRGbE5UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0WldVMQpObUUzWkRrdFpUQmtZUzAwT1RFNExXRmtPR1l0WTJaa01tTTFPREV4WlRVekxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdRekQ5ZEhod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBU2lTbFkKaUgwNmswY2hqUVhETSswb0RaMjFadDBHSXF4d2lET2dFdmlYQ1ZFNkhKeTlKZWErZzQ3aWpiVnhhMENZWEo5Zwo2cFNjejJCWTI1RlRxVlprTHhjTGVud1RKYWxQY0lWRXdOR05SdVpNS2VTWXE2L0NSZk1seWl5T0FReHVnUS9xCmp5M1VNMHQ1Z0RVWVc3TXN2ZkU3cTBYemJPbzZ2QjhJOWR2NFlTUDNUdFlwYVVKVzFrR3BLSW5UU1ZDWCtBcmIKWUpEUzFMZE9zMU9LU2d2enBaeHJlTUZVU1hTaHQ0TTZNdWhOcENpcFdXcUFnN0wwU21RUERvcWMzR1hvelZUYwpoV093cnF0Qmc4K281WmJ4OWxCb1NZaFlnamFBYXdUNGRPNnJiMFJlVUtJN2pQS2h4TllPdkdneWlNS2ZIeGtNCkJEOHFlOXZrVE5lQnJKNksKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVY1RQOFdHbmFwNDdkMmIzeTlNNFBKU1BTTWN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EVTFObG9YRFRNek1USXhOVEUyTkRVMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJmUHdTZy9ibEQzbGJZTm9jcnlrRm5GSGdjeGFFRWkvRFAva090SzJ5OTFNV2xkekZIcHkKdWxxMjk3MjhVbXpxVnhoemNhVHJWZjdLM3owR3pkWFUzRzFORWZTcHltaUxLby9zNXZiTFoxRmtGWWtoTUZZeAoxT2s3eDBHSEsxMVhjOEFRK1k2QnZNUWhWbThkMmNGczBnaGZtczZwd3NHbDhLbGw0aDFtUW8rY21TZXFrb1MvCi9MZGJjN0NWaG1KYjNQbFVmKzF5VHZaL3Fad01VSW5lSE5rUDNrOTAweFI3Ujk2M0JIby9lZ1Qrdm84SEVOcm0KUUJrMUh1ZldoTnRBYisxcXVsSERJOHMwM0tWMDNEbDRWUFZ4Z1BrcUNRSS9iQ2VwZjJJWERkZFdRc3RJQ1VvKwprQWVUWjVjUkdXNi9nRmkyQkxRbTZENDlmUVFUQTJLUjdRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAwT0RVeFltSmhZUzFrTUdFekxUUXpaREV0WWpCbE9TMHoKWVdVNVkyRmlNR1ZoTXpRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwME9EVXhZbUpoWVMxa01HRXpMVFF6WkRFdFlqQmxPUzB6WVdVNVkyRmlNR1ZoTXpRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDeUNWK0hQQjZlL2xOOXNXV0J5aU1ka0tIdlFWSWwrWHI5eGtLYkVNWVFTMytSNmtuMzBQRUVOVWcrVQp3bFVYVXVLU1FHNU5JK3N0UHB2VjdFYzUwV0sxRXVXRHUrakhFeG9IaGIyM2hmbzZLUzUyQTM3WWdjVlpJdm85CnhkSWVzY0YvQ05Obk9Ea3F5YTd0NjViM2N5ZkFOVjhkMzNuUFJLdWVjb3hkR0ZmRFJvaUQvZC8xSnEvaGpJTHgKa1ROdTJhaUZ3MjlFaDhkd2xodU9TL3VSU0g3WkNDeGNYaWQ3U2wwY3RXN0NDUzFUZ1pGRmx2ZEhYNmVjSnBFegpwV3p0UmJibWFad01BRHhIbXdJQXpqU1RURXl4QWZGdzcza2xyTHRRMGFQTFoxa0pmVlVvY2pIVzdwd0NRZGRLCk5MYnYxWTh0VC91UDNHUGhpUHlUc1dYSnVnRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:06 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73e08d63-e60b-4713-ab5c-1b48a8a60102
+      - e50e937b-07e2-403d-b920-8c3db1503e03
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1224"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:07 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01a861a1-1f08-4f7d-aef0-2f4c9eaa46af
+      - 9447b744-9def-42bb-8d82-32a03bdf54de
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:07 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9e449f6-78d2-493e-b8fc-7f30ddb10f3d
+      - 2009aa79-5f39-4ff4-8311-d1dc29f3bbe4
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:07 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4b5f744-1be8-451f-a187-0f7d42ae2204
+      - 53938fdc-ba13-4876-8549-deac388fe4e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "245"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:07 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90928b9c-9b68-4b76-a149-4e0653ed26b4
+      - 0872a0d8-57c1-4ae6-9af0-03d44b415cf9
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,172 +1170,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1224"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 839ae909-5391-4cc7-82f5-47758d2ae38d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
-    method: GET
-  response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eacad830-b294-4243-aeef-d2d79a04ba48
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1224"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a50f0ca1-df79-475a-9150-0d7fe68e355f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
-    method: GET
-  response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "245"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bcc2dce9-e75a-44ab-9cf5-cc2ddd6254ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1224"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:59:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2b14981-f8d4-4497-a879-eb7296bb879d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -1479,7 +1182,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:08 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 918f6a91-ff61-4780-9718-80e03ce9a9e1
+      - 57bd4220-8662-4894-a8fa-3101d8c6d578
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVQkF2TmNzT2ZXY3R0R3pnbG8rMGZueldtSUZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRVNE1USmFGdzB6TXpFeU1UVXhORFU0TVRKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURjL3VQMkFCZFRjRkxmVFNYOUxOc0Q3UGV0d01SUnZ1U1RqZitOcEh1YVB0Qk9yeEhFamlmeEpCanUKdWh3eTNJNmR6ME5CWmRHQ2dxWTg5U0tPc1ZwczNaeUJId2FXcGFFZUp5Y1hDZ1cvNjJrQThIeVFrUDNoY2Roegp4eFAyTFZTMkJ0dmVxd2pjNFI3amowTjBBR2RXc3hyQnU4UHVpZmlBN0xpMWhiY01tNHprQnBQZEdBNUloZk5CCmlqc3N2QkVXRDQxWXpDbnZYTmpvbHlDK2hEMFVlNGoyWFpRSHB0ZWl3TDJnZy9KYU50ZFBaTHBxTXJBWURRcGkKN24yNDJGQUNEaUhUNFlReHVvZFIxT1k5WGdOZVFQdXp4T0pSbC9sV1IreU04Zjd6WlltdWswZThPcGpvVEhrVgpBSlVQYW9uOXV5LzhFczN1djRZbFJnQXh2RGtkQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkxbFpUVTJZVGRrT1MxbE1HUmhMVFE1TVRndFlXUTRaaTFqWm1ReVl6VTQKTVRGbE5UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0WldVMQpObUUzWkRrdFpUQmtZUzAwT1RFNExXRmtPR1l0WTJaa01tTTFPREV4WlRVekxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdRekQ5ZEhod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBU2lTbFkKaUgwNmswY2hqUVhETSswb0RaMjFadDBHSXF4d2lET2dFdmlYQ1ZFNkhKeTlKZWErZzQ3aWpiVnhhMENZWEo5Zwo2cFNjejJCWTI1RlRxVlprTHhjTGVud1RKYWxQY0lWRXdOR05SdVpNS2VTWXE2L0NSZk1seWl5T0FReHVnUS9xCmp5M1VNMHQ1Z0RVWVc3TXN2ZkU3cTBYemJPbzZ2QjhJOWR2NFlTUDNUdFlwYVVKVzFrR3BLSW5UU1ZDWCtBcmIKWUpEUzFMZE9zMU9LU2d2enBaeHJlTUZVU1hTaHQ0TTZNdWhOcENpcFdXcUFnN0wwU21RUERvcWMzR1hvelZUYwpoV093cnF0Qmc4K281WmJ4OWxCb1NZaFlnamFBYXdUNGRPNnJiMFJlVUtJN2pQS2h4TllPdkdneWlNS2ZIeGtNCkJEOHFlOXZrVE5lQnJKNksKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVY1RQOFdHbmFwNDdkMmIzeTlNNFBKU1BTTWN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EVTFObG9YRFRNek1USXhOVEUyTkRVMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJmUHdTZy9ibEQzbGJZTm9jcnlrRm5GSGdjeGFFRWkvRFAva090SzJ5OTFNV2xkekZIcHkKdWxxMjk3MjhVbXpxVnhoemNhVHJWZjdLM3owR3pkWFUzRzFORWZTcHltaUxLby9zNXZiTFoxRmtGWWtoTUZZeAoxT2s3eDBHSEsxMVhjOEFRK1k2QnZNUWhWbThkMmNGczBnaGZtczZwd3NHbDhLbGw0aDFtUW8rY21TZXFrb1MvCi9MZGJjN0NWaG1KYjNQbFVmKzF5VHZaL3Fad01VSW5lSE5rUDNrOTAweFI3Ujk2M0JIby9lZ1Qrdm84SEVOcm0KUUJrMUh1ZldoTnRBYisxcXVsSERJOHMwM0tWMDNEbDRWUFZ4Z1BrcUNRSS9iQ2VwZjJJWERkZFdRc3RJQ1VvKwprQWVUWjVjUkdXNi9nRmkyQkxRbTZENDlmUVFUQTJLUjdRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAwT0RVeFltSmhZUzFrTUdFekxUUXpaREV0WWpCbE9TMHoKWVdVNVkyRmlNR1ZoTXpRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwME9EVXhZbUpoWVMxa01HRXpMVFF6WkRFdFlqQmxPUzB6WVdVNVkyRmlNR1ZoTXpRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDeUNWK0hQQjZlL2xOOXNXV0J5aU1ka0tIdlFWSWwrWHI5eGtLYkVNWVFTMytSNmtuMzBQRUVOVWcrVQp3bFVYVXVLU1FHNU5JK3N0UHB2VjdFYzUwV0sxRXVXRHUrakhFeG9IaGIyM2hmbzZLUzUyQTM3WWdjVlpJdm85CnhkSWVzY0YvQ05Obk9Ea3F5YTd0NjViM2N5ZkFOVjhkMzNuUFJLdWVjb3hkR0ZmRFJvaUQvZC8xSnEvaGpJTHgKa1ROdTJhaUZ3MjlFaDhkd2xodU9TL3VSU0g3WkNDeGNYaWQ3U2wwY3RXN0NDUzFUZ1pGRmx2ZEhYNmVjSnBFegpwV3p0UmJibWFad01BRHhIbXdJQXpqU1RURXl4QWZGdzcza2xyTHRRMGFQTFoxa0pmVlVvY2pIVzdwd0NRZGRLCk5MYnYxWTh0VC91UDNHUGhpUHlUc1dYSnVnRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:08 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90fcff1e-02c6-4c81-ba0f-38ac9df4c253
+      - 54b9cbe8-8bc7-45f3-b631-d95f8fc17e6c
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1224"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:09 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0faac38f-f866-4e15-b8f5-af63e572f024
+      - d4c1ae31-6cc8-4c4e-97eb-21b1c6c4c2e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:09 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4acd9f8-ef5b-4e34-9c31-453bd4b5e589
+      - b63a4f6a-af7b-4b86-864f-a505c3a14818
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "245"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:09 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32755865-3121-4006-bf2d-bec3188dd8e8
+      - f9b50e10-3974-4f83-acbd-d2f53cc7f68a
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "245"
+      - "243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:09 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef008664-bf0c-4943-a83b-5f93b89d52ab
+      - 2949a4de-3bdb-4e86-b58e-b10054750bdf
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1224"
+      - "243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:09 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d10378fe-67a3-4a07-a839-20283275e01d
+      - 8df1da28-daa2-4441-b0c3-9cca850746ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "245"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:10 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d6b711f-fbe0-43d9-994d-8ff2820e3c5b
+      - feb5cf22-7dce-44e3-9f49-6f9e00639de8
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1224"
+      - "243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:10 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1456,436 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4201edc4-675d-42e3-bead-b88212b0bef3
+      - 65f72030-59c3-4931-8703-dd90dde8b024
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1226"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e653a1bb-2590-4b65-b554-58702bf16068
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "243"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 015c48c5-1e5c-46d6-b369-69e6a12864e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1226"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f4960726-46ed-4dbf-8975-bf77af48201e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/users?order_by=name_asc&page=1
+    method: GET
+  response:
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - acb35daa-581f-4d85-8849-15076907a8a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVY1RQOFdHbmFwNDdkMmIzeTlNNFBKU1BTTWN3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EVTFObG9YRFRNek1USXhOVEUyTkRVMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXJmUHdTZy9ibEQzbGJZTm9jcnlrRm5GSGdjeGFFRWkvRFAva090SzJ5OTFNV2xkekZIcHkKdWxxMjk3MjhVbXpxVnhoemNhVHJWZjdLM3owR3pkWFUzRzFORWZTcHltaUxLby9zNXZiTFoxRmtGWWtoTUZZeAoxT2s3eDBHSEsxMVhjOEFRK1k2QnZNUWhWbThkMmNGczBnaGZtczZwd3NHbDhLbGw0aDFtUW8rY21TZXFrb1MvCi9MZGJjN0NWaG1KYjNQbFVmKzF5VHZaL3Fad01VSW5lSE5rUDNrOTAweFI3Ujk2M0JIby9lZ1Qrdm84SEVOcm0KUUJrMUh1ZldoTnRBYisxcXVsSERJOHMwM0tWMDNEbDRWUFZ4Z1BrcUNRSS9iQ2VwZjJJWERkZFdRc3RJQ1VvKwprQWVUWjVjUkdXNi9nRmkyQkxRbTZENDlmUVFUQTJLUjdRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAwT0RVeFltSmhZUzFrTUdFekxUUXpaREV0WWpCbE9TMHoKWVdVNVkyRmlNR1ZoTXpRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwME9EVXhZbUpoWVMxa01HRXpMVFF6WkRFdFlqQmxPUzB6WVdVNVkyRmlNR1ZoTXpRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDeUNWK0hQQjZlL2xOOXNXV0J5aU1ka0tIdlFWSWwrWHI5eGtLYkVNWVFTMytSNmtuMzBQRUVOVWcrVQp3bFVYVXVLU1FHNU5JK3N0UHB2VjdFYzUwV0sxRXVXRHUrakhFeG9IaGIyM2hmbzZLUzUyQTM3WWdjVlpJdm85CnhkSWVzY0YvQ05Obk9Ea3F5YTd0NjViM2N5ZkFOVjhkMzNuUFJLdWVjb3hkR0ZmRFJvaUQvZC8xSnEvaGpJTHgKa1ROdTJhaUZ3MjlFaDhkd2xodU9TL3VSU0g3WkNDeGNYaWQ3U2wwY3RXN0NDUzFUZ1pGRmx2ZEhYNmVjSnBFegpwV3p0UmJibWFad01BRHhIbXdJQXpqU1RURXl4QWZGdzcza2xyTHRRMGFQTFoxa0pmVlVvY2pIVzdwd0NRZGRLCk5MYnYxWTh0VC91UDNHUGhpUHlUc1dYSnVnRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca7d08fc-0a12-44d8-96c3-e7f6dba70772
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54b58224-2123-4d55-9110-b42bd00492ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1226"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 617660ec-e2a3-464f-8233-48952c7b7b93
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1226"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a609dbda-446e-4a14-9de2-3e7f5b85a6d5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "243"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0f67822a-83c7-436d-bb36-e296151ea272
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "243"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 352e4e1d-ae66-41f6-b752-484cf642a378
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1226"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a23850aa-fade-4a2f-be44-4ce253203318
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "243"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5cd033d1-a3b1-4cd6-9656-f35dfea944ec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1226"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7cb0c602-a7d4-4ef6-ac6f-e884a9d2693b
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1898,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34/acls
     method: DELETE
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":19794,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":19794,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":9432,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":9432,"protocol":"tcp"}]}'
     headers:
       Content-Length:
-      - "229"
+      - "227"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:11 GMT
+      - Mon, 18 Dec 2023 16:47:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0750715-fd74-476b-b15b-b59813c9e423
+      - 11f2c798-2bed-4d41-9c81-a78490202e20
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,19 +1931,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1232"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:11 GMT
+      - Mon, 18 Dec 2023 16:47:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c14d9107-0e56-4178-b572-ab2fb1af318a
+      - 85f424ee-6dd5-4f7b-b2c9-72f001d46d9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,19 +1964,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:41 GMT
+      - Mon, 18 Dec 2023 16:47:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7177f462-458b-4ff9-a211-e64640a76c43
+      - b475f43a-35b4-4671-8e34-8ae3e33fc31c
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,19 +1997,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:41 GMT
+      - Mon, 18 Dec 2023 16:47:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +2019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7b99338-c25a-4dba-aac3-42e0e8ccd5ee
+      - 4550bbea-581c-4c3f-a3a9-2adbf98d7a6d
     status: 200 OK
     code: 200
     duration: ""
@@ -1898,19 +2030,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:42 GMT
+      - Mon, 18 Dec 2023 16:47:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1920,7 +2052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d3d8fbf-5229-408f-9ee2-97461a9e39bd
+      - f7aecba1-30ce-43dc-982a-937cd97bcb34
     status: 200 OK
     code: 200
     duration: ""
@@ -1931,19 +2063,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:55:23.496220Z","retention":7},"created_at":"2023-12-18T14:55:23.496220Z","endpoint":{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794},"endpoints":[{"id":"e133048e-f649-4d20-b2c8-30b85a0f7a5c","ip":"51.158.56.32","load_balancer":{},"name":null,"port":19794}],"engine":"PostgreSQL-15","id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.718350Z","retention":7},"created_at":"2023-12-18T16:43:38.718350Z","endpoint":{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432},"endpoints":[{"id":"291786a9-c2dc-493e-ae3b-1c83c8cfba30","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9432}],"engine":"PostgreSQL-15","id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayDataSourceRDBAcl_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:42 GMT
+      - Mon, 18 Dec 2023 16:47:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1953,7 +2085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6278f251-23db-4302-8446-1b24bd65c457
+      - 84fc6d75-0a60-440b-94ed-a21100da60bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1964,10 +2096,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1976,7 +2108,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:00:12 GMT
+      - Mon, 18 Dec 2023 16:48:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1986,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b656b61-0764-4579-ae18-ee23ef70f6ca
+      - e8736c79-31a5-4c06-88dd-f15bc378f0ff
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1997,10 +2129,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee56a7d9-e0da-4918-ad8f-cfd2c5811e53
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"ee56a7d9-e0da-4918-ad8f-cfd2c5811e53","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4851bbaa-d0a3-43d1-b0e9-3ae9cab0ea34","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2009,7 +2141,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:00:12 GMT
+      - Mon, 18 Dec 2023 16:48:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2019,7 +2151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e9239ce-514d-4e22-b0b5-5ffdddbf2350
+      - 79d3b9bb-cbe3-4df5-9e7e-598800460c59
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-database-backup-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-database-backup-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:00 GMT
+      - Mon, 18 Dec 2023 14:14:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52dde299-16ae-45af-91c2-7b2f8a368d2f
+      - 5aa32bc3-1c9f-42bb-8a36-c1c1ef0f138f
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:55 GMT
+      - Mon, 18 Dec 2023 14:14:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c6aee57-2302-46a0-8c8f-18d5ee2990d6
+      - 6757a5e3-c377-410b-a191-7ba83792cac4
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:55 GMT
+      - Mon, 18 Dec 2023 14:14:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88cfde9c-2bad-45d7-bbd5-3bbac7fb2a79
+      - eb3cdc50-a6ca-4d4b-bfa8-6933a172fce1
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:25 GMT
+      - Mon, 18 Dec 2023 14:14:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12cc4b2f-3384-4492-a6a2-7ce297b594fe
+      - 9d52c1a8-bf70-41c5-94e4-bc54e5be809a
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:55 GMT
+      - Mon, 18 Dec 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8af3d61-2122-4186-bc5c-3de1cd2e4f45
+      - 80e3e82b-0596-429a-b307-abb27a597ccd
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:26 GMT
+      - Mon, 18 Dec 2023 14:15:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad807d3c-347c-4044-b330-3680b44d9322
+      - 9bad7a83-b661-4509-a140-0088312cbafc
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:58 GMT
+      - Mon, 18 Dec 2023 14:16:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78caa520-818c-4390-a108-09379c29f2b1
+      - 9ea8246b-b01a-40ec-8ba3-0dcb11a3d2a6
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1160"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:30 GMT
+      - Mon, 18 Dec 2023 14:16:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e70e1d7-9a36-43ad-a3bd-d0195e4cdf02
+      - c93b7f8d-ad79-4754-8f8e-cda9f0838797
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:00 GMT
+      - Mon, 18 Dec 2023 14:17:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a45c428a-6282-48c3-aff6-7ba34e4a7277
+      - 8141afc1-29e4-47a8-a7e1-d74bb162feb1
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:01 GMT
+      - Mon, 18 Dec 2023 14:17:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c551f6d-10dd-46cb-b161-a9d412a79710
+      - 83a000a4-0418-4eb2-a064-d4c2ba495c23
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:01 GMT
+      - Mon, 18 Dec 2023 14:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 313ea621-31ca-406d-a9fe-f13cdae5b89b
+      - 489f5a42-2ef4-440d-8e12-df2580762893
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVV29udTFQRWhrQURuWGEwWmh0cUtOR0V2QzZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1Ea3pPRm9YRFRNek1USXhOVEV6TURrek9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdiWE8waTN3L3JmWG9aeUd2K0MvcG9UeEZCMkloUGJqa25jUTVSd3RuUlVoSG1PWmc5RUsKUWpPUzFhTTlJbm5aYklETGFsQzZtUEVWamxENngvT3lSNVVtb3RJTjl0aXdpMnp2c1hnUEtPV3hIQmxMMmZSLwpYOWQ5ZlJ5N04zdnJqZ1czaFB6WCtxTzJCclcwZ0h4bzFjSm5WRjBGZktHSnBVU2swMGI5bUs0VVc2VVowUCs3Cmg4eWRDcFhXVkt2bWZvVWR6TU9FcDZjSHZFZk5KWnNYZTVMdFRqSXh6aUE5RlhIbkk5RUNnaHlWV3VvNXZCUlgKOEl2dkRJbE5yWUQvTjhodmhLcVExUDZPOXFOSHpVeld1WlJRRTd2RDg0V0puL1ltd0JQRHNUTndRdndwa2JXQQpzS2s0empkT01hZUxqb2pucHRRbGdLSjA2dXBGYWRWMXlRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTA0T1RKak5tUmxZUzAwT1RReUxUUXpOREV0T1RjME9TMDQKWkRRME9USTRZVGcwT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwNE9USmpObVJsWVMwME9UUXlMVFF6TkRFdE9UYzBPUzA0WkRRME9USTRZVGcwT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDEwZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFJMnROZmx0L0VXUmpUdmgyZng4MEtMWlduTEZmaU9nOFZRemw1enMrRUZTNFI4ZCtrWVBZMGxNNktQKwo2T1RmRkRhdnFKY09XYUlTSVZ5RnFEdEtkeFFxRk9WcHVaOWhKVjEyZDljVHNISjRuNy92Z1hoQlJnSkpyNGtFCllLd0lLWDR6d3BRN0VyeTc4K0ZSRVAva3NXeTdqRXNTOGtpckdoUTFLL1lMWkQzcGlWQTVZR2RhMzAvb2lXOUwKRWJlemlVNjd2VVNsUWRDZnd4cmgweW9DYkZjT25LaFhKZ04weEpUOTFYWlY4RXFtczVSOU9QV0FQeXhyRHFJQgpva3o2RU9zeURXdkgrWGxma0dTRCt1b3J6alVWaXRlRVdEYWdXZnJ0dStVOCtUYm14RFZEN3Jmc09BZmdWanRqCjZWSWprN09kS1dwdnc0Sk9tNW0xZnJxdTE0cz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:01 GMT
+      - Mon, 18 Dec 2023 14:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b801d9c-da99-4a4c-a1ad-f0602bf2c18c
+      - 508a09b1-ee68-4c0b-8fdd-82c04ec45cb1
     status: 200 OK
     code: 200
     duration: ""
@@ -706,7 +706,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=892c6dea-4942-4341-9749-8d44928a848a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQkw2b2tpWnlRcUN6UHVoUWZWL0hKTFpOZ3pFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRReE5qVTJXaGNOTXpNeE1qRTFNVFF4TmpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxnYnFseGM0dVBmcHB0YW42VEZKMVg3YXBVZ1hrWGpCRXJTaUFkTnZNN3dpTXZIS3gvTlBuZ0oKbENkSEx2MzlMMUcvMFlnekRWMldDelZFYmpmUHFBTWpCcFZMd2pZUlJ5a28veEFvdG1FczAvME9aZi9vdXhsMgpXeU1iZDRTdk92UHl5TldId3V1Z015elNRRFgyZFdRaFdWOGZ2OGk4UXN3WVN4NFBuWFlCcFpUSDdtd3kxdjNlCmQrK0xDUEtaYWJJa1kzR29VZlZjQ1I3bi94UVBaeWMzVlhGaXBzcE9aRE1Zamg2dGd1d09WMFJsOElsSXVIMnIKK1psNnhtYTZ4MDhOM0Y2V2EvejZySVlueGsxb2xrcTRtS1dxWUd4SUM1alFEYUtBTWI4UUFMT3Q1Z1dTQmN0RAp5THMycXBwUXMzdHY5SXpSN0d6WnJPUVVaNnVzb3IwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MW1aalZqTW1JM01pMWtNMlpoTFRSallUZ3RZVGt3TXkxaVpERXcKTnpRMU1HUTROMk11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1ptTldNeVlqY3lMV1F6Wm1FdE5HTmhPQzFoT1RBekxXSmtNVEEzTkRVd1pEZzNZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnloSG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKTlNRQVFvOTJURHNzbDVidkwyeURONFZUVW9yQkY4NHNQNXNvZVVnclV0Zzg2QmVRSGZVTm5HTmc4cDRQeStSVQpQOWJ6bm1qd21KVzM4MlJuL3hVZFVLb09jQjg3dnBROElaL215aVgwU3hXa3ZaWkJzSTFlUEJZdXgxMFg1M0hwClEzYnpxbjIzRUFITFNWb0lnM25mVVFDOWJFS2lyOEpDNXBCRlpUUy8zYS84Y080cEgyNmFCRGdQN0Zzclc2bk0KeE1IbUxyQTUyUEwxQS83ajZ3bFFMWU03UmFpbitxYkVZRnJLWDRxZjc0M1gwM3VQUGk4WEtlbjRqc0ZybzFyTQpKeDJUYk9pVU14V2hzTDNHOHBOZ3d3eFFHS0lHeHRwWWxvRldUVHIwUktMallKRFVxT2plYWFGSmFpWVZuajE5CnNrWUpsb0tZckVYaTltVFRBVEI3RlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:17:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fc511fa-88c6-4a75-a518-48a6b52a4e8f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ff5c2b72-d3fa-4ca8-a903-bd107450d87c&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -718,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:01 GMT
+      - Mon, 18 Dec 2023 14:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd6376fd-56f8-403b-be1a-b92a06b86cf6
+      - f3e33c78-6162-4475-a3dd-9a165d8c4b41
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:01 GMT
+      - Mon, 18 Dec 2023 14:17:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dbdc032-843f-4e6b-b8cc-4d54a860cd3c
+      - e2a818e0-4f8e-432d-9260-16e5d8ca6e8d
     status: 200 OK
     code: 200
     duration: ""
@@ -774,7 +807,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/databases
     method: POST
   response:
     body: '{"managed":true,"name":"test-terraform","owner":"","size":0}'
@@ -786,7 +819,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:01 GMT
+      - Mon, 18 Dec 2023 14:17:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f3e7e3b-5e8d-48c2-ba9c-c651ae189a33
+      - a2988691-2a1e-4848-828c-9ce9b7658513
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:02 GMT
+      - Mon, 18 Dec 2023 14:17:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3a85c46-c114-4844-bc76-e7a8a7668abe
+      - 306430a4-d8a5-4ca6-8a34-e92485f9495d
     status: 200 OK
     code: 200
     duration: ""
@@ -840,7 +873,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -852,7 +885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:02 GMT
+      - Mon, 18 Dec 2023 14:17:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85451cdc-70f4-432d-b2c7-eaecaefdc655
+      - bc586895-e27e-445e-8b6e-94e1f9248dc7
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:02 GMT
+      - Mon, 18 Dec 2023 14:17:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9109622-8d02-43f9-96e2-3e62386aa1ac
+      - e4cdfb6a-c37e-489c-bcfa-d59e0317cd38
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVV29udTFQRWhrQURuWGEwWmh0cUtOR0V2QzZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1Ea3pPRm9YRFRNek1USXhOVEV6TURrek9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdiWE8waTN3L3JmWG9aeUd2K0MvcG9UeEZCMkloUGJqa25jUTVSd3RuUlVoSG1PWmc5RUsKUWpPUzFhTTlJbm5aYklETGFsQzZtUEVWamxENngvT3lSNVVtb3RJTjl0aXdpMnp2c1hnUEtPV3hIQmxMMmZSLwpYOWQ5ZlJ5N04zdnJqZ1czaFB6WCtxTzJCclcwZ0h4bzFjSm5WRjBGZktHSnBVU2swMGI5bUs0VVc2VVowUCs3Cmg4eWRDcFhXVkt2bWZvVWR6TU9FcDZjSHZFZk5KWnNYZTVMdFRqSXh6aUE5RlhIbkk5RUNnaHlWV3VvNXZCUlgKOEl2dkRJbE5yWUQvTjhodmhLcVExUDZPOXFOSHpVeld1WlJRRTd2RDg0V0puL1ltd0JQRHNUTndRdndwa2JXQQpzS2s0empkT01hZUxqb2pucHRRbGdLSjA2dXBGYWRWMXlRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTA0T1RKak5tUmxZUzAwT1RReUxUUXpOREV0T1RjME9TMDQKWkRRME9USTRZVGcwT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwNE9USmpObVJsWVMwME9UUXlMVFF6TkRFdE9UYzBPUzA0WkRRME9USTRZVGcwT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDEwZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFJMnROZmx0L0VXUmpUdmgyZng4MEtMWlduTEZmaU9nOFZRemw1enMrRUZTNFI4ZCtrWVBZMGxNNktQKwo2T1RmRkRhdnFKY09XYUlTSVZ5RnFEdEtkeFFxRk9WcHVaOWhKVjEyZDljVHNISjRuNy92Z1hoQlJnSkpyNGtFCllLd0lLWDR6d3BRN0VyeTc4K0ZSRVAva3NXeTdqRXNTOGtpckdoUTFLL1lMWkQzcGlWQTVZR2RhMzAvb2lXOUwKRWJlemlVNjd2VVNsUWRDZnd4cmgweW9DYkZjT25LaFhKZ04weEpUOTFYWlY4RXFtczVSOU9QV0FQeXhyRHFJQgpva3o2RU9zeURXdkgrWGxma0dTRCt1b3J6alVWaXRlRVdEYWdXZnJ0dStVOCtUYm14RFZEN3Jmc09BZmdWanRqCjZWSWprN09kS1dwdnc0Sk9tNW0xZnJxdTE0cz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:02 GMT
+      - Mon, 18 Dec 2023 14:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f514b61-fabe-4427-b4b3-35aaedf42862
+      - 53c04c2b-6133-4f97-92e6-9ac2cc4db89f
     status: 200 OK
     code: 200
     duration: ""
@@ -939,7 +972,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=892c6dea-4942-4341-9749-8d44928a848a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQkw2b2tpWnlRcUN6UHVoUWZWL0hKTFpOZ3pFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRReE5qVTJXaGNOTXpNeE1qRTFNVFF4TmpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxnYnFseGM0dVBmcHB0YW42VEZKMVg3YXBVZ1hrWGpCRXJTaUFkTnZNN3dpTXZIS3gvTlBuZ0oKbENkSEx2MzlMMUcvMFlnekRWMldDelZFYmpmUHFBTWpCcFZMd2pZUlJ5a28veEFvdG1FczAvME9aZi9vdXhsMgpXeU1iZDRTdk92UHl5TldId3V1Z015elNRRFgyZFdRaFdWOGZ2OGk4UXN3WVN4NFBuWFlCcFpUSDdtd3kxdjNlCmQrK0xDUEtaYWJJa1kzR29VZlZjQ1I3bi94UVBaeWMzVlhGaXBzcE9aRE1Zamg2dGd1d09WMFJsOElsSXVIMnIKK1psNnhtYTZ4MDhOM0Y2V2EvejZySVlueGsxb2xrcTRtS1dxWUd4SUM1alFEYUtBTWI4UUFMT3Q1Z1dTQmN0RAp5THMycXBwUXMzdHY5SXpSN0d6WnJPUVVaNnVzb3IwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MW1aalZqTW1JM01pMWtNMlpoTFRSallUZ3RZVGt3TXkxaVpERXcKTnpRMU1HUTROMk11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1ptTldNeVlqY3lMV1F6Wm1FdE5HTmhPQzFoT1RBekxXSmtNVEEzTkRVd1pEZzNZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnloSG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKTlNRQVFvOTJURHNzbDVidkwyeURONFZUVW9yQkY4NHNQNXNvZVVnclV0Zzg2QmVRSGZVTm5HTmc4cDRQeStSVQpQOWJ6bm1qd21KVzM4MlJuL3hVZFVLb09jQjg3dnBROElaL215aVgwU3hXa3ZaWkJzSTFlUEJZdXgxMFg1M0hwClEzYnpxbjIzRUFITFNWb0lnM25mVVFDOWJFS2lyOEpDNXBCRlpUUy8zYS84Y080cEgyNmFCRGdQN0Zzclc2bk0KeE1IbUxyQTUyUEwxQS83ajZ3bFFMWU03UmFpbitxYkVZRnJLWDRxZjc0M1gwM3VQUGk4WEtlbjRqc0ZybzFyTQpKeDJUYk9pVU14V2hzTDNHOHBOZ3d3eFFHS0lHeHRwWWxvRldUVHIwUktMallKRFVxT2plYWFGSmFpWVZuajE5CnNrWUpsb0tZckVYaTltVFRBVEI3RlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:17:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 07dc278a-d345-4d2f-879c-0cc7aed6381a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ff5c2b72-d3fa-4ca8-a903-bd107450d87c&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -951,7 +1017,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:02 GMT
+      - Mon, 18 Dec 2023 14:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec2223dd-bb56-4ddd-8da9-83ad5045633d
+      - 4a1954f1-147f-4651-be58-f867d46ddf8e
     status: 200 OK
     code: 200
     duration: ""
@@ -972,7 +1038,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -984,7 +1050,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:02 GMT
+      - Mon, 18 Dec 2023 14:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 876151bc-650c-4cf2-980c-b6acbd41fc4a
+      - 7bd3b4f1-07bd-404e-82fe-64e65bd9ea25
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:03 GMT
+      - Mon, 18 Dec 2023 14:17:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e9253cf-8732-45ff-90b1-080a5cce363b
+      - a8708f18-dd6b-4e41-9cf9-4dbfd37041f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVV29udTFQRWhrQURuWGEwWmh0cUtOR0V2QzZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1Ea3pPRm9YRFRNek1USXhOVEV6TURrek9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdiWE8waTN3L3JmWG9aeUd2K0MvcG9UeEZCMkloUGJqa25jUTVSd3RuUlVoSG1PWmc5RUsKUWpPUzFhTTlJbm5aYklETGFsQzZtUEVWamxENngvT3lSNVVtb3RJTjl0aXdpMnp2c1hnUEtPV3hIQmxMMmZSLwpYOWQ5ZlJ5N04zdnJqZ1czaFB6WCtxTzJCclcwZ0h4bzFjSm5WRjBGZktHSnBVU2swMGI5bUs0VVc2VVowUCs3Cmg4eWRDcFhXVkt2bWZvVWR6TU9FcDZjSHZFZk5KWnNYZTVMdFRqSXh6aUE5RlhIbkk5RUNnaHlWV3VvNXZCUlgKOEl2dkRJbE5yWUQvTjhodmhLcVExUDZPOXFOSHpVeld1WlJRRTd2RDg0V0puL1ltd0JQRHNUTndRdndwa2JXQQpzS2s0empkT01hZUxqb2pucHRRbGdLSjA2dXBGYWRWMXlRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTA0T1RKak5tUmxZUzAwT1RReUxUUXpOREV0T1RjME9TMDQKWkRRME9USTRZVGcwT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwNE9USmpObVJsWVMwME9UUXlMVFF6TkRFdE9UYzBPUzA0WkRRME9USTRZVGcwT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDEwZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFJMnROZmx0L0VXUmpUdmgyZng4MEtMWlduTEZmaU9nOFZRemw1enMrRUZTNFI4ZCtrWVBZMGxNNktQKwo2T1RmRkRhdnFKY09XYUlTSVZ5RnFEdEtkeFFxRk9WcHVaOWhKVjEyZDljVHNISjRuNy92Z1hoQlJnSkpyNGtFCllLd0lLWDR6d3BRN0VyeTc4K0ZSRVAva3NXeTdqRXNTOGtpckdoUTFLL1lMWkQzcGlWQTVZR2RhMzAvb2lXOUwKRWJlemlVNjd2VVNsUWRDZnd4cmgweW9DYkZjT25LaFhKZ04weEpUOTFYWlY4RXFtczVSOU9QV0FQeXhyRHFJQgpva3o2RU9zeURXdkgrWGxma0dTRCt1b3J6alVWaXRlRVdEYWdXZnJ0dStVOCtUYm14RFZEN3Jmc09BZmdWanRqCjZWSWprN09kS1dwdnc0Sk9tNW0xZnJxdTE0cz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:03 GMT
+      - Mon, 18 Dec 2023 14:17:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fdaa82f-ffd3-4749-a857-1c2cab234a65
+      - 33e68381-beab-4466-a144-e7a612a8e657
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,7 +1137,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=892c6dea-4942-4341-9749-8d44928a848a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQkw2b2tpWnlRcUN6UHVoUWZWL0hKTFpOZ3pFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRReE5qVTJXaGNOTXpNeE1qRTFNVFF4TmpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxnYnFseGM0dVBmcHB0YW42VEZKMVg3YXBVZ1hrWGpCRXJTaUFkTnZNN3dpTXZIS3gvTlBuZ0oKbENkSEx2MzlMMUcvMFlnekRWMldDelZFYmpmUHFBTWpCcFZMd2pZUlJ5a28veEFvdG1FczAvME9aZi9vdXhsMgpXeU1iZDRTdk92UHl5TldId3V1Z015elNRRFgyZFdRaFdWOGZ2OGk4UXN3WVN4NFBuWFlCcFpUSDdtd3kxdjNlCmQrK0xDUEtaYWJJa1kzR29VZlZjQ1I3bi94UVBaeWMzVlhGaXBzcE9aRE1Zamg2dGd1d09WMFJsOElsSXVIMnIKK1psNnhtYTZ4MDhOM0Y2V2EvejZySVlueGsxb2xrcTRtS1dxWUd4SUM1alFEYUtBTWI4UUFMT3Q1Z1dTQmN0RAp5THMycXBwUXMzdHY5SXpSN0d6WnJPUVVaNnVzb3IwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MW1aalZqTW1JM01pMWtNMlpoTFRSallUZ3RZVGt3TXkxaVpERXcKTnpRMU1HUTROMk11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1ptTldNeVlqY3lMV1F6Wm1FdE5HTmhPQzFoT1RBekxXSmtNVEEzTkRVd1pEZzNZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnloSG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKTlNRQVFvOTJURHNzbDVidkwyeURONFZUVW9yQkY4NHNQNXNvZVVnclV0Zzg2QmVRSGZVTm5HTmc4cDRQeStSVQpQOWJ6bm1qd21KVzM4MlJuL3hVZFVLb09jQjg3dnBROElaL215aVgwU3hXa3ZaWkJzSTFlUEJZdXgxMFg1M0hwClEzYnpxbjIzRUFITFNWb0lnM25mVVFDOWJFS2lyOEpDNXBCRlpUUy8zYS84Y080cEgyNmFCRGdQN0Zzclc2bk0KeE1IbUxyQTUyUEwxQS83ajZ3bFFMWU03UmFpbitxYkVZRnJLWDRxZjc0M1gwM3VQUGk4WEtlbjRqc0ZybzFyTQpKeDJUYk9pVU14V2hzTDNHOHBOZ3d3eFFHS0lHeHRwWWxvRldUVHIwUktMallKRFVxT2plYWFGSmFpWVZuajE5CnNrWUpsb0tZckVYaTltVFRBVEI3RlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:17:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aba0f5f9-8da3-4898-8467-33f443367ae7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ff5c2b72-d3fa-4ca8-a903-bd107450d87c&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1083,7 +1182,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:03 GMT
+      - Mon, 18 Dec 2023 14:17:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bf5a16f-7c83-4499-b746-b41edbe09620
+      - 35f87935-3d8c-4d7a-9664-4341704df6e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,7 +1203,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -1116,7 +1215,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:03 GMT
+      - Mon, 18 Dec 2023 14:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,12 +1225,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a2f296b-3e73-4f41-aae3-408b140d0c2a
+      - 0751cdb8-8d47-4127-8665-3d9aeed9dad7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"892c6dea-4942-4341-9749-8d44928a848a","database_name":"test-terraform","name":"test_backup_datasource"}'
+    body: '{"instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","database_name":"test-terraform","name":"test_backup_datasource"}'
     form: {}
     headers:
       Content-Type:
@@ -1142,7 +1241,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
       - "396"
@@ -1151,7 +1250,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:04 GMT
+      - Mon, 18 Dec 2023 14:17:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93fecd87-be08-4a9f-baed-80622d2ae962
+      - 572a8694-8079-4838-a422-a49a68b088f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,10 +1271,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
       - "396"
@@ -1184,7 +1283,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:05 GMT
+      - Mon, 18 Dec 2023 14:17:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 131de354-33a6-4584-b49a-791a52fb20d8
+      - ec05b958-bb09-4aff-9bbe-728d1acac8c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,10 +1304,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1217,7 +1316,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:18:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c786ddd-749c-41e2-b2c4-04f5e83e0841
+      - 6b166ee3-df0c-401f-98bb-eae7e569bf65
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,10 +1337,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1250,7 +1349,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:18:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a554c8c-a153-4752-a1e1-40ed073d8d8f
+      - 4a4b3014-08fa-4e89-b81a-5fe82e63a95c
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,10 +1370,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1283,7 +1382,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:18:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bec0b13-1e83-4428-bec2-eda13637187e
+      - 864b438d-50a8-458c-87cc-11d9f172d9da
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,10 +1403,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=892c6dea-4942-4341-9749-8d44928a848a&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ff5c2b72-d3fa-4ca8-a903-bd107450d87c&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1316,7 +1415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:18:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a13380d3-76ec-49b5-be3d-29defe51dc12
+      - b3f720a1-c650-4966-8c88-e900cadfd8f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,10 +1436,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1349,7 +1448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:18:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c133a03a-a864-42af-9b62-2ccc0f007993
+      - a6af2f50-dc86-480e-81ac-de30d4fc9b1e
     status: 200 OK
     code: 200
     duration: ""
@@ -1373,7 +1472,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1382,7 +1481,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:45 GMT
+      - Mon, 18 Dec 2023 14:18:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3376450c-8c37-4c60-b0c8-9e0d6e0c3696
+      - 903e9298-31b9-4bda-bae8-04e6cbc216f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,10 +1502,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1415,7 +1514,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:46 GMT
+      - Mon, 18 Dec 2023 14:18:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8eaf911b-b774-4a76-a513-3c4245cb08d3
+      - 88875a21-77e7-4d78-914b-284974655ecd
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,7 +1535,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -1448,7 +1547,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:46 GMT
+      - Mon, 18 Dec 2023 14:18:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6938c6c-6283-4521-8460-ff38aaa0ec9d
+      - 7b0dd041-bdb9-438f-af74-20e977c4f6b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,10 +1568,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1481,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:46 GMT
+      - Mon, 18 Dec 2023 14:18:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d66d6b4-5757-4c1d-af62-5ecdad936a69
+      - 836fbf52-3146-49b1-910c-e146369d5436
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,10 +1601,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1514,7 +1613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:47 GMT
+      - Mon, 18 Dec 2023 14:18:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae451b0a-1f2f-4be9-b37b-44965b6a8c12
+      - 33b8d8d5-ad95-4bd7-9cc4-4eba4cfbd9ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,10 +1634,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=892c6dea-4942-4341-9749-8d44928a848a&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ff5c2b72-d3fa-4ca8-a903-bd107450d87c&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1547,7 +1646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:47 GMT
+      - Mon, 18 Dec 2023 14:18:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87c03da3-4ac5-4992-9523-e9fbfe7dcd3f
+      - 3a97d5c0-6f95-4fdd-8038-8038f33e9af2
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,10 +1667,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1580,7 +1679,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:47 GMT
+      - Mon, 18 Dec 2023 14:18:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 674712d4-854e-4c7b-8032-d2a9792364d9
+      - 593efb9a-c2e3-45ab-81f0-5c39bca1eba7
     status: 200 OK
     code: 200
     duration: ""
@@ -1604,7 +1703,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1613,7 +1712,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:56 GMT
+      - Mon, 18 Dec 2023 14:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72bb1681-caee-4343-9b86-43acc3dc4eb6
+      - cead8e25-b0e6-45ca-b439-93dcbe0dd080
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,10 +1733,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1646,7 +1745,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aec978a-5b8b-4f0e-b473-17cf1ceaaa06
+      - 4df71cc4-5aed-4f1d-9737-42d74454106f
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,19 +1766,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bbd0884-c7f0-48f7-a7bf-897d6e036b62
+      - 7df32d77-9d8a-4f80-b972-725cc0c174df
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVV29udTFQRWhrQURuWGEwWmh0cUtOR0V2QzZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1Ea3pPRm9YRFRNek1USXhOVEV6TURrek9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdiWE8waTN3L3JmWG9aeUd2K0MvcG9UeEZCMkloUGJqa25jUTVSd3RuUlVoSG1PWmc5RUsKUWpPUzFhTTlJbm5aYklETGFsQzZtUEVWamxENngvT3lSNVVtb3RJTjl0aXdpMnp2c1hnUEtPV3hIQmxMMmZSLwpYOWQ5ZlJ5N04zdnJqZ1czaFB6WCtxTzJCclcwZ0h4bzFjSm5WRjBGZktHSnBVU2swMGI5bUs0VVc2VVowUCs3Cmg4eWRDcFhXVkt2bWZvVWR6TU9FcDZjSHZFZk5KWnNYZTVMdFRqSXh6aUE5RlhIbkk5RUNnaHlWV3VvNXZCUlgKOEl2dkRJbE5yWUQvTjhodmhLcVExUDZPOXFOSHpVeld1WlJRRTd2RDg0V0puL1ltd0JQRHNUTndRdndwa2JXQQpzS2s0empkT01hZUxqb2pucHRRbGdLSjA2dXBGYWRWMXlRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTA0T1RKak5tUmxZUzAwT1RReUxUUXpOREV0T1RjME9TMDQKWkRRME9USTRZVGcwT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwNE9USmpObVJsWVMwME9UUXlMVFF6TkRFdE9UYzBPUzA0WkRRME9USTRZVGcwT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDEwZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFJMnROZmx0L0VXUmpUdmgyZng4MEtMWlduTEZmaU9nOFZRemw1enMrRUZTNFI4ZCtrWVBZMGxNNktQKwo2T1RmRkRhdnFKY09XYUlTSVZ5RnFEdEtkeFFxRk9WcHVaOWhKVjEyZDljVHNISjRuNy92Z1hoQlJnSkpyNGtFCllLd0lLWDR6d3BRN0VyeTc4K0ZSRVAva3NXeTdqRXNTOGtpckdoUTFLL1lMWkQzcGlWQTVZR2RhMzAvb2lXOUwKRWJlemlVNjd2VVNsUWRDZnd4cmgweW9DYkZjT25LaFhKZ04weEpUOTFYWlY4RXFtczVSOU9QV0FQeXhyRHFJQgpva3o2RU9zeURXdkgrWGxma0dTRCt1b3J6alVWaXRlRVdEYWdXZnJ0dStVOCtUYm14RFZEN3Jmc09BZmdWanRqCjZWSWprN09kS1dwdnc0Sk9tNW0xZnJxdTE0cz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0422ec9-aab3-4b4c-92a8-df63c8dc4ed1
+      - bca9ca2e-48db-49dc-beee-59a350b6a718
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,7 +1832,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=892c6dea-4942-4341-9749-8d44928a848a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQkw2b2tpWnlRcUN6UHVoUWZWL0hKTFpOZ3pFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRReE5qVTJXaGNOTXpNeE1qRTFNVFF4TmpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxnYnFseGM0dVBmcHB0YW42VEZKMVg3YXBVZ1hrWGpCRXJTaUFkTnZNN3dpTXZIS3gvTlBuZ0oKbENkSEx2MzlMMUcvMFlnekRWMldDelZFYmpmUHFBTWpCcFZMd2pZUlJ5a28veEFvdG1FczAvME9aZi9vdXhsMgpXeU1iZDRTdk92UHl5TldId3V1Z015elNRRFgyZFdRaFdWOGZ2OGk4UXN3WVN4NFBuWFlCcFpUSDdtd3kxdjNlCmQrK0xDUEtaYWJJa1kzR29VZlZjQ1I3bi94UVBaeWMzVlhGaXBzcE9aRE1Zamg2dGd1d09WMFJsOElsSXVIMnIKK1psNnhtYTZ4MDhOM0Y2V2EvejZySVlueGsxb2xrcTRtS1dxWUd4SUM1alFEYUtBTWI4UUFMT3Q1Z1dTQmN0RAp5THMycXBwUXMzdHY5SXpSN0d6WnJPUVVaNnVzb3IwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MW1aalZqTW1JM01pMWtNMlpoTFRSallUZ3RZVGt3TXkxaVpERXcKTnpRMU1HUTROMk11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1ptTldNeVlqY3lMV1F6Wm1FdE5HTmhPQzFoT1RBekxXSmtNVEEzTkRVd1pEZzNZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnloSG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKTlNRQVFvOTJURHNzbDVidkwyeURONFZUVW9yQkY4NHNQNXNvZVVnclV0Zzg2QmVRSGZVTm5HTmc4cDRQeStSVQpQOWJ6bm1qd21KVzM4MlJuL3hVZFVLb09jQjg3dnBROElaL215aVgwU3hXa3ZaWkJzSTFlUEJZdXgxMFg1M0hwClEzYnpxbjIzRUFITFNWb0lnM25mVVFDOWJFS2lyOEpDNXBCRlpUUy8zYS84Y080cEgyNmFCRGdQN0Zzclc2bk0KeE1IbUxyQTUyUEwxQS83ajZ3bFFMWU03UmFpbitxYkVZRnJLWDRxZjc0M1gwM3VQUGk4WEtlbjRqc0ZybzFyTQpKeDJUYk9pVU14V2hzTDNHOHBOZ3d3eFFHS0lHeHRwWWxvRldUVHIwUktMallKRFVxT2plYWFGSmFpWVZuajE5CnNrWUpsb0tZckVYaTltVFRBVEI3RlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:18:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bc961c64-8a39-4eac-8a62-e1b31c8998f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ff5c2b72-d3fa-4ca8-a903-bd107450d87c&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1745,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 181faec5-140b-4920-8249-382b8ac32498
+      - 15f8534b-0bd0-493c-8ccf-08adbc2cedf4
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,7 +1898,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -1778,7 +1910,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:18:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64a2826e-d038-4bde-b850-b0ebc3425311
+      - 9a482f14-a182-4e05-89da-ff6b2a5f2e8b
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,10 +1931,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1811,7 +1943,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:18:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1ec9b2c-02be-4c17-be79-806de43fe15c
+      - 9030c3fc-ef8c-4648-ac1c-a9e301442c43
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,10 +1964,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=892c6dea-4942-4341-9749-8d44928a848a&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:18:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 301b25f5-e56c-4c53-859f-f903b3ee6cc0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ff5c2b72-d3fa-4ca8-a903-bd107450d87c&name=test_backup_datasource&order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"database_backups":[{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1844,7 +2009,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:58 GMT
+      - Mon, 18 Dec 2023 14:18:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +2019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9298a99-649a-4de7-bc07-73bf163e57de
+      - f1d74ced-a821-4670-903d-6f92e39f90bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,10 +2030,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1877,7 +2042,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:58 GMT
+      - Mon, 18 Dec 2023 14:18:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,40 +2052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4f0def0-e4ba-4e1d-a0e5-75c4cacc0402
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
-    headers:
-      Content-Length:
-      - "418"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:10:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8f77a862-630b-473f-b020-edb9c63beee4
+      - 993fa033-f7bb-4816-80a4-c9c832c9147c
     status: 200 OK
     code: 200
     duration: ""
@@ -1934,7 +2066,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1943,7 +2075,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:15 GMT
+      - Mon, 18 Dec 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1953,7 +2085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26f74186-4db3-4fbb-9018-96458ffcf700
+      - 706a1558-613f-4803-b95b-c79e9f08c992
     status: 200 OK
     code: 200
     duration: ""
@@ -1964,10 +2096,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1976,7 +2108,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:15 GMT
+      - Mon, 18 Dec 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1986,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cf82b5f-156d-422a-abc7-78eff2738ff1
+      - cc8328fe-2769-48d2-9c71-e33966c54200
     status: 200 OK
     code: 200
     duration: ""
@@ -1997,10 +2129,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=892c6dea-4942-4341-9749-8d44928a848a&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:18:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e7dca546-ddfc-481d-9d39-49407f52dc60
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=ff5c2b72-d3fa-4ca8-a903-bd107450d87c&name=test_backup_datasource&order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"database_backups":[{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -2009,7 +2174,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:15 GMT
+      - Mon, 18 Dec 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2019,7 +2184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3361ecfe-a7ef-4f1e-b153-da7faa17ba79
+      - b65b8bcd-d556-4a5f-ac3d-7ef30e7774cf
     status: 200 OK
     code: 200
     duration: ""
@@ -2030,10 +2195,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -2042,7 +2207,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:15 GMT
+      - Mon, 18 Dec 2023 14:18:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2052,40 +2217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cc90ad1-793e-4b6e-a748-9c240113ecac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
-    headers:
-      Content-Length:
-      - "418"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:11:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2403c847-27f1-44a3-a629-7577399426d7
+      - 18483e92-b6c8-491b-bc3f-3fe5b6406890
     status: 200 OK
     code: 200
     duration: ""
@@ -2099,7 +2231,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -2108,7 +2240,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:28 GMT
+      - Mon, 18 Dec 2023 14:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2118,7 +2250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d3db3b1-5edd-4e9a-83eb-f0ca5074f83f
+      - 2b625c5e-7891-4a31-9467-7a4fc6ffec10
     status: 200 OK
     code: 200
     duration: ""
@@ -2129,10 +2261,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -2141,7 +2273,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:28 GMT
+      - Mon, 18 Dec 2023 14:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2151,7 +2283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfcfc9a9-487f-4516-b10b-099316dda83f
+      - 0816749f-51d3-4965-b90b-adf47954a35c
     status: 200 OK
     code: 200
     duration: ""
@@ -2162,10 +2294,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "418"
@@ -2174,7 +2306,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:31 GMT
+      - Mon, 18 Dec 2023 14:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2184,7 +2316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ccc0d7a-8b22-4a0a-bebe-99dcefa23961
+      - 027f2e80-99a9-403a-bf4b-85d6a670a013
     status: 200 OK
     code: 200
     duration: ""
@@ -2195,10 +2327,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: DELETE
   response:
-    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"deleting","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    body: '{"created_at":"2023-12-18T14:17:31.317950Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","instance_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"deleting","updated_at":"2023-12-18T14:17:33.442561Z"}'
     headers:
       Content-Length:
       - "421"
@@ -2207,7 +2339,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:32 GMT
+      - Mon, 18 Dec 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2217,7 +2349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32a57977-6e50-45ab-a5ca-e51f617b569d
+      - 83681273-d9da-40c6-949f-f4c332dbfe34
     status: 200 OK
     code: 200
     duration: ""
@@ -2228,10 +2360,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2240,7 +2372,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:32 GMT
+      - Mon, 18 Dec 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2250,7 +2382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24118c9d-214a-4ad2-9391-4ba6cd30c72d
+      - 9d09d48a-a49b-479e-9687-869c839bb752
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2261,19 +2393,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:33 GMT
+      - Mon, 18 Dec 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2283,7 +2415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b153ba3-5bdc-44d5-8112-f424add14a16
+      - e0186a42-4e1b-4e34-b450-4a78c76439f4
     status: 200 OK
     code: 200
     duration: ""
@@ -2294,7 +2426,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases/test-terraform
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c/databases/test-terraform
     method: DELETE
   response:
     body: ""
@@ -2304,7 +2436,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:33 GMT
+      - Mon, 18 Dec 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2314,7 +2446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d22b87eb-336b-4555-878d-643517b3b7e8
+      - 0d129329-01f3-4103-860a-a702e69684f3
     status: 204 No Content
     code: 204
     duration: ""
@@ -2325,19 +2457,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:33 GMT
+      - Mon, 18 Dec 2023 14:18:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9eff4def-48b4-484e-b358-6b295a02501f
+      - fe7aa63b-040c-49ec-bd94-e550aa313d3e
     status: 200 OK
     code: 200
     duration: ""
@@ -2358,19 +2490,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:34 GMT
+      - Mon, 18 Dec 2023 14:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2380,7 +2512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e6edfbc-6276-4b33-b298-d2d8e5627333
+      - b65bdfb3-0470-446d-adb6-c5532ecc4c4d
     status: 200 OK
     code: 200
     duration: ""
@@ -2391,19 +2523,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1208"
+      - "1206"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:34 GMT
+      - Mon, 18 Dec 2023 14:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2413,7 +2545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1da6cca3-03d5-4cb6-b3bb-3740ac63869b
+      - 251693bd-5bd5-4327-a8c8-7a8b1af6203f
     status: 200 OK
     code: 200
     duration: ""
@@ -2424,19 +2556,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:14:13.806962Z","retention":7},"created_at":"2023-12-18T14:14:13.806962Z","endpoint":{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003},"endpoints":[{"id":"164b14cd-d3df-45d7-8881-3a8238294a62","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24003}],"engine":"PostgreSQL-15","id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1208"
+      - "1206"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:34 GMT
+      - Mon, 18 Dec 2023 14:18:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2446,7 +2578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aca69a25-acc1-4c2c-a735-c96316d42209
+      - 412b323a-4fbc-423c-bc5b-a63efa55c455
     status: 200 OK
     code: 200
     duration: ""
@@ -2457,10 +2589,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"892c6dea-4942-4341-9749-8d44928a848a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2469,7 +2601,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:05 GMT
+      - Mon, 18 Dec 2023 14:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2479,7 +2611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 935585ca-1d24-474b-a5ca-a47646535a45
+      - ab1767cc-adf7-4a1c-bf93-8b0bc53ac7e4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2490,10 +2622,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ff5c2b72-d3fa-4ca8-a903-bd107450d87c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"892c6dea-4942-4341-9749-8d44928a848a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ff5c2b72-d3fa-4ca8-a903-bd107450d87c","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2502,7 +2634,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:05 GMT
+      - Mon, 18 Dec 2023 14:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2512,7 +2644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61fc7403-848b-4f8f-8131-634e14974c5c
+      - 5d153716-920d-4a9d-8fe9-aff7f06f6c3e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2523,10 +2655,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2535,7 +2667,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:05 GMT
+      - Mon, 18 Dec 2023 14:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2545,7 +2677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecbb57f1-ed05-4dd1-a7cb-370060cd234e
+      - 050cf563-42e1-4378-9bb2-7fb679dccc59
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2556,10 +2688,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2568,7 +2700,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:05 GMT
+      - Mon, 18 Dec 2023 14:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2578,7 +2710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 239409a4-a532-491a-abf4-4492d25efc33
+      - 00a240d1-132c-48ea-8852-2bd0fd919caf
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2589,10 +2721,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2601,7 +2733,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:05 GMT
+      - Mon, 18 Dec 2023 14:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2611,7 +2743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5ef65cb-2cde-4b7f-9246-4e44efc109dc
+      - a02985be-a997-4cb1-921c-ceb2f9fe6d09
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2622,10 +2754,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/746a1cae-e29b-4c70-8f57-f5e296f8bdda
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"746a1cae-e29b-4c70-8f57-f5e296f8bdda","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2634,7 +2766,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:05 GMT
+      - Mon, 18 Dec 2023 14:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2644,7 +2776,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26505e95-67fe-46a6-a495-878abb3a9c4d
+      - a0e7e538-db3a-41d6-b628-69fad2f5ba52
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-database-backup-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-database-backup-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:00 GMT
+      - Mon, 18 Dec 2023 12:57:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16347983-07ad-4869-a935-c5ad678cdc1a
+      - 52dde299-16ae-45af-91c2-7b2f8a368d2f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:02 GMT
+      - Mon, 18 Dec 2023 13:06:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c091cc44-105d-410e-9873-e5b7b25a766e
+      - 7c6aee57-2302-46a0-8c8f-18d5ee2990d6
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:03 GMT
+      - Mon, 18 Dec 2023 13:06:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3507e5c0-3ec9-454c-b003-d23b168ef520
+      - 88cfde9c-2bad-45d7-bbd5-3bbac7fb2a79
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:33 GMT
+      - Mon, 18 Dec 2023 13:07:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77d15a43-60ac-42ba-88fd-85706cc8b0f2
+      - 12cc4b2f-3384-4492-a6a2-7ce297b594fe
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:03 GMT
+      - Mon, 18 Dec 2023 13:07:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3a6ec70-3d59-4d75-a8a1-86a4dde0ae35
+      - d8af3d61-2122-4186-bc5c-3de1cd2e4f45
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:33 GMT
+      - Mon, 18 Dec 2023 13:08:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f9f4cd2-17b9-428f-b0e5-28504b36327d
+      - ad807d3c-347c-4044-b330-3680b44d9322
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:04 GMT
+      - Mon, 18 Dec 2023 13:08:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02b8d370-3e43-4ba9-acca-bae8e7288c91
+      - 78caa520-818c-4390-a108-09379c29f2b1
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "896"
+      - "1160"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:09:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ee5e2b3-be47-4147-83b4-7230bd2e45c8
+      - 3e70e1d7-9a36-43ad-a3bd-d0195e4cdf02
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:04 GMT
+      - Mon, 18 Dec 2023 13:10:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,40 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fc3704d-8180-4147-b6c7-43f41a240972
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1203"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 44aa26f4-b6e4-4703-abf9-c14446a3cbca
+      - a45c428a-6282-48c3-aff6-7ba34e4a7277
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccaadb30-290c-4eff-a410-d74eb07a38b6
+      - 4c551f6d-10dd-46cb-b161-a9d412a79710
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72ab1606-7d4a-48c0-bfff-8662c4ec11d1
+      - 313ea621-31ca-406d-a9fe-f13cdae5b89b
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVV29udTFQRWhrQURuWGEwWmh0cUtOR0V2QzZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1Ea3pPRm9YRFRNek1USXhOVEV6TURrek9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdiWE8waTN3L3JmWG9aeUd2K0MvcG9UeEZCMkloUGJqa25jUTVSd3RuUlVoSG1PWmc5RUsKUWpPUzFhTTlJbm5aYklETGFsQzZtUEVWamxENngvT3lSNVVtb3RJTjl0aXdpMnp2c1hnUEtPV3hIQmxMMmZSLwpYOWQ5ZlJ5N04zdnJqZ1czaFB6WCtxTzJCclcwZ0h4bzFjSm5WRjBGZktHSnBVU2swMGI5bUs0VVc2VVowUCs3Cmg4eWRDcFhXVkt2bWZvVWR6TU9FcDZjSHZFZk5KWnNYZTVMdFRqSXh6aUE5RlhIbkk5RUNnaHlWV3VvNXZCUlgKOEl2dkRJbE5yWUQvTjhodmhLcVExUDZPOXFOSHpVeld1WlJRRTd2RDg0V0puL1ltd0JQRHNUTndRdndwa2JXQQpzS2s0empkT01hZUxqb2pucHRRbGdLSjA2dXBGYWRWMXlRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTA0T1RKak5tUmxZUzAwT1RReUxUUXpOREV0T1RjME9TMDQKWkRRME9USTRZVGcwT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwNE9USmpObVJsWVMwME9UUXlMVFF6TkRFdE9UYzBPUzA0WkRRME9USTRZVGcwT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDEwZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFJMnROZmx0L0VXUmpUdmgyZng4MEtMWlduTEZmaU9nOFZRemw1enMrRUZTNFI4ZCtrWVBZMGxNNktQKwo2T1RmRkRhdnFKY09XYUlTSVZ5RnFEdEtkeFFxRk9WcHVaOWhKVjEyZDljVHNISjRuNy92Z1hoQlJnSkpyNGtFCllLd0lLWDR6d3BRN0VyeTc4K0ZSRVAva3NXeTdqRXNTOGtpckdoUTFLL1lMWkQzcGlWQTVZR2RhMzAvb2lXOUwKRWJlemlVNjd2VVNsUWRDZnd4cmgweW9DYkZjT25LaFhKZ04weEpUOTFYWlY4RXFtczVSOU9QV0FQeXhyRHFJQgpva3o2RU9zeURXdkgrWGxma0dTRCt1b3J6alVWaXRlRVdEYWdXZnJ0dStVOCtUYm14RFZEN3Jmc09BZmdWanRqCjZWSWprN09kS1dwdnc0Sk9tNW0xZnJxdTE0cz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5757e119-58c6-47a8-aad3-13947b6600cd
+      - 6b801d9c-da99-4a4c-a1ad-f0602bf2c18c
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=892c6dea-4942-4341-9749-8d44928a848a&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVE82RlpnMkpEbXB3KzNYWUlaWnpteUNQdmtzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE9EUTNXaGNOTXpNeE1qRTFNVE14T0RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUx0U0pmTDRwMTRmYlZkaU1wMUtwRmFZMU9ZSHEyQUVOa29YK1JZWVNwVGEybGxGMkdRdDBLSFUKcDB4Q29pN0NHd0ZzckpGdHhQa2xxeDlPQ21laVZvd0R6bmh6L0JSS3pYVjY1UmJKZ1dxdWswRTlvKzgwNlpNLwo2NGdWU2VEamZNSTV3UFFzVzh6bWEyWnRsUzBiMDZ5N2RKQnozeWFKcEJQSVVHRUViVy9DNllDRUhnZ25oZGRRCkp1dEF6TVl5MGQycWpVUEpaZTQyemRyTEVwRlQwN1B4d0pQZXAwTjdrcmp2c3RXTHdYMGgvZHFKM3F2di9qY1IKbzZ0V2tCNHJWMmN4UEVBb0Z2VjN3SW1rSGlOWkZaRTdvUjExZnZGRGdZbThvNng1bFlqRTRDZEJnZjJEZGVrbgp6UGZ3d0J4aEhuSXZNZEdWWENORGRqYlpwdlJDMXVrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHhaRFUxWkdNNU55MDNOalkzTFRSbVlXSXRPR05pTWkxbU1UazQKTXpGa1lUWmxNemd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEZrTlRWa1l6azNMVGMyTmpjdE5HWmhZaTA0WTJJeUxXWXhPVGd6TVdSaE5tVXpPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy9YUjRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUtjcmZVS2hKa2hYS1ZCZUxpaW9Kek5XTkY4ODJIMnFrdDBZakdOYVQ5NkdLSUV5VjQ3dWU0Lzg1dUFMNXJhbQphdDhMUlM4OHpJajVLb3FaeCtSb21CdStZVUgxTG5JMTJGZFE1bU16MU1HL0IxNWZ2RFBXaXdPbGdNNStidWxDCnVUSEFKb29qQmZ1b01Jc0FUNmRXc3dmOXdHUmxobUVadllKK1luNmNEOEtDNlRyUkoyMzRrRGxSdVZscVBrTm8KcnltRFQ1YmMwMWZqUW1iWWRoTG03WmcxT25ic2xISUdIZnpsTVlTQVBVZWJ5NFBXczFsMU1IMnhlVUd1UUVYbgo4ODJSM0ZLbGdjakZFV2FxTy9vU0ZyWkRkck42TFRQVUZvdlVXMXk2QWFFYWdvWjlObWNielY3MW1rN3VKUzJ4CjkwMyttbmxUMnRwcm5BZkNWcU1pUkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2007"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad991d10-4709-4982-b8f1-c4be314ea620
+      - cd6376fd-56f8-403b-be1a-b92a06b86cf6
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44b0c0df-c934-45fa-aea4-534a8616024a
+      - 3dbdc032-843f-4e6b-b8cc-4d54a860cd3c
     status: 200 OK
     code: 200
     duration: ""
@@ -807,7 +774,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases
     method: POST
   response:
     body: '{"managed":true,"name":"test-terraform","owner":"","size":0}'
@@ -819,7 +786,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:06 GMT
+      - Mon, 18 Dec 2023 13:10:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a71c4703-07c0-4bf4-aaea-ec427cc9b478
+      - 8f3e7e3b-5e8d-48c2-ba9c-c651ae189a33
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +807,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:06 GMT
+      - Mon, 18 Dec 2023 13:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bae95a07-e0f4-4f69-8f76-4ce47327d579
+      - c3a85c46-c114-4844-bc76-e7a8a7668abe
     status: 200 OK
     code: 200
     duration: ""
@@ -873,142 +840,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "113"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 564e6145-746f-40cc-a29f-fe5cf91efb6b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1203"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f08159ec-e222-49ad-9db9-61937ca78a48
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/users?order_by=name_asc&page=1
-    method: GET
-  response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d452ccb7-a6c8-4f7f-9319-64057da2ef5d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVE82RlpnMkpEbXB3KzNYWUlaWnpteUNQdmtzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE9EUTNXaGNOTXpNeE1qRTFNVE14T0RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUx0U0pmTDRwMTRmYlZkaU1wMUtwRmFZMU9ZSHEyQUVOa29YK1JZWVNwVGEybGxGMkdRdDBLSFUKcDB4Q29pN0NHd0ZzckpGdHhQa2xxeDlPQ21laVZvd0R6bmh6L0JSS3pYVjY1UmJKZ1dxdWswRTlvKzgwNlpNLwo2NGdWU2VEamZNSTV3UFFzVzh6bWEyWnRsUzBiMDZ5N2RKQnozeWFKcEJQSVVHRUViVy9DNllDRUhnZ25oZGRRCkp1dEF6TVl5MGQycWpVUEpaZTQyemRyTEVwRlQwN1B4d0pQZXAwTjdrcmp2c3RXTHdYMGgvZHFKM3F2di9qY1IKbzZ0V2tCNHJWMmN4UEVBb0Z2VjN3SW1rSGlOWkZaRTdvUjExZnZGRGdZbThvNng1bFlqRTRDZEJnZjJEZGVrbgp6UGZ3d0J4aEhuSXZNZEdWWENORGRqYlpwdlJDMXVrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHhaRFUxWkdNNU55MDNOalkzTFRSbVlXSXRPR05pTWkxbU1UazQKTXpGa1lUWmxNemd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEZrTlRWa1l6azNMVGMyTmpjdE5HWmhZaTA0WTJJeUxXWXhPVGd6TVdSaE5tVXpPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy9YUjRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUtjcmZVS2hKa2hYS1ZCZUxpaW9Kek5XTkY4ODJIMnFrdDBZakdOYVQ5NkdLSUV5VjQ3dWU0Lzg1dUFMNXJhbQphdDhMUlM4OHpJajVLb3FaeCtSb21CdStZVUgxTG5JMTJGZFE1bU16MU1HL0IxNWZ2RFBXaXdPbGdNNStidWxDCnVUSEFKb29qQmZ1b01Jc0FUNmRXc3dmOXdHUmxobUVadllKK1luNmNEOEtDNlRyUkoyMzRrRGxSdVZscVBrTm8KcnltRFQ1YmMwMWZqUW1iWWRoTG03WmcxT25ic2xISUdIZnpsTVlTQVBVZWJ5NFBXczFsMU1IMnhlVUd1UUVYbgo4ODJSM0ZLbGdjakZFV2FxTy9vU0ZyWkRkck42TFRQVUZvdlVXMXk2QWFFYWdvWjlObWNielY3MW1rN3VKUzJ4CjkwMyttbmxUMnRwcm5BZkNWcU1pUkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2007"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f445672b-e9bc-4c27-bff0-d76bff9275e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1017,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94150f2d-4e30-45e8-b28f-e7aaa3692dda
+      - 85451cdc-70f4-432d-b2c7-eaecaefdc655
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce8fb21a-ced1-4cff-8051-ab9f710044ce
+      - a9109622-8d02-43f9-96e2-3e62386aa1ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVV29udTFQRWhrQURuWGEwWmh0cUtOR0V2QzZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1Ea3pPRm9YRFRNek1USXhOVEV6TURrek9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdiWE8waTN3L3JmWG9aeUd2K0MvcG9UeEZCMkloUGJqa25jUTVSd3RuUlVoSG1PWmc5RUsKUWpPUzFhTTlJbm5aYklETGFsQzZtUEVWamxENngvT3lSNVVtb3RJTjl0aXdpMnp2c1hnUEtPV3hIQmxMMmZSLwpYOWQ5ZlJ5N04zdnJqZ1czaFB6WCtxTzJCclcwZ0h4bzFjSm5WRjBGZktHSnBVU2swMGI5bUs0VVc2VVowUCs3Cmg4eWRDcFhXVkt2bWZvVWR6TU9FcDZjSHZFZk5KWnNYZTVMdFRqSXh6aUE5RlhIbkk5RUNnaHlWV3VvNXZCUlgKOEl2dkRJbE5yWUQvTjhodmhLcVExUDZPOXFOSHpVeld1WlJRRTd2RDg0V0puL1ltd0JQRHNUTndRdndwa2JXQQpzS2s0empkT01hZUxqb2pucHRRbGdLSjA2dXBGYWRWMXlRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTA0T1RKak5tUmxZUzAwT1RReUxUUXpOREV0T1RjME9TMDQKWkRRME9USTRZVGcwT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwNE9USmpObVJsWVMwME9UUXlMVFF6TkRFdE9UYzBPUzA0WkRRME9USTRZVGcwT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDEwZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFJMnROZmx0L0VXUmpUdmgyZng4MEtMWlduTEZmaU9nOFZRemw1enMrRUZTNFI4ZCtrWVBZMGxNNktQKwo2T1RmRkRhdnFKY09XYUlTSVZ5RnFEdEtkeFFxRk9WcHVaOWhKVjEyZDljVHNISjRuNy92Z1hoQlJnSkpyNGtFCllLd0lLWDR6d3BRN0VyeTc4K0ZSRVAva3NXeTdqRXNTOGtpckdoUTFLL1lMWkQzcGlWQTVZR2RhMzAvb2lXOUwKRWJlemlVNjd2VVNsUWRDZnd4cmgweW9DYkZjT25LaFhKZ04weEpUOTFYWlY4RXFtczVSOU9QV0FQeXhyRHFJQgpva3o2RU9zeURXdkgrWGxma0dTRCt1b3J6alVWaXRlRVdEYWdXZnJ0dStVOCtUYm14RFZEN3Jmc09BZmdWanRqCjZWSWprN09kS1dwdnc0Sk9tNW0xZnJxdTE0cz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9b4750b-7371-422e-8c24-ed4008f75e01
+      - 2f514b61-fabe-4427-b4b3-35aaedf42862
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=892c6dea-4942-4341-9749-8d44928a848a&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVE82RlpnMkpEbXB3KzNYWUlaWnpteUNQdmtzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE9EUTNXaGNOTXpNeE1qRTFNVE14T0RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUx0U0pmTDRwMTRmYlZkaU1wMUtwRmFZMU9ZSHEyQUVOa29YK1JZWVNwVGEybGxGMkdRdDBLSFUKcDB4Q29pN0NHd0ZzckpGdHhQa2xxeDlPQ21laVZvd0R6bmh6L0JSS3pYVjY1UmJKZ1dxdWswRTlvKzgwNlpNLwo2NGdWU2VEamZNSTV3UFFzVzh6bWEyWnRsUzBiMDZ5N2RKQnozeWFKcEJQSVVHRUViVy9DNllDRUhnZ25oZGRRCkp1dEF6TVl5MGQycWpVUEpaZTQyemRyTEVwRlQwN1B4d0pQZXAwTjdrcmp2c3RXTHdYMGgvZHFKM3F2di9qY1IKbzZ0V2tCNHJWMmN4UEVBb0Z2VjN3SW1rSGlOWkZaRTdvUjExZnZGRGdZbThvNng1bFlqRTRDZEJnZjJEZGVrbgp6UGZ3d0J4aEhuSXZNZEdWWENORGRqYlpwdlJDMXVrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHhaRFUxWkdNNU55MDNOalkzTFRSbVlXSXRPR05pTWkxbU1UazQKTXpGa1lUWmxNemd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEZrTlRWa1l6azNMVGMyTmpjdE5HWmhZaTA0WTJJeUxXWXhPVGd6TVdSaE5tVXpPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy9YUjRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUtjcmZVS2hKa2hYS1ZCZUxpaW9Kek5XTkY4ODJIMnFrdDBZakdOYVQ5NkdLSUV5VjQ3dWU0Lzg1dUFMNXJhbQphdDhMUlM4OHpJajVLb3FaeCtSb21CdStZVUgxTG5JMTJGZFE1bU16MU1HL0IxNWZ2RFBXaXdPbGdNNStidWxDCnVUSEFKb29qQmZ1b01Jc0FUNmRXc3dmOXdHUmxobUVadllKK1luNmNEOEtDNlRyUkoyMzRrRGxSdVZscVBrTm8KcnltRFQ1YmMwMWZqUW1iWWRoTG03WmcxT25ic2xISUdIZnpsTVlTQVBVZWJ5NFBXczFsMU1IMnhlVUd1UUVYbgo4ODJSM0ZLbGdjakZFV2FxTy9vU0ZyWkRkck42TFRQVUZvdlVXMXk2QWFFYWdvWjlObWNielY3MW1rN3VKUzJ4CjkwMyttbmxUMnRwcm5BZkNWcU1pUkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2007"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd656856-979b-42a8-b3cc-9ae04cbb3fbb
+      - ec2223dd-bb56-4ddd-8da9-83ad5045633d
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,10 +972,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1149,7 +984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:10:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,12 +994,144 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b54a8920-4406-4588-8c51-142040a0fdda
+      - 876151bc-650c-4cf2-980c-b6acbd41fc4a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","database_name":"test-terraform","name":"test_backup_datasource"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1205"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:10:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4e9253cf-8732-45ff-90b1-080a5cce363b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVV29udTFQRWhrQURuWGEwWmh0cUtOR0V2QzZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1Ea3pPRm9YRFRNek1USXhOVEV6TURrek9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdiWE8waTN3L3JmWG9aeUd2K0MvcG9UeEZCMkloUGJqa25jUTVSd3RuUlVoSG1PWmc5RUsKUWpPUzFhTTlJbm5aYklETGFsQzZtUEVWamxENngvT3lSNVVtb3RJTjl0aXdpMnp2c1hnUEtPV3hIQmxMMmZSLwpYOWQ5ZlJ5N04zdnJqZ1czaFB6WCtxTzJCclcwZ0h4bzFjSm5WRjBGZktHSnBVU2swMGI5bUs0VVc2VVowUCs3Cmg4eWRDcFhXVkt2bWZvVWR6TU9FcDZjSHZFZk5KWnNYZTVMdFRqSXh6aUE5RlhIbkk5RUNnaHlWV3VvNXZCUlgKOEl2dkRJbE5yWUQvTjhodmhLcVExUDZPOXFOSHpVeld1WlJRRTd2RDg0V0puL1ltd0JQRHNUTndRdndwa2JXQQpzS2s0empkT01hZUxqb2pucHRRbGdLSjA2dXBGYWRWMXlRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTA0T1RKak5tUmxZUzAwT1RReUxUUXpOREV0T1RjME9TMDQKWkRRME9USTRZVGcwT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwNE9USmpObVJsWVMwME9UUXlMVFF6TkRFdE9UYzBPUzA0WkRRME9USTRZVGcwT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDEwZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFJMnROZmx0L0VXUmpUdmgyZng4MEtMWlduTEZmaU9nOFZRemw1enMrRUZTNFI4ZCtrWVBZMGxNNktQKwo2T1RmRkRhdnFKY09XYUlTSVZ5RnFEdEtkeFFxRk9WcHVaOWhKVjEyZDljVHNISjRuNy92Z1hoQlJnSkpyNGtFCllLd0lLWDR6d3BRN0VyeTc4K0ZSRVAva3NXeTdqRXNTOGtpckdoUTFLL1lMWkQzcGlWQTVZR2RhMzAvb2lXOUwKRWJlemlVNjd2VVNsUWRDZnd4cmgweW9DYkZjT25LaFhKZ04weEpUOTFYWlY4RXFtczVSOU9QV0FQeXhyRHFJQgpva3o2RU9zeURXdkgrWGxma0dTRCt1b3J6alVWaXRlRVdEYWdXZnJ0dStVOCtUYm14RFZEN3Jmc09BZmdWanRqCjZWSWprN09kS1dwdnc0Sk9tNW0xZnJxdTE0cz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:10:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8fdaa82f-ffd3-4749-a857-1c2cab234a65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=892c6dea-4942-4341-9749-8d44928a848a&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:10:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5bf5a16f-7c83-4499-b746-b41edbe09620
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "113"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:10:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a2f296b-3e73-4f41-aae3-408b140d0c2a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"892c6dea-4942-4341-9749-8d44928a848a","database_name":"test-terraform","name":"test_backup_datasource"}'
     form: {}
     headers:
       Content-Type:
@@ -1175,7 +1142,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
       - "396"
@@ -1184,7 +1151,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:10:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4609d89-6c31-41ed-971a-03a194957d44
+      - 93fecd87-be08-4a9f-baed-80622d2ae962
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,10 +1172,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
       - "396"
@@ -1217,7 +1184,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:10:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e39381fd-d9fa-4b0b-be1e-1f1f90d07734
+      - 131de354-33a6-4584-b49a-791a52fb20d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,10 +1205,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1250,7 +1217,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:39 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5d657f9-0f85-4f5a-b074-d169e79657ce
+      - 9c786ddd-749c-41e2-b2c4-04f5e83e0841
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,10 +1238,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1283,7 +1250,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:39 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 942bfe25-d9e7-498d-8106-cf70aeaaf4b7
+      - 3a554c8c-a153-4752-a1e1-40ed073d8d8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,10 +1271,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=1d55dc97-7667-4fab-8cb2-f19831da6e38&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}],"total_count":1}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:10:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0bec0b13-1e83-4428-bec2-eda13637187e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=892c6dea-4942-4341-9749-8d44928a848a&name=test_backup_datasource&order_by=created_at_asc
+    method: GET
+  response:
+    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1316,7 +1316,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:39 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f350aeb-4717-4fab-a34b-642af45ef8e5
+      - a13380d3-76ec-49b5-be3d-29defe51dc12
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,10 +1337,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1349,7 +1349,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:39 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,40 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5c6abba-218a-4609-8d55-391eda1fabe6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
-    headers:
-      Content-Length:
-      - "418"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ef1d6318-293a-4666-aa06-52e2ca09f47c
+      - c133a03a-a864-42af-9b62-2ccc0f007993
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,7 +1373,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1415,7 +1382,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:40 GMT
+      - Mon, 18 Dec 2023 13:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7be882fd-a595-4849-8b93-3294a889f830
+      - 3376450c-8c37-4c60-b0c8-9e0d6e0c3696
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,10 +1403,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1448,7 +1415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:40 GMT
+      - Mon, 18 Dec 2023 13:10:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 762c7567-8c71-4400-a551-7b6b777f733c
+      - 8eaf911b-b774-4a76-a513-3c4245cb08d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,10 +1436,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1481,7 +1448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:40 GMT
+      - Mon, 18 Dec 2023 13:10:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8ce6dee-44b7-4a0f-916c-cd419ad13aaa
+      - b6938c6c-6283-4521-8460-ff38aaa0ec9d
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,10 +1469,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1514,7 +1481,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:40 GMT
+      - Mon, 18 Dec 2023 13:10:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cd5e9dd-d2e1-4f43-8874-2a50f4376deb
+      - 0d66d6b4-5757-4c1d-af62-5ecdad936a69
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,10 +1502,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1547,7 +1514,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:40 GMT
+      - Mon, 18 Dec 2023 13:10:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecdb5e70-8ec8-4ae3-b3c5-c304e9cfa6d7
+      - ae451b0a-1f2f-4be9-b37b-44965b6a8c12
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,10 +1535,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=1d55dc97-7667-4fab-8cb2-f19831da6e38&name=test_backup_datasource&order_by=created_at_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=892c6dea-4942-4341-9749-8d44928a848a&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1580,7 +1547,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:40 GMT
+      - Mon, 18 Dec 2023 13:10:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8258c3c1-d128-4343-ba6d-caa3410141ed
+      - 87c03da3-4ac5-4992-9523-e9fbfe7dcd3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,10 +1568,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1613,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:40 GMT
+      - Mon, 18 Dec 2023 13:10:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4de7ede8-20cd-42af-a5cb-72225eda2dbb
+      - 674712d4-854e-4c7b-8032-d2a9792364d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1637,7 +1604,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1646,7 +1613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 062ea6a1-6cd0-4603-a015-02a188e6f402
+      - 72bb1681-caee-4343-9b86-43acc3dc4eb6
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,10 +1634,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1679,7 +1646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87aa092d-5fc6-4f15-9857-f3912af5a5a9
+      - 5aec978a-5b8b-4f0e-b473-17cf1ceaaa06
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b44ecc4-2c63-49bc-9af6-e49a329a7173
+      - 2bbd0884-c7f0-48f7-a7bf-897d6e036b62
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVV29udTFQRWhrQURuWGEwWmh0cUtOR0V2QzZZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1Ea3pPRm9YRFRNek1USXhOVEV6TURrek9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdiWE8waTN3L3JmWG9aeUd2K0MvcG9UeEZCMkloUGJqa25jUTVSd3RuUlVoSG1PWmc5RUsKUWpPUzFhTTlJbm5aYklETGFsQzZtUEVWamxENngvT3lSNVVtb3RJTjl0aXdpMnp2c1hnUEtPV3hIQmxMMmZSLwpYOWQ5ZlJ5N04zdnJqZ1czaFB6WCtxTzJCclcwZ0h4bzFjSm5WRjBGZktHSnBVU2swMGI5bUs0VVc2VVowUCs3Cmg4eWRDcFhXVkt2bWZvVWR6TU9FcDZjSHZFZk5KWnNYZTVMdFRqSXh6aUE5RlhIbkk5RUNnaHlWV3VvNXZCUlgKOEl2dkRJbE5yWUQvTjhodmhLcVExUDZPOXFOSHpVeld1WlJRRTd2RDg0V0puL1ltd0JQRHNUTndRdndwa2JXQQpzS2s0empkT01hZUxqb2pucHRRbGdLSjA2dXBGYWRWMXlRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTA0T1RKak5tUmxZUzAwT1RReUxUUXpOREV0T1RjME9TMDQKWkRRME9USTRZVGcwT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwNE9USmpObVJsWVMwME9UUXlMVFF6TkRFdE9UYzBPUzA0WkRRME9USTRZVGcwT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDEwZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFJMnROZmx0L0VXUmpUdmgyZng4MEtMWlduTEZmaU9nOFZRemw1enMrRUZTNFI4ZCtrWVBZMGxNNktQKwo2T1RmRkRhdnFKY09XYUlTSVZ5RnFEdEtkeFFxRk9WcHVaOWhKVjEyZDljVHNISjRuNy92Z1hoQlJnSkpyNGtFCllLd0lLWDR6d3BRN0VyeTc4K0ZSRVAva3NXeTdqRXNTOGtpckdoUTFLL1lMWkQzcGlWQTVZR2RhMzAvb2lXOUwKRWJlemlVNjd2VVNsUWRDZnd4cmgweW9DYkZjT25LaFhKZ04weEpUOTFYWlY4RXFtczVSOU9QV0FQeXhyRHFJQgpva3o2RU9zeURXdkgrWGxma0dTRCt1b3J6alVWaXRlRVdEYWdXZnJ0dStVOCtUYm14RFZEN3Jmc09BZmdWanRqCjZWSWprN09kS1dwdnc0Sk9tNW0xZnJxdTE0cz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6b01f30-1c40-4861-a084-876ce667e187
+      - c0422ec9-aab3-4b4c-92a8-df63c8dc4ed1
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=892c6dea-4942-4341-9749-8d44928a848a&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVE82RlpnMkpEbXB3KzNYWUlaWnpteUNQdmtzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE9EUTNXaGNOTXpNeE1qRTFNVE14T0RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUx0U0pmTDRwMTRmYlZkaU1wMUtwRmFZMU9ZSHEyQUVOa29YK1JZWVNwVGEybGxGMkdRdDBLSFUKcDB4Q29pN0NHd0ZzckpGdHhQa2xxeDlPQ21laVZvd0R6bmh6L0JSS3pYVjY1UmJKZ1dxdWswRTlvKzgwNlpNLwo2NGdWU2VEamZNSTV3UFFzVzh6bWEyWnRsUzBiMDZ5N2RKQnozeWFKcEJQSVVHRUViVy9DNllDRUhnZ25oZGRRCkp1dEF6TVl5MGQycWpVUEpaZTQyemRyTEVwRlQwN1B4d0pQZXAwTjdrcmp2c3RXTHdYMGgvZHFKM3F2di9qY1IKbzZ0V2tCNHJWMmN4UEVBb0Z2VjN3SW1rSGlOWkZaRTdvUjExZnZGRGdZbThvNng1bFlqRTRDZEJnZjJEZGVrbgp6UGZ3d0J4aEhuSXZNZEdWWENORGRqYlpwdlJDMXVrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHhaRFUxWkdNNU55MDNOalkzTFRSbVlXSXRPR05pTWkxbU1UazQKTXpGa1lUWmxNemd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEZrTlRWa1l6azNMVGMyTmpjdE5HWmhZaTA0WTJJeUxXWXhPVGd6TVdSaE5tVXpPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy9YUjRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUtjcmZVS2hKa2hYS1ZCZUxpaW9Kek5XTkY4ODJIMnFrdDBZakdOYVQ5NkdLSUV5VjQ3dWU0Lzg1dUFMNXJhbQphdDhMUlM4OHpJajVLb3FaeCtSb21CdStZVUgxTG5JMTJGZFE1bU16MU1HL0IxNWZ2RFBXaXdPbGdNNStidWxDCnVUSEFKb29qQmZ1b01Jc0FUNmRXc3dmOXdHUmxobUVadllKK1luNmNEOEtDNlRyUkoyMzRrRGxSdVZscVBrTm8KcnltRFQ1YmMwMWZqUW1iWWRoTG03WmcxT25ic2xISUdIZnpsTVlTQVBVZWJ5NFBXczFsMU1IMnhlVUd1UUVYbgo4ODJSM0ZLbGdjakZFV2FxTy9vU0ZyWkRkck42TFRQVUZvdlVXMXk2QWFFYWdvWjlObWNielY3MW1rN3VKUzJ4CjkwMyttbmxUMnRwcm5BZkNWcU1pUkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2007"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81cf726d-de4a-42b3-8da0-966f7499145d
+      - 181faec5-140b-4920-8249-382b8ac32498
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,10 +1766,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1811,7 +1778,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb0d93f8-5b9a-4b71-bdd7-bba7bb831800
+      - 64a2826e-d038-4bde-b850-b0ebc3425311
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,10 +1799,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1844,7 +1811,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fe9e143-265c-4c00-a9a7-e23cbe6a113f
+      - f1ec9b2c-02be-4c17-be79-806de43fe15c
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,43 +1832,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=892c6dea-4942-4341-9749-8d44928a848a&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
-    headers:
-      Content-Length:
-      - "418"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 368e6e38-3f19-4171-bb03-2cde56a5afa8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=1d55dc97-7667-4fab-8cb2-f19831da6e38&name=test_backup_datasource&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1910,7 +1844,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1920,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd5fffaf-738d-42a2-853c-f8f0126cc1f7
+      - a9298a99-649a-4de7-bc07-73bf163e57de
     status: 200 OK
     code: 200
     duration: ""
@@ -1931,10 +1865,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -1943,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:10:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1953,7 +1887,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ba3f0b-a533-4a39-a35a-dcc1bcbbff8f
+      - a4f0def0-e4ba-4e1d-a0e5-75c4cacc0402
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:10:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8f77a862-630b-473f-b020-edb9c63beee4
     status: 200 OK
     code: 200
     duration: ""
@@ -1967,7 +1934,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -1976,7 +1943,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1986,7 +1953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b053b1f9-4037-4558-8c33-417578153ed3
+      - 26f74186-4db3-4fbb-9018-96458ffcf700
     status: 200 OK
     code: 200
     duration: ""
@@ -1997,10 +1964,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -2009,7 +1976,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2019,7 +1986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9938982c-88c9-4ad2-8d0a-a1febb0a6e7a
+      - 5cf82b5f-156d-422a-abc7-78eff2738ff1
     status: 200 OK
     code: 200
     duration: ""
@@ -2030,43 +1997,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=892c6dea-4942-4341-9749-8d44928a848a&name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
-    headers:
-      Content-Length:
-      - "418"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d9901046-f17d-4fda-a4e6-65ca2783a7f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?instance_id=1d55dc97-7667-4fab-8cb2-f19831da6e38&name=test_backup_datasource&order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -2075,7 +2009,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2085,7 +2019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4da6c29-c99c-4a3f-84fb-a41dcd41c8a7
+      - 3361ecfe-a7ef-4f1e-b153-da7faa17ba79
     status: 200 OK
     code: 200
     duration: ""
@@ -2096,10 +2030,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -2108,7 +2042,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2118,7 +2052,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9178a0e4-1c44-4d86-a31b-ed435dc9f517
+      - 7cc90ad1-793e-4b6e-a748-9c240113ecac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
+    headers:
+      Content-Length:
+      - "418"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2403c847-27f1-44a3-a629-7577399426d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2132,7 +2099,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups?name=test_backup_datasource&order_by=created_at_asc
     method: GET
   response:
-    body: '{"database_backups":[{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}],"total_count":1}'
+    body: '{"database_backups":[{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "457"
@@ -2141,7 +2108,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2151,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb254dc5-6e8c-44e6-8dfc-9fc1a5111b66
+      - 2d3db3b1-5edd-4e9a-83eb-f0ca5074f83f
     status: 200 OK
     code: 200
     duration: ""
@@ -2162,10 +2129,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -2174,7 +2141,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2184,7 +2151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fb71630-954d-4078-a0c5-3498e597b6c3
+      - bfcfc9a9-487f-4516-b10b-099316dda83f
     status: 200 OK
     code: 200
     duration: ""
@@ -2195,10 +2162,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"ready","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "418"
@@ -2207,7 +2174,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2217,7 +2184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ad10a6a-f67b-4d47-a798-fda689d855c8
+      - 9ccc0d7a-8b22-4a0a-bebe-99dcefa23961
     status: 200 OK
     code: 200
     duration: ""
@@ -2228,10 +2195,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: DELETE
   response:
-    body: '{"created_at":"2023-12-18T13:20:09.086764Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","instance_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"deleting","updated_at":"2023-12-18T13:20:11.040775Z"}'
+    body: '{"created_at":"2023-12-18T13:10:04.542409Z","database_name":"test-terraform","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"74da7741-5db3-44af-bbf6-33de1e7c4291","instance_id":"892c6dea-4942-4341-9749-8d44928a848a","instance_name":"test-terraform","name":"test_backup_datasource","region":"fr-par","same_region":false,"size":1303,"status":"deleting","updated_at":"2023-12-18T13:10:06.495501Z"}'
     headers:
       Content-Length:
       - "421"
@@ -2240,7 +2207,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:43 GMT
+      - Mon, 18 Dec 2023 13:11:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2250,7 +2217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b519768a-2d20-4533-895c-777d28cd4a6c
+      - 32a57977-6e50-45ab-a5ca-e51f617b569d
     status: 200 OK
     code: 200
     duration: ""
@@ -2261,10 +2228,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2273,7 +2240,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:44 GMT
+      - Mon, 18 Dec 2023 13:11:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2283,7 +2250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92c1a6f2-b251-4236-833d-e13b4dce18bd
+      - 24118c9d-214a-4ad2-9391-4ba6cd30c72d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2294,19 +2261,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:44 GMT
+      - Mon, 18 Dec 2023 13:11:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2316,7 +2283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7f3b1be-ef66-4799-9ea2-6a4e724b92f2
+      - 9b153ba3-5bdc-44d5-8112-f424add14a16
     status: 200 OK
     code: 200
     duration: ""
@@ -2327,7 +2294,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38/databases/test-terraform
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a/databases/test-terraform
     method: DELETE
   response:
     body: ""
@@ -2337,7 +2304,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:44 GMT
+      - Mon, 18 Dec 2023 13:11:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2347,7 +2314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a74a80d-c2d8-4037-ae04-0a98ae2cf788
+      - d22b87eb-336b-4555-878d-643517b3b7e8
     status: 204 No Content
     code: 204
     duration: ""
@@ -2358,19 +2325,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:44 GMT
+      - Mon, 18 Dec 2023 13:11:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2380,7 +2347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfb17263-6de7-4e8d-9ae1-352a038c6592
+      - 9eff4def-48b4-484e-b358-6b295a02501f
     status: 200 OK
     code: 200
     duration: ""
@@ -2391,19 +2358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:45 GMT
+      - Mon, 18 Dec 2023 13:11:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2413,7 +2380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6366a42-04a8-4d75-a553-048a39600c82
+      - 6e6edfbc-6276-4b33-b298-d2d8e5627333
     status: 200 OK
     code: 200
     duration: ""
@@ -2424,19 +2391,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:45 GMT
+      - Mon, 18 Dec 2023 13:11:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2446,7 +2413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d3c229e-ce80-431a-a80c-f13d1cb95780
+      - 1da6cca3-03d5-4cb6-b3bb-3740ac63869b
     status: 200 OK
     code: 200
     duration: ""
@@ -2457,19 +2424,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.718469Z","retention":7},"created_at":"2023-12-18T13:16:02.718469Z","endpoint":{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220},"endpoints":[{"id":"9b52af54-9d53-4bf4-9a36-c7d76d1a37de","ip":"51.159.74.238","load_balancer":{},"name":null,"port":24220}],"engine":"PostgreSQL-15","id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:55.021273Z","retention":7},"created_at":"2023-12-18T13:06:55.021273Z","endpoint":{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980},"endpoints":[{"id":"7f073ab7-bb49-417e-9cb5-d434bda9f388","ip":"195.154.68.173","load_balancer":{},"name":null,"port":20980}],"engine":"PostgreSQL-15","id":"892c6dea-4942-4341-9749-8d44928a848a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:45 GMT
+      - Mon, 18 Dec 2023 13:11:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2479,7 +2446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91dc254a-2f6b-49da-bde4-947c20005407
+      - aca69a25-acc1-4c2c-a735-c96316d42209
     status: 200 OK
     code: 200
     duration: ""
@@ -2490,10 +2457,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"892c6dea-4942-4341-9749-8d44928a848a","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2502,7 +2469,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:12:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2512,7 +2479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05f7b62b-338d-455b-840d-d77762504e28
+      - 935585ca-1d24-474b-a5ca-a47646535a45
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2523,10 +2490,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d55dc97-7667-4fab-8cb2-f19831da6e38
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/892c6dea-4942-4341-9749-8d44928a848a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1d55dc97-7667-4fab-8cb2-f19831da6e38","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"892c6dea-4942-4341-9749-8d44928a848a","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2535,7 +2502,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:12:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2545,7 +2512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66f81415-1306-4618-9b90-f433ff2f45d8
+      - 61fc7403-848b-4f8f-8131-634e14974c5c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2556,10 +2523,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2568,7 +2535,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:12:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2578,7 +2545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a186b732-5ab1-4997-be3b-7dba767097a6
+      - ecbb57f1-ed05-4dd1-a7cb-370060cd234e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2589,10 +2556,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2601,7 +2568,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:12:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2611,7 +2578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e342ee2-c95a-440d-b711-ac3cdb7991f5
+      - 239409a4-a532-491a-abf4-4492d25efc33
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2622,10 +2589,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2634,7 +2601,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:12:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2644,7 +2611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f172576d-3d7f-4078-adf6-8332f31544bd
+      - c5ef65cb-2cde-4b7f-9246-4e44efc109dc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2655,10 +2622,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/a43408f2-0986-41ee-9dcb-e1084de3ff83
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/74da7741-5db3-44af-bbf6-33de1e7c4291
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"a43408f2-0986-41ee-9dcb-e1084de3ff83","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"74da7741-5db3-44af-bbf6-33de1e7c4291","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2667,7 +2634,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:12:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2677,7 +2644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 973ec8a7-bbbe-4560-b0f1-659948bbbb9b
+      - 26505e95-67fe-46a6-a495-878abb3a9c4d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-database-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-database-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:01 GMT
+      - Mon, 18 Dec 2023 14:13:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0101083-b1d8-45c2-90f2-2f697fc50888
+      - 93ac5e39-efdc-42cf-922c-2a36d7bc128f
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:53 GMT
+      - Mon, 18 Dec 2023 14:13:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10c75e53-b6a9-4220-b67d-953ced6a0fe7
+      - 56a32080-94e1-409b-b45b-25106b684cba
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:54 GMT
+      - Mon, 18 Dec 2023 14:13:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0806a2e1-355b-4cb9-862f-de3a4add473b
+      - 0cd73a15-d4c7-4193-8ceb-75c01a3bab14
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:24 GMT
+      - Mon, 18 Dec 2023 14:14:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09ed21d9-8a2b-4b87-b1cf-3b69c07041bb
+      - 2606982d-acaa-437e-8ee6-77bb00121e3b
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:55 GMT
+      - Mon, 18 Dec 2023 14:14:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 001d0e3a-daef-4fd5-acd2-77fbbb114174
+      - 3a2430e6-b3e6-419e-a41b-a38359ffb390
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:25 GMT
+      - Mon, 18 Dec 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb4ca5d8-db90-4991-b138-d4a28c63c87f
+      - 8fad8a24-ebfc-4253-afd0-d9248c0755de
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:55 GMT
+      - Mon, 18 Dec 2023 14:15:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 859e8ef7-cc72-4d97-bd55-db05359d917f
+      - 45602f18-be41-4ea0-9143-9ca1cfe2235a
     status: 200 OK
     code: 200
     duration: ""
@@ -539,76 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "896"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1d5d8c74-d501-455a-8fbc-8107337ba399
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "896"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 62c26b75-39c1-453f-9c54-0a1f0bfc3843
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1160"
@@ -617,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:25 GMT
+      - Mon, 18 Dec 2023 14:16:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8745a96-e65d-47ad-8afa-b02210a39ae3
+      - 3dfdfe92-ed15-4275-8d70-0c26744b9d8c
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:56 GMT
+      - Mon, 18 Dec 2023 14:16:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40f48e86-0ecc-4ea0-8056-d4237d0f7173
+      - a96b39b7-a73a-4d45-944e-d805c4dd17cd
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:56 GMT
+      - Mon, 18 Dec 2023 14:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7bbc7ab-b46f-4a19-8134-a98aae0914b1
+      - f8998a8c-ff10-4744-bf2f-24962614af55
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:56 GMT
+      - Mon, 18 Dec 2023 14:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58e841d9-32cf-459c-aa14-24edab742025
+      - f2d6b641-76ba-46e3-a292-9084c3b59e3f
     status: 200 OK
     code: 200
     duration: ""
@@ -739,10 +673,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVSXM1MXhhdC9jTHpGMlRPdlM1OC9raysySHlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXdNakphRncwek16RXlNVFV4TXpFd01qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRHM5Mk9qa2xPT1VvdHYrU0gwbytOZ3lkdDZpL0Znb3lMS3NPYXhxTytualVZYXc5T0kKTVBpbDJVNkg5aHlwSFNDdjFUTGErNmhxZUpTZk9wbEdKSkpPZENPbmNUUklldWl6WkhTZEhzWDVDR3EwUys1YwpReEgwSjNmaWY4V0k1a0IxM0Y4REFxMG82V2h2VkRkR1hKdFpBTituVmw4eXBZWG5YZnpXQWs1RlhhQURBakt0CnpsUlRITGJxWUN2NnVQcWtjVDRzcEpsUnIvdDNtbEpJNzJOMUd4S01lUWRrT0JUUzNmKzhHYVBVanNBamYwdkMKdk96VlRxMnhHTHgrYXFaNjJmcnZHVnR3dkZMVmxUbmxrQzVWM3U5ZzFKZHpNSDlaNTluRWQ5MnVrMi8xYWFMNgpqWnNYVUg1SDR0VFIxV0tEaHQ3TFpzSFdka1pBTlQwUXpUK2JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbU1Ua3dOV0ZqWVMwd05HTXdMVFE0TUdJdFlXSTMKWmkwMk1qTmtNMkUyTURFMU5qUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaakU1TURWaFkyRXRNRFJqTUMwME9EQmlMV0ZpTjJZdE5qSXpaRE5oTmpBeE5UWTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubUdaaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE1NVllZ3ltVXR3Q3RZNGRMcnlydlVvV2ovRVlwUHM4NVRKRHdjWXYrWVRrWlIxdHM5Q2RBYQppV2o0NGRyNVFEUmFEd3IxS1M1MTFBRG5mWis0cmg1LzhhN3FXSTR3eW8xTFdHY0JQTWR1N3BoUVBKSnpxbzVTCkI3aXY3dnE3aTNveUhsdVBWNDFDbjBzYldCemxIaUIwZi9EdjVBQ3lXakxSbHdnM3EzcGZPYU1jcnJJUUJsTSsKSzE0NDQ1OXYwKytEZkw0cTJmZWVaN1NYRVV5cnIxdEExQ2k5WVJOOW16M25MekZzcGpmMG9XZnFpVE1Ea2RDQwpQVlgxZmR4R2ErNVJ6QnpQZWdJcUdIL3FtRHd5K0IxSHBtZVM4UlRGQWljend5Tm9KWGoxcDVtSmVzelJaYjJ1Cmp0R1FXR2UyamhDUmVUeWZkREMzZlRZOTdiWS9FWmtNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6b1586a0-0069-4aa4-b24c-7d2a0ae78464
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZUY0NTErTXhMTXZzTnBzNGRHUHNhTmc3RXdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqRTBPVEFlCkZ3MHlNekV5TVRneE5ERTJNakphRncwek16RXlNVFV4TkRFMk1qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eE5Ea3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2dSTFl0ckdHYmdKTHdlY3h4RzJpMHBZR21xaXdCc0xFNTNMTm1wNVNydllpbU55VjUKNnBNR1hOaUxSWWVFaldyNWk3dEhDRkJJUkZYdnlHMDBFU0hEME1zZ05qMjJkb2wwSjBGSUpmR21LRUdKTk9OMgpSMlN4RGVtT0RPOUxMdVl5clI2QXVnbHNIRHZrNHBtOG9WYkx3UnhvaWFjWVVDak0zOU43cGZDSEhPRmR5eFBVCkpDUUt4T3oxTUpHNjZLK3FmV1pLY3FaaUV3dEhURG14eHNEVDNjOC91ZW5WeENGblVXOXNyN0JEVnFTaGdJUk4KU3NUTHVnRzR1Z3dzOUsybEdWaGJramJPY1g0MXZ4RWpWQVhNMm9YZ0dtU2pBdDdxY2RLU1VhZ2Q0WUthU2huRQppMjVxOWtkNjJTZm9lb2VnZ3p3bnBES0N6TGJPbmhqbzQ2SUpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1UUTVnanh5ZHkwMllUZzRZak13TWkwM016ZGlMVFEzTURJdFlURmgKT1Mxa01qazBaREExTWpNNU9UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakUwT1lJOGNuY3RObUU0T0dJek1ESXROek0zWWkwME56QXlMV0V4WVRrdFpESTVOR1F3TlRJek9Ua3pMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpua2NvaHdURG1zV1Zod1REbXNXVk1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXREpEUVlJdWJTclowVURaNUpjOFozaDBHUHg3Sm8yQytINkk3ZFVYMC9XbHNqL0JJenpxTQpWWkxHYmZQTGhLb2piRjhqZVRiTDA1T3dxTFlFaHBpRlJBNFFjb3dITi83bHFGekxLdnZxWW01NFM1T3d2THlBCnRMSXVGWkZ3ZStNaDV0VzJHa1V5MjFIZTRFVitPS2E3dmpURitxeTBIK3lhek03QWtlbTRMZEhYUUZJTXQrK1MKblRIMXIzWXhaMlNqUnM2QVcvUldXcWJIcW80Q3RUMWVrcmg4YmYyckQ2Z2lsSUxFNnJoaVduVUMvLzR3aGdRQwo5VmJBTlpjaWpHM0orcEhLSlova3pqNTZ5UTk4V25SakNvejIxcnFINVQ0dVBvSGlqRCs3blB6VDhVTkhBK0NpClZWL0ZNWDlreFlMSUlOL0hKUnNGM0hmOC9RclVUV3FNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2015"
@@ -751,7 +718,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7673d42-7909-455f-b95a-a9cc1b53950e
+      - cbb39298-e088-4e90-ab52-7a145908690a
     status: 200 OK
     code: 200
     duration: ""
@@ -772,7 +739,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f1905aca-04c0-480b-ab7f-623d3a601564&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=6a88b302-737b-4702-a1a9-d294d0523993&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -784,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a68c95db-62c6-40cb-904b-cc75fcf4df4c
+      - 43826fbc-ecf4-4bf0-96ed-9a9c8d7cc3ac
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bdf6010-89ea-44e1-a27d-800c90deded3
+      - 86972962-d62a-4f4c-b712-b1fe377006d9
     status: 200 OK
     code: 200
     duration: ""
@@ -840,7 +807,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases
     method: POST
   response:
     body: '{"managed":true,"name":"test-terraform","owner":"","size":0}'
@@ -852,7 +819,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:57 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00f6d475-3d4b-4c2f-aee3-8aae4f37ffce
+      - 43f5e4c7-a986-4f02-a287-c20705a2aaa5
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:58 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d6b17f3-e6aa-4b12-8f24-2db91f20a7c3
+      - 0b3456f2-39d2-429e-aa20-3fb1d5fa84f3
     status: 200 OK
     code: 200
     duration: ""
@@ -906,10 +873,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -918,7 +885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:58 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0b83b67-bd19-431f-9b34-8dafc03379db
+      - ff1776cf-573b-4c44-ab8f-f2e8c78400e8
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:58 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fee1644-193e-48a0-8643-5e32bc571eb9
+      - e1763275-ca5f-49ae-ab80-b76b903d4caf
     status: 200 OK
     code: 200
     duration: ""
@@ -972,10 +939,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVSXM1MXhhdC9jTHpGMlRPdlM1OC9raysySHlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXdNakphRncwek16RXlNVFV4TXpFd01qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRHM5Mk9qa2xPT1VvdHYrU0gwbytOZ3lkdDZpL0Znb3lMS3NPYXhxTytualVZYXc5T0kKTVBpbDJVNkg5aHlwSFNDdjFUTGErNmhxZUpTZk9wbEdKSkpPZENPbmNUUklldWl6WkhTZEhzWDVDR3EwUys1YwpReEgwSjNmaWY4V0k1a0IxM0Y4REFxMG82V2h2VkRkR1hKdFpBTituVmw4eXBZWG5YZnpXQWs1RlhhQURBakt0CnpsUlRITGJxWUN2NnVQcWtjVDRzcEpsUnIvdDNtbEpJNzJOMUd4S01lUWRrT0JUUzNmKzhHYVBVanNBamYwdkMKdk96VlRxMnhHTHgrYXFaNjJmcnZHVnR3dkZMVmxUbmxrQzVWM3U5ZzFKZHpNSDlaNTluRWQ5MnVrMi8xYWFMNgpqWnNYVUg1SDR0VFIxV0tEaHQ3TFpzSFdka1pBTlQwUXpUK2JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbU1Ua3dOV0ZqWVMwd05HTXdMVFE0TUdJdFlXSTMKWmkwMk1qTmtNMkUyTURFMU5qUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaakU1TURWaFkyRXRNRFJqTUMwME9EQmlMV0ZpTjJZdE5qSXpaRE5oTmpBeE5UWTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubUdaaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE1NVllZ3ltVXR3Q3RZNGRMcnlydlVvV2ovRVlwUHM4NVRKRHdjWXYrWVRrWlIxdHM5Q2RBYQppV2o0NGRyNVFEUmFEd3IxS1M1MTFBRG5mWis0cmg1LzhhN3FXSTR3eW8xTFdHY0JQTWR1N3BoUVBKSnpxbzVTCkI3aXY3dnE3aTNveUhsdVBWNDFDbjBzYldCemxIaUIwZi9EdjVBQ3lXakxSbHdnM3EzcGZPYU1jcnJJUUJsTSsKSzE0NDQ1OXYwKytEZkw0cTJmZWVaN1NYRVV5cnIxdEExQ2k5WVJOOW16M25MekZzcGpmMG9XZnFpVE1Ea2RDQwpQVlgxZmR4R2ErNVJ6QnpQZWdJcUdIL3FtRHd5K0IxSHBtZVM4UlRGQWljend5Tm9KWGoxcDVtSmVzelJaYjJ1Cmp0R1FXR2UyamhDUmVUeWZkREMzZlRZOTdiWS9FWmtNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8cbd0bf2-cdbe-4730-a0e2-7f5a1c936e63
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZUY0NTErTXhMTXZzTnBzNGRHUHNhTmc3RXdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqRTBPVEFlCkZ3MHlNekV5TVRneE5ERTJNakphRncwek16RXlNVFV4TkRFMk1qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eE5Ea3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2dSTFl0ckdHYmdKTHdlY3h4RzJpMHBZR21xaXdCc0xFNTNMTm1wNVNydllpbU55VjUKNnBNR1hOaUxSWWVFaldyNWk3dEhDRkJJUkZYdnlHMDBFU0hEME1zZ05qMjJkb2wwSjBGSUpmR21LRUdKTk9OMgpSMlN4RGVtT0RPOUxMdVl5clI2QXVnbHNIRHZrNHBtOG9WYkx3UnhvaWFjWVVDak0zOU43cGZDSEhPRmR5eFBVCkpDUUt4T3oxTUpHNjZLK3FmV1pLY3FaaUV3dEhURG14eHNEVDNjOC91ZW5WeENGblVXOXNyN0JEVnFTaGdJUk4KU3NUTHVnRzR1Z3dzOUsybEdWaGJramJPY1g0MXZ4RWpWQVhNMm9YZ0dtU2pBdDdxY2RLU1VhZ2Q0WUthU2huRQppMjVxOWtkNjJTZm9lb2VnZ3p3bnBES0N6TGJPbmhqbzQ2SUpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1UUTVnanh5ZHkwMllUZzRZak13TWkwM016ZGlMVFEzTURJdFlURmgKT1Mxa01qazBaREExTWpNNU9UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakUwT1lJOGNuY3RObUU0T0dJek1ESXROek0zWWkwME56QXlMV0V4WVRrdFpESTVOR1F3TlRJek9Ua3pMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpua2NvaHdURG1zV1Zod1REbXNXVk1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXREpEUVlJdWJTclowVURaNUpjOFozaDBHUHg3Sm8yQytINkk3ZFVYMC9XbHNqL0JJenpxTQpWWkxHYmZQTGhLb2piRjhqZVRiTDA1T3dxTFlFaHBpRlJBNFFjb3dITi83bHFGekxLdnZxWW01NFM1T3d2THlBCnRMSXVGWkZ3ZStNaDV0VzJHa1V5MjFIZTRFVitPS2E3dmpURitxeTBIK3lhek03QWtlbTRMZEhYUUZJTXQrK1MKblRIMXIzWXhaMlNqUnM2QVcvUldXcWJIcW80Q3RUMWVrcmg4YmYyckQ2Z2lsSUxFNnJoaVduVUMvLzR3aGdRQwo5VmJBTlpjaWpHM0orcEhLSlova3pqNTZ5UTk4V25SakNvejIxcnFINVQ0dVBvSGlqRCs3blB6VDhVTkhBK0NpClZWL0ZNWDlreFlMSUlOL0hKUnNGM0hmOC9RclVUV3FNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2015"
@@ -984,7 +984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:58 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c544f51-3391-4bd6-b209-114f409508d5
+      - a5023f7e-3f3e-4a65-8933-a4836f06fb19
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,7 +1005,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f1905aca-04c0-480b-ab7f-623d3a601564&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=6a88b302-737b-4702-a1a9-d294d0523993&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1017,7 +1017,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:59 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e096dfa4-1e0d-4020-a513-6159b017e7b4
+      - febf9d82-3878-4069-8e62-46e0cc850043
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,10 +1038,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1050,7 +1050,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:00 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76071e05-77ea-40b0-a914-e9bcddc2a9c3
+      - 586f761a-f649-4cc7-9fac-e492e5383f63
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:01 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c66fe5f-ec92-4e2f-b636-40753c49a9b3
+      - 5b8b2606-c5c1-42f8-92d4-da1bf01d8e8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,10 +1104,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVSXM1MXhhdC9jTHpGMlRPdlM1OC9raysySHlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXdNakphRncwek16RXlNVFV4TXpFd01qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRHM5Mk9qa2xPT1VvdHYrU0gwbytOZ3lkdDZpL0Znb3lMS3NPYXhxTytualVZYXc5T0kKTVBpbDJVNkg5aHlwSFNDdjFUTGErNmhxZUpTZk9wbEdKSkpPZENPbmNUUklldWl6WkhTZEhzWDVDR3EwUys1YwpReEgwSjNmaWY4V0k1a0IxM0Y4REFxMG82V2h2VkRkR1hKdFpBTituVmw4eXBZWG5YZnpXQWs1RlhhQURBakt0CnpsUlRITGJxWUN2NnVQcWtjVDRzcEpsUnIvdDNtbEpJNzJOMUd4S01lUWRrT0JUUzNmKzhHYVBVanNBamYwdkMKdk96VlRxMnhHTHgrYXFaNjJmcnZHVnR3dkZMVmxUbmxrQzVWM3U5ZzFKZHpNSDlaNTluRWQ5MnVrMi8xYWFMNgpqWnNYVUg1SDR0VFIxV0tEaHQ3TFpzSFdka1pBTlQwUXpUK2JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbU1Ua3dOV0ZqWVMwd05HTXdMVFE0TUdJdFlXSTMKWmkwMk1qTmtNMkUyTURFMU5qUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaakU1TURWaFkyRXRNRFJqTUMwME9EQmlMV0ZpTjJZdE5qSXpaRE5oTmpBeE5UWTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubUdaaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE1NVllZ3ltVXR3Q3RZNGRMcnlydlVvV2ovRVlwUHM4NVRKRHdjWXYrWVRrWlIxdHM5Q2RBYQppV2o0NGRyNVFEUmFEd3IxS1M1MTFBRG5mWis0cmg1LzhhN3FXSTR3eW8xTFdHY0JQTWR1N3BoUVBKSnpxbzVTCkI3aXY3dnE3aTNveUhsdVBWNDFDbjBzYldCemxIaUIwZi9EdjVBQ3lXakxSbHdnM3EzcGZPYU1jcnJJUUJsTSsKSzE0NDQ1OXYwKytEZkw0cTJmZWVaN1NYRVV5cnIxdEExQ2k5WVJOOW16M25MekZzcGpmMG9XZnFpVE1Ea2RDQwpQVlgxZmR4R2ErNVJ6QnpQZWdJcUdIL3FtRHd5K0IxSHBtZVM4UlRGQWljend5Tm9KWGoxcDVtSmVzelJaYjJ1Cmp0R1FXR2UyamhDUmVUeWZkREMzZlRZOTdiWS9FWmtNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f392cc27-d7e8-42c5-a37a-0d03e92a974a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZUY0NTErTXhMTXZzTnBzNGRHUHNhTmc3RXdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqRTBPVEFlCkZ3MHlNekV5TVRneE5ERTJNakphRncwek16RXlNVFV4TkRFMk1qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eE5Ea3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2dSTFl0ckdHYmdKTHdlY3h4RzJpMHBZR21xaXdCc0xFNTNMTm1wNVNydllpbU55VjUKNnBNR1hOaUxSWWVFaldyNWk3dEhDRkJJUkZYdnlHMDBFU0hEME1zZ05qMjJkb2wwSjBGSUpmR21LRUdKTk9OMgpSMlN4RGVtT0RPOUxMdVl5clI2QXVnbHNIRHZrNHBtOG9WYkx3UnhvaWFjWVVDak0zOU43cGZDSEhPRmR5eFBVCkpDUUt4T3oxTUpHNjZLK3FmV1pLY3FaaUV3dEhURG14eHNEVDNjOC91ZW5WeENGblVXOXNyN0JEVnFTaGdJUk4KU3NUTHVnRzR1Z3dzOUsybEdWaGJramJPY1g0MXZ4RWpWQVhNMm9YZ0dtU2pBdDdxY2RLU1VhZ2Q0WUthU2huRQppMjVxOWtkNjJTZm9lb2VnZ3p3bnBES0N6TGJPbmhqbzQ2SUpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1UUTVnanh5ZHkwMllUZzRZak13TWkwM016ZGlMVFEzTURJdFlURmgKT1Mxa01qazBaREExTWpNNU9UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakUwT1lJOGNuY3RObUU0T0dJek1ESXROek0zWWkwME56QXlMV0V4WVRrdFpESTVOR1F3TlRJek9Ua3pMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpua2NvaHdURG1zV1Zod1REbXNXVk1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXREpEUVlJdWJTclowVURaNUpjOFozaDBHUHg3Sm8yQytINkk3ZFVYMC9XbHNqL0JJenpxTQpWWkxHYmZQTGhLb2piRjhqZVRiTDA1T3dxTFlFaHBpRlJBNFFjb3dITi83bHFGekxLdnZxWW01NFM1T3d2THlBCnRMSXVGWkZ3ZStNaDV0VzJHa1V5MjFIZTRFVitPS2E3dmpURitxeTBIK3lhek03QWtlbTRMZEhYUUZJTXQrK1MKblRIMXIzWXhaMlNqUnM2QVcvUldXcWJIcW80Q3RUMWVrcmg4YmYyckQ2Z2lsSUxFNnJoaVduVUMvLzR3aGdRQwo5VmJBTlpjaWpHM0orcEhLSlova3pqNTZ5UTk4V25SakNvejIxcnFINVQ0dVBvSGlqRCs3blB6VDhVTkhBK0NpClZWL0ZNWDlreFlMSUlOL0hKUnNGM0hmOC9RclVUV3FNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2015"
@@ -1116,7 +1149,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:01 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5149c097-d67b-4fec-a6da-6f981a5673cf
+      - 3d92970e-3334-4235-87fa-a70d58fb8d81
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,7 +1170,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f1905aca-04c0-480b-ab7f-623d3a601564&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=6a88b302-737b-4702-a1a9-d294d0523993&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1149,7 +1182,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:02 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96b5ae28-2320-4843-b6bb-59c90466a750
+      - 751fae52-5065-4ff3-9212-c3e0eefce4a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,10 +1203,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1182,7 +1215,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:02 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c174715-12ad-4f44-a247-4f469be5a642
+      - be9248fc-2c56-45d8-b3cd-288228d050b6
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,10 +1236,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1215,7 +1248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:02 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8081f91e-7e96-49f4-8718-ec7a2d01c058
+      - 08d3ed45-045a-440b-a7d2-d49eed94e85b
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,10 +1269,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1248,7 +1281,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:02 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d4acaec-83ca-4e3c-9a39-569b456be8ef
+      - 33abe53c-de6f-44db-a81e-e3504ebf6c17
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,10 +1302,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1281,7 +1314,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:03 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4e92271-2463-4bd6-9045-1b94fae92f92
+      - c76956af-51f8-46a7-b25d-5007cb9c2158
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,10 +1335,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1314,7 +1347,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:03 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53c4c194-5f62-4747-baf8-6d826ff62111
+      - eb2f8686-af72-4b24-9d8b-dacba7871df3
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:03 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5026d9e4-fc6d-400d-a066-30a401fd7f7c
+      - b65957fa-8766-4fc8-97a9-d78165fcc970
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,10 +1401,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVSXM1MXhhdC9jTHpGMlRPdlM1OC9raysySHlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXdNakphRncwek16RXlNVFV4TXpFd01qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRHM5Mk9qa2xPT1VvdHYrU0gwbytOZ3lkdDZpL0Znb3lMS3NPYXhxTytualVZYXc5T0kKTVBpbDJVNkg5aHlwSFNDdjFUTGErNmhxZUpTZk9wbEdKSkpPZENPbmNUUklldWl6WkhTZEhzWDVDR3EwUys1YwpReEgwSjNmaWY4V0k1a0IxM0Y4REFxMG82V2h2VkRkR1hKdFpBTituVmw4eXBZWG5YZnpXQWs1RlhhQURBakt0CnpsUlRITGJxWUN2NnVQcWtjVDRzcEpsUnIvdDNtbEpJNzJOMUd4S01lUWRrT0JUUzNmKzhHYVBVanNBamYwdkMKdk96VlRxMnhHTHgrYXFaNjJmcnZHVnR3dkZMVmxUbmxrQzVWM3U5ZzFKZHpNSDlaNTluRWQ5MnVrMi8xYWFMNgpqWnNYVUg1SDR0VFIxV0tEaHQ3TFpzSFdka1pBTlQwUXpUK2JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbU1Ua3dOV0ZqWVMwd05HTXdMVFE0TUdJdFlXSTMKWmkwMk1qTmtNMkUyTURFMU5qUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaakU1TURWaFkyRXRNRFJqTUMwME9EQmlMV0ZpTjJZdE5qSXpaRE5oTmpBeE5UWTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubUdaaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE1NVllZ3ltVXR3Q3RZNGRMcnlydlVvV2ovRVlwUHM4NVRKRHdjWXYrWVRrWlIxdHM5Q2RBYQppV2o0NGRyNVFEUmFEd3IxS1M1MTFBRG5mWis0cmg1LzhhN3FXSTR3eW8xTFdHY0JQTWR1N3BoUVBKSnpxbzVTCkI3aXY3dnE3aTNveUhsdVBWNDFDbjBzYldCemxIaUIwZi9EdjVBQ3lXakxSbHdnM3EzcGZPYU1jcnJJUUJsTSsKSzE0NDQ1OXYwKytEZkw0cTJmZWVaN1NYRVV5cnIxdEExQ2k5WVJOOW16M25MekZzcGpmMG9XZnFpVE1Ea2RDQwpQVlgxZmR4R2ErNVJ6QnpQZWdJcUdIL3FtRHd5K0IxSHBtZVM4UlRGQWljend5Tm9KWGoxcDVtSmVzelJaYjJ1Cmp0R1FXR2UyamhDUmVUeWZkREMzZlRZOTdiWS9FWmtNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 293d9081-cdad-43d6-99b5-c9c0c0935bb2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZUY0NTErTXhMTXZzTnBzNGRHUHNhTmc3RXdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqRTBPVEFlCkZ3MHlNekV5TVRneE5ERTJNakphRncwek16RXlNVFV4TkRFMk1qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eE5Ea3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2dSTFl0ckdHYmdKTHdlY3h4RzJpMHBZR21xaXdCc0xFNTNMTm1wNVNydllpbU55VjUKNnBNR1hOaUxSWWVFaldyNWk3dEhDRkJJUkZYdnlHMDBFU0hEME1zZ05qMjJkb2wwSjBGSUpmR21LRUdKTk9OMgpSMlN4RGVtT0RPOUxMdVl5clI2QXVnbHNIRHZrNHBtOG9WYkx3UnhvaWFjWVVDak0zOU43cGZDSEhPRmR5eFBVCkpDUUt4T3oxTUpHNjZLK3FmV1pLY3FaaUV3dEhURG14eHNEVDNjOC91ZW5WeENGblVXOXNyN0JEVnFTaGdJUk4KU3NUTHVnRzR1Z3dzOUsybEdWaGJramJPY1g0MXZ4RWpWQVhNMm9YZ0dtU2pBdDdxY2RLU1VhZ2Q0WUthU2huRQppMjVxOWtkNjJTZm9lb2VnZ3p3bnBES0N6TGJPbmhqbzQ2SUpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1UUTVnanh5ZHkwMllUZzRZak13TWkwM016ZGlMVFEzTURJdFlURmgKT1Mxa01qazBaREExTWpNNU9UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakUwT1lJOGNuY3RObUU0T0dJek1ESXROek0zWWkwME56QXlMV0V4WVRrdFpESTVOR1F3TlRJek9Ua3pMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpua2NvaHdURG1zV1Zod1REbXNXVk1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXREpEUVlJdWJTclowVURaNUpjOFozaDBHUHg3Sm8yQytINkk3ZFVYMC9XbHNqL0JJenpxTQpWWkxHYmZQTGhLb2piRjhqZVRiTDA1T3dxTFlFaHBpRlJBNFFjb3dITi83bHFGekxLdnZxWW01NFM1T3d2THlBCnRMSXVGWkZ3ZStNaDV0VzJHa1V5MjFIZTRFVitPS2E3dmpURitxeTBIK3lhek03QWtlbTRMZEhYUUZJTXQrK1MKblRIMXIzWXhaMlNqUnM2QVcvUldXcWJIcW80Q3RUMWVrcmg4YmYyckQ2Z2lsSUxFNnJoaVduVUMvLzR3aGdRQwo5VmJBTlpjaWpHM0orcEhLSlova3pqNTZ5UTk4V25SakNvejIxcnFINVQ0dVBvSGlqRCs3blB6VDhVTkhBK0NpClZWL0ZNWDlreFlMSUlOL0hKUnNGM0hmOC9RclVUV3FNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2015"
@@ -1380,7 +1446,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:04 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ad8d284-adc1-4d32-94fd-f62f71d851bd
+      - 67c76c9a-b484-4457-8688-548aa360dc6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,7 +1467,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f1905aca-04c0-480b-ab7f-623d3a601564&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=6a88b302-737b-4702-a1a9-d294d0523993&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1413,7 +1479,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:04 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bde7c9f-54a9-4ed2-aad5-ff71a510fa92
+      - 5d9c9ee0-7849-4761-a153-fcbae81e408e
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,10 +1500,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1446,7 +1512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:04 GMT
+      - Mon, 18 Dec 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2c54c8c-beed-41be-9cd1-d593214783fd
+      - e5ae5944-e040-4029-a022-ddb63a56166d
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,10 +1533,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1479,7 +1545,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:04 GMT
+      - Mon, 18 Dec 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ba6f6fe-b7fe-43e7-8a0e-10a0b27a99cf
+      - dd05c85e-835d-42b7-95a5-deaf480ed210
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,10 +1566,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1512,7 +1578,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:04 GMT
+      - Mon, 18 Dec 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a4845c4-0cce-4947-b0fe-f466ec69f551
+      - 90b77e1c-fe35-4c0f-952b-4fd6e6de6dc3
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:05 GMT
+      - Mon, 18 Dec 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65fa92f9-c439-4ade-9b11-3f79b52d6788
+      - 74c5286a-a5cc-403a-bb1e-158d19aa6d67
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,7 +1632,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases/test-terraform
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993/databases/test-terraform
     method: DELETE
   response:
     body: ""
@@ -1576,7 +1642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:05 GMT
+      - Mon, 18 Dec 2023 14:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5baadb2-65bc-4da9-9c08-dfd72e087953
+      - ad082365-2f91-4011-872b-004db189e905
     status: 204 No Content
     code: 204
     duration: ""
@@ -1597,19 +1663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:06 GMT
+      - Mon, 18 Dec 2023 14:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bc56656-82d8-4bad-8f13-6494676e2494
+      - 677b9beb-b771-487b-a257-98dc42395049
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,19 +1696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1207"
+      - "1205"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:06 GMT
+      - Mon, 18 Dec 2023 14:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a39fc81a-ebd1-40ca-a14c-34ad018239f1
+      - efab5f8b-4404-405d-89ed-a36347366de1
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,19 +1729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:07 GMT
+      - Mon, 18 Dec 2023 14:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1685,7 +1751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77a978ac-5cfb-45c4-ab09-6c67e4bada4c
+      - 0fad168c-aeff-4f90-a023-6815ca21d301
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,19 +1762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:44.836046Z","retention":7},"created_at":"2023-12-18T14:13:44.836046Z","endpoint":{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203},"endpoints":[{"id":"f7ef774c-5fa9-4132-9f5f-ea5c1c9cac0c","ip":"195.154.197.149","load_balancer":{},"name":null,"port":3203}],"engine":"PostgreSQL-15","id":"6a88b302-737b-4702-a1a9-d294d0523993","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:07 GMT
+      - Mon, 18 Dec 2023 14:17:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1718,7 +1784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 154a280b-8c36-4131-9780-c5fa19cb2bec
+      - 77e41fa3-c8af-48fd-8b5a-a2e94eb6f3b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,10 +1795,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f1905aca-04c0-480b-ab7f-623d3a601564","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6a88b302-737b-4702-a1a9-d294d0523993","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1741,7 +1807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:37 GMT
+      - Mon, 18 Dec 2023 14:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1751,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f3c2879-8616-48c5-be17-3698794d5237
+      - 1bb23e90-eea8-450c-96aa-c107eee57721
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1762,10 +1828,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/6a88b302-737b-4702-a1a9-d294d0523993
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f1905aca-04c0-480b-ab7f-623d3a601564","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"6a88b302-737b-4702-a1a9-d294d0523993","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1774,7 +1840,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:37 GMT
+      - Mon, 18 Dec 2023 14:17:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1784,7 +1850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d006e0eb-6f41-4146-bc16-1ab7a2923fe1
+      - c407af73-55e8-447e-88de-37471332de42
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-database-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-database-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:00 GMT
+      - Mon, 18 Dec 2023 12:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbcd3fa5-123d-47e0-98e3-76ef044ec037
+      - b0101083-b1d8-45c2-90f2-2f697fc50888
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:02 GMT
+      - Mon, 18 Dec 2023 13:06:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb24820a-5b17-42d1-ae9b-faf044197c09
+      - 10c75e53-b6a9-4220-b67d-953ced6a0fe7
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:03 GMT
+      - Mon, 18 Dec 2023 13:06:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03136bde-aeb7-460d-986e-84ddb93f563e
+      - 0806a2e1-355b-4cb9-862f-de3a4add473b
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:33 GMT
+      - Mon, 18 Dec 2023 13:07:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 453cee04-b0c8-454f-9df5-f9f693733fd6
+      - 09ed21d9-8a2b-4b87-b1cf-3b69c07041bb
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:03 GMT
+      - Mon, 18 Dec 2023 13:07:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67da6da2-2cc1-48c4-8f80-492936b31170
+      - 001d0e3a-daef-4fd5-acd2-77fbbb114174
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:33 GMT
+      - Mon, 18 Dec 2023 13:08:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e82f60e7-ddd9-4aca-92b9-d0a79742b2a5
+      - bb4ca5d8-db90-4991-b138-d4a28c63c87f
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:04 GMT
+      - Mon, 18 Dec 2023 13:08:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1632ecba-5162-4196-a0ac-96f64c4c5318
+      - 859e8ef7-cc72-4d97-bd55-db05359d917f
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "896"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55f380d0-c9e6-427a-aaef-db79926fba28
+      - 1d5d8c74-d501-455a-8fbc-8107337ba399
     status: 200 OK
     code: 200
     duration: ""
@@ -572,10 +572,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "896"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62c26b75-39c1-453f-9c54-0a1f0bfc3843
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1160"
@@ -584,7 +617,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:04 GMT
+      - Mon, 18 Dec 2023 13:10:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6f4a035-7c5f-4750-9488-59a1a4e8f4cf
+      - a8745a96-e65d-47ad-8afa-b02210a39ae3
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec9abd0a-7405-4cec-b140-2c42269ac9e5
+      - 40f48e86-0ecc-4ea0-8056-d4237d0f7173
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98074d8f-5de9-43e2-93a3-29212ac8681a
+      - d7bbc7ab-b46f-4a19-8134-a98aae0914b1
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:10:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0994618f-a02c-4c80-82c2-3f71a6298786
+      - 58e841d9-32cf-459c-aa14-24edab742025
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVSXM1MXhhdC9jTHpGMlRPdlM1OC9raysySHlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXdNakphRncwek16RXlNVFV4TXpFd01qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRHM5Mk9qa2xPT1VvdHYrU0gwbytOZ3lkdDZpL0Znb3lMS3NPYXhxTytualVZYXc5T0kKTVBpbDJVNkg5aHlwSFNDdjFUTGErNmhxZUpTZk9wbEdKSkpPZENPbmNUUklldWl6WkhTZEhzWDVDR3EwUys1YwpReEgwSjNmaWY4V0k1a0IxM0Y4REFxMG82V2h2VkRkR1hKdFpBTituVmw4eXBZWG5YZnpXQWs1RlhhQURBakt0CnpsUlRITGJxWUN2NnVQcWtjVDRzcEpsUnIvdDNtbEpJNzJOMUd4S01lUWRrT0JUUzNmKzhHYVBVanNBamYwdkMKdk96VlRxMnhHTHgrYXFaNjJmcnZHVnR3dkZMVmxUbmxrQzVWM3U5ZzFKZHpNSDlaNTluRWQ5MnVrMi8xYWFMNgpqWnNYVUg1SDR0VFIxV0tEaHQ3TFpzSFdka1pBTlQwUXpUK2JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbU1Ua3dOV0ZqWVMwd05HTXdMVFE0TUdJdFlXSTMKWmkwMk1qTmtNMkUyTURFMU5qUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaakU1TURWaFkyRXRNRFJqTUMwME9EQmlMV0ZpTjJZdE5qSXpaRE5oTmpBeE5UWTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubUdaaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE1NVllZ3ltVXR3Q3RZNGRMcnlydlVvV2ovRVlwUHM4NVRKRHdjWXYrWVRrWlIxdHM5Q2RBYQppV2o0NGRyNVFEUmFEd3IxS1M1MTFBRG5mWis0cmg1LzhhN3FXSTR3eW8xTFdHY0JQTWR1N3BoUVBKSnpxbzVTCkI3aXY3dnE3aTNveUhsdVBWNDFDbjBzYldCemxIaUIwZi9EdjVBQ3lXakxSbHdnM3EzcGZPYU1jcnJJUUJsTSsKSzE0NDQ1OXYwKytEZkw0cTJmZWVaN1NYRVV5cnIxdEExQ2k5WVJOOW16M25MekZzcGpmMG9XZnFpVE1Ea2RDQwpQVlgxZmR4R2ErNVJ6QnpQZWdJcUdIL3FtRHd5K0IxSHBtZVM4UlRGQWljend5Tm9KWGoxcDVtSmVzelJaYjJ1Cmp0R1FXR2UyamhDUmVUeWZkREMzZlRZOTdiWS9FWmtNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57904ae8-4c53-4dcc-a405-1d7cfb266d11
+      - f7673d42-7909-455f-b95a-a9cc1b53950e
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f1905aca-04c0-480b-ab7f-623d3a601564&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVQ2ROS3Jpa1VPRGVwQ3RzbC9ZWGpVdjhDT2dnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1UZzBPRm9YRFRNek1USXhOVEV6TVRnME9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXpGNTZtc1lBWkFZMTlLVnBIdU1Pem4vUkVzRmxRdnBRMitZcnpQVG1pOTBHU2lNU1NzR3EKYU85Vkx4YTV2aEJ4MmdaZlovMm02dWYwN04rOGxTWVVQMzF4RWxxQzRtdmMrdThZclpjbXhlZmxpYlZSRjkxZworZjFaV3VsZkZmbUsvdUJiMzBxV1h1NzluNERLZnZ4cHY0RkpjODU3NFZ0NzE1dGRiQmJ1VEdtdEpFejBQSWc1CjdONnNBeGZkZ25SSDBDS3NuTmdkbjA1ZnNMUGhQTjlHbDh2R2JaWkQxVFJQTUNHbVpqWWJHeVV3TS9yMyttRTUKcVhKZkl1V005YWlTZkdKTWNkSHFDV1RiZFZna25ieXlKVU9CMndpQkJQYVFyaUZYcHUzQ2x4SDFDY1FzNmlTawptRThtY0Flc3hFSFNKZkhhWGJmTHdaY1FHSENEa1dKQnBRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTAxWkRFM01tSmlNUzAzWVdSaExUUTROVEl0T1Roak5pMDUKTW1RellUTmlNR1JrWmpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwMVpERTNNbUppTVMwM1lXUmhMVFE0TlRJdE9UaGpOaTA1TW1RellUTmlNR1JrWmpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMVmtRc0NDcjVHVHNnSVp3VmYrZDc3d0FiSHVpaGp4WEFMbHRBQ3lEU3c1K2pmL29nREx1TmZadGI2WgphaVNOcTVDM0xpSlFWT3g3ZU9xRzhVNmxkNE9ha1REQXBMcE5ic1VUWi9Ea0N0K0VxallzOXJYNmplMDlzb2NJCklOY2oySnFSRDBKVVhxWWkxVG1qcXFPUzUyZi9zaXphNHIwUjloL0tmUTJNK1pVTW1OL1BsdHVKSjVrUUk1aHEKYUJXVVZ2ZVZoMTc1R08xYnVlTVFMQmQrOGZpYnlGNVdKR2IxcUtQbkorSHI2U0NWYXJuOU5RUnZPUm9UbjRoMQo5NzJzUG9RRndodkFNU0prN2RaSFhJaDNwZ2Rnazk1ZmtxNmlmdW1iVUdTdTVhd0NQUERaZml3dmxVTTlJMmx1ClhVazE2ZjBNUEsvZGVhRDdWT0V1V2QrQmU4RT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2011"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd9adbdb-5183-4ca6-a8e3-94f903b6e2da
+      - a68c95db-62c6-40cb-904b-cc75fcf4df4c
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4248919-4b52-4260-9330-a28b5b1967cb
+      - 9bdf6010-89ea-44e1-a27d-800c90deded3
     status: 200 OK
     code: 200
     duration: ""
@@ -807,7 +840,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases
     method: POST
   response:
     body: '{"managed":true,"name":"test-terraform","owner":"","size":0}'
@@ -819,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:06 GMT
+      - Mon, 18 Dec 2023 13:10:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2080c524-1afd-4a1a-aecc-7080725bc6ba
+      - 00f6d475-3d4b-4c2f-aee3-8aae4f37ffce
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:06 GMT
+      - Mon, 18 Dec 2023 13:10:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4687c6c1-4042-4324-b9ca-f38f38cac16e
+      - 7d6b17f3-e6aa-4b12-8f24-2db91f20a7c3
     status: 200 OK
     code: 200
     duration: ""
@@ -873,142 +906,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "113"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7bcf6034-ad66-43e0-8adb-7a0255f18dd0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1205"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 41aff2ca-3ec9-4b3f-ba8c-6b6ae7db3f86
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/users?order_by=name_asc&page=1
-    method: GET
-  response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55e6009b-524f-4e83-9fa7-72fe84cb9c95
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVQ2ROS3Jpa1VPRGVwQ3RzbC9ZWGpVdjhDT2dnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1UZzBPRm9YRFRNek1USXhOVEV6TVRnME9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXpGNTZtc1lBWkFZMTlLVnBIdU1Pem4vUkVzRmxRdnBRMitZcnpQVG1pOTBHU2lNU1NzR3EKYU85Vkx4YTV2aEJ4MmdaZlovMm02dWYwN04rOGxTWVVQMzF4RWxxQzRtdmMrdThZclpjbXhlZmxpYlZSRjkxZworZjFaV3VsZkZmbUsvdUJiMzBxV1h1NzluNERLZnZ4cHY0RkpjODU3NFZ0NzE1dGRiQmJ1VEdtdEpFejBQSWc1CjdONnNBeGZkZ25SSDBDS3NuTmdkbjA1ZnNMUGhQTjlHbDh2R2JaWkQxVFJQTUNHbVpqWWJHeVV3TS9yMyttRTUKcVhKZkl1V005YWlTZkdKTWNkSHFDV1RiZFZna25ieXlKVU9CMndpQkJQYVFyaUZYcHUzQ2x4SDFDY1FzNmlTawptRThtY0Flc3hFSFNKZkhhWGJmTHdaY1FHSENEa1dKQnBRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTAxWkRFM01tSmlNUzAzWVdSaExUUTROVEl0T1Roak5pMDUKTW1RellUTmlNR1JrWmpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwMVpERTNNbUppTVMwM1lXUmhMVFE0TlRJdE9UaGpOaTA1TW1RellUTmlNR1JrWmpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMVmtRc0NDcjVHVHNnSVp3VmYrZDc3d0FiSHVpaGp4WEFMbHRBQ3lEU3c1K2pmL29nREx1TmZadGI2WgphaVNOcTVDM0xpSlFWT3g3ZU9xRzhVNmxkNE9ha1REQXBMcE5ic1VUWi9Ea0N0K0VxallzOXJYNmplMDlzb2NJCklOY2oySnFSRDBKVVhxWWkxVG1qcXFPUzUyZi9zaXphNHIwUjloL0tmUTJNK1pVTW1OL1BsdHVKSjVrUUk1aHEKYUJXVVZ2ZVZoMTc1R08xYnVlTVFMQmQrOGZpYnlGNVdKR2IxcUtQbkorSHI2U0NWYXJuOU5RUnZPUm9UbjRoMQo5NzJzUG9RRndodkFNU0prN2RaSFhJaDNwZ2Rnazk1ZmtxNmlmdW1iVUdTdTVhd0NQUERaZml3dmxVTTlJMmx1ClhVazE2ZjBNUEsvZGVhRDdWT0V1V2QrQmU4RT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2011"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f28d6462-c4ae-4fb1-918c-82083ae107cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1017,7 +918,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:10:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39da3151-e84b-4998-a7eb-2892498f43d2
+      - a0b83b67-bd19-431f-9b34-8dafc03379db
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:10:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1af24b2-95b9-4aca-80fa-685836032bab
+      - 0fee1644-193e-48a0-8643-5e32bc571eb9
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVSXM1MXhhdC9jTHpGMlRPdlM1OC9raysySHlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXdNakphRncwek16RXlNVFV4TXpFd01qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRHM5Mk9qa2xPT1VvdHYrU0gwbytOZ3lkdDZpL0Znb3lMS3NPYXhxTytualVZYXc5T0kKTVBpbDJVNkg5aHlwSFNDdjFUTGErNmhxZUpTZk9wbEdKSkpPZENPbmNUUklldWl6WkhTZEhzWDVDR3EwUys1YwpReEgwSjNmaWY4V0k1a0IxM0Y4REFxMG82V2h2VkRkR1hKdFpBTituVmw4eXBZWG5YZnpXQWs1RlhhQURBakt0CnpsUlRITGJxWUN2NnVQcWtjVDRzcEpsUnIvdDNtbEpJNzJOMUd4S01lUWRrT0JUUzNmKzhHYVBVanNBamYwdkMKdk96VlRxMnhHTHgrYXFaNjJmcnZHVnR3dkZMVmxUbmxrQzVWM3U5ZzFKZHpNSDlaNTluRWQ5MnVrMi8xYWFMNgpqWnNYVUg1SDR0VFIxV0tEaHQ3TFpzSFdka1pBTlQwUXpUK2JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbU1Ua3dOV0ZqWVMwd05HTXdMVFE0TUdJdFlXSTMKWmkwMk1qTmtNMkUyTURFMU5qUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaakU1TURWaFkyRXRNRFJqTUMwME9EQmlMV0ZpTjJZdE5qSXpaRE5oTmpBeE5UWTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubUdaaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE1NVllZ3ltVXR3Q3RZNGRMcnlydlVvV2ovRVlwUHM4NVRKRHdjWXYrWVRrWlIxdHM5Q2RBYQppV2o0NGRyNVFEUmFEd3IxS1M1MTFBRG5mWis0cmg1LzhhN3FXSTR3eW8xTFdHY0JQTWR1N3BoUVBKSnpxbzVTCkI3aXY3dnE3aTNveUhsdVBWNDFDbjBzYldCemxIaUIwZi9EdjVBQ3lXakxSbHdnM3EzcGZPYU1jcnJJUUJsTSsKSzE0NDQ1OXYwKytEZkw0cTJmZWVaN1NYRVV5cnIxdEExQ2k5WVJOOW16M25MekZzcGpmMG9XZnFpVE1Ea2RDQwpQVlgxZmR4R2ErNVJ6QnpQZWdJcUdIL3FtRHd5K0IxSHBtZVM4UlRGQWljend5Tm9KWGoxcDVtSmVzelJaYjJ1Cmp0R1FXR2UyamhDUmVUeWZkREMzZlRZOTdiWS9FWmtNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:10:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2fee179-886e-426e-84bd-01565683749f
+      - 6c544f51-3391-4bd6-b209-114f409508d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f1905aca-04c0-480b-ab7f-623d3a601564&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVQ2ROS3Jpa1VPRGVwQ3RzbC9ZWGpVdjhDT2dnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1UZzBPRm9YRFRNek1USXhOVEV6TVRnME9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXpGNTZtc1lBWkFZMTlLVnBIdU1Pem4vUkVzRmxRdnBRMitZcnpQVG1pOTBHU2lNU1NzR3EKYU85Vkx4YTV2aEJ4MmdaZlovMm02dWYwN04rOGxTWVVQMzF4RWxxQzRtdmMrdThZclpjbXhlZmxpYlZSRjkxZworZjFaV3VsZkZmbUsvdUJiMzBxV1h1NzluNERLZnZ4cHY0RkpjODU3NFZ0NzE1dGRiQmJ1VEdtdEpFejBQSWc1CjdONnNBeGZkZ25SSDBDS3NuTmdkbjA1ZnNMUGhQTjlHbDh2R2JaWkQxVFJQTUNHbVpqWWJHeVV3TS9yMyttRTUKcVhKZkl1V005YWlTZkdKTWNkSHFDV1RiZFZna25ieXlKVU9CMndpQkJQYVFyaUZYcHUzQ2x4SDFDY1FzNmlTawptRThtY0Flc3hFSFNKZkhhWGJmTHdaY1FHSENEa1dKQnBRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTAxWkRFM01tSmlNUzAzWVdSaExUUTROVEl0T1Roak5pMDUKTW1RellUTmlNR1JrWmpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwMVpERTNNbUppTVMwM1lXUmhMVFE0TlRJdE9UaGpOaTA1TW1RellUTmlNR1JrWmpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMVmtRc0NDcjVHVHNnSVp3VmYrZDc3d0FiSHVpaGp4WEFMbHRBQ3lEU3c1K2pmL29nREx1TmZadGI2WgphaVNOcTVDM0xpSlFWT3g3ZU9xRzhVNmxkNE9ha1REQXBMcE5ic1VUWi9Ea0N0K0VxallzOXJYNmplMDlzb2NJCklOY2oySnFSRDBKVVhxWWkxVG1qcXFPUzUyZi9zaXphNHIwUjloL0tmUTJNK1pVTW1OL1BsdHVKSjVrUUk1aHEKYUJXVVZ2ZVZoMTc1R08xYnVlTVFMQmQrOGZpYnlGNVdKR2IxcUtQbkorSHI2U0NWYXJuOU5RUnZPUm9UbjRoMQo5NzJzUG9RRndodkFNU0prN2RaSFhJaDNwZ2Rnazk1ZmtxNmlmdW1iVUdTdTVhd0NQUERaZml3dmxVTTlJMmx1ClhVazE2ZjBNUEsvZGVhRDdWT0V1V2QrQmU4RT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2011"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:10:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdf5735b-f841-47da-86cc-4890fac52809
+      - e096dfa4-1e0d-4020-a513-6159b017e7b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,43 +1038,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "113"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1616eb4d-78d6-4dae-9ee3-ba3e09d4bc0e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1182,7 +1050,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:11:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0c49636-0400-418b-919e-7f145fac1b5d
+      - 76071e05-77ea-40b0-a914-e9bcddc2a9c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,10 +1071,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1207"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4c66fe5f-ec92-4e2f-b636-40753c49a9b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVSXM1MXhhdC9jTHpGMlRPdlM1OC9raysySHlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXdNakphRncwek16RXlNVFV4TXpFd01qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRHM5Mk9qa2xPT1VvdHYrU0gwbytOZ3lkdDZpL0Znb3lMS3NPYXhxTytualVZYXc5T0kKTVBpbDJVNkg5aHlwSFNDdjFUTGErNmhxZUpTZk9wbEdKSkpPZENPbmNUUklldWl6WkhTZEhzWDVDR3EwUys1YwpReEgwSjNmaWY4V0k1a0IxM0Y4REFxMG82V2h2VkRkR1hKdFpBTituVmw4eXBZWG5YZnpXQWs1RlhhQURBakt0CnpsUlRITGJxWUN2NnVQcWtjVDRzcEpsUnIvdDNtbEpJNzJOMUd4S01lUWRrT0JUUzNmKzhHYVBVanNBamYwdkMKdk96VlRxMnhHTHgrYXFaNjJmcnZHVnR3dkZMVmxUbmxrQzVWM3U5ZzFKZHpNSDlaNTluRWQ5MnVrMi8xYWFMNgpqWnNYVUg1SDR0VFIxV0tEaHQ3TFpzSFdka1pBTlQwUXpUK2JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbU1Ua3dOV0ZqWVMwd05HTXdMVFE0TUdJdFlXSTMKWmkwMk1qTmtNMkUyTURFMU5qUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaakU1TURWaFkyRXRNRFJqTUMwME9EQmlMV0ZpTjJZdE5qSXpaRE5oTmpBeE5UWTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubUdaaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE1NVllZ3ltVXR3Q3RZNGRMcnlydlVvV2ovRVlwUHM4NVRKRHdjWXYrWVRrWlIxdHM5Q2RBYQppV2o0NGRyNVFEUmFEd3IxS1M1MTFBRG5mWis0cmg1LzhhN3FXSTR3eW8xTFdHY0JQTWR1N3BoUVBKSnpxbzVTCkI3aXY3dnE3aTNveUhsdVBWNDFDbjBzYldCemxIaUIwZi9EdjVBQ3lXakxSbHdnM3EzcGZPYU1jcnJJUUJsTSsKSzE0NDQ1OXYwKytEZkw0cTJmZWVaN1NYRVV5cnIxdEExQ2k5WVJOOW16M25MekZzcGpmMG9XZnFpVE1Ea2RDQwpQVlgxZmR4R2ErNVJ6QnpQZWdJcUdIL3FtRHd5K0IxSHBtZVM4UlRGQWljend5Tm9KWGoxcDVtSmVzelJaYjJ1Cmp0R1FXR2UyamhDUmVUeWZkREMzZlRZOTdiWS9FWmtNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2015"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5149c097-d67b-4fec-a6da-6f981a5673cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f1905aca-04c0-480b-ab7f-623d3a601564&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:02 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 96b5ae28-2320-4843-b6bb-59c90466a750
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1215,7 +1182,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:11:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9bb1d46-13e0-4ae1-9ca4-ae89d49be3a7
+      - 8c174715-12ad-4f44-a247-4f469be5a642
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,10 +1203,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1248,7 +1215,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:11:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a65884f4-000f-4f12-87aa-60a066a23cd4
+      - 8081f91e-7e96-49f4-8718-ec7a2d01c058
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,10 +1236,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1281,7 +1248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:11:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a50be80-3ace-4a85-a0cb-e6370a08ec4a
+      - 9d4acaec-83ca-4e3c-9a39-569b456be8ef
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,109 +1269,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1205"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71a6b898-4209-4d45-bfe9-3b38800814d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/users?order_by=name_asc&page=1
-    method: GET
-  response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 349f7c6a-0531-4d98-a8b2-7224e0569320
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVQ2ROS3Jpa1VPRGVwQ3RzbC9ZWGpVdjhDT2dnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1UZzBPRm9YRFRNek1USXhOVEV6TVRnME9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXpGNTZtc1lBWkFZMTlLVnBIdU1Pem4vUkVzRmxRdnBRMitZcnpQVG1pOTBHU2lNU1NzR3EKYU85Vkx4YTV2aEJ4MmdaZlovMm02dWYwN04rOGxTWVVQMzF4RWxxQzRtdmMrdThZclpjbXhlZmxpYlZSRjkxZworZjFaV3VsZkZmbUsvdUJiMzBxV1h1NzluNERLZnZ4cHY0RkpjODU3NFZ0NzE1dGRiQmJ1VEdtdEpFejBQSWc1CjdONnNBeGZkZ25SSDBDS3NuTmdkbjA1ZnNMUGhQTjlHbDh2R2JaWkQxVFJQTUNHbVpqWWJHeVV3TS9yMyttRTUKcVhKZkl1V005YWlTZkdKTWNkSHFDV1RiZFZna25ieXlKVU9CMndpQkJQYVFyaUZYcHUzQ2x4SDFDY1FzNmlTawptRThtY0Flc3hFSFNKZkhhWGJmTHdaY1FHSENEa1dKQnBRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTAxWkRFM01tSmlNUzAzWVdSaExUUTROVEl0T1Roak5pMDUKTW1RellUTmlNR1JrWmpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwMVpERTNNbUppTVMwM1lXUmhMVFE0TlRJdE9UaGpOaTA1TW1RellUTmlNR1JrWmpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMVmtRc0NDcjVHVHNnSVp3VmYrZDc3d0FiSHVpaGp4WEFMbHRBQ3lEU3c1K2pmL29nREx1TmZadGI2WgphaVNOcTVDM0xpSlFWT3g3ZU9xRzhVNmxkNE9ha1REQXBMcE5ic1VUWi9Ea0N0K0VxallzOXJYNmplMDlzb2NJCklOY2oySnFSRDBKVVhxWWkxVG1qcXFPUzUyZi9zaXphNHIwUjloL0tmUTJNK1pVTW1OL1BsdHVKSjVrUUk1aHEKYUJXVVZ2ZVZoMTc1R08xYnVlTVFMQmQrOGZpYnlGNVdKR2IxcUtQbkorSHI2U0NWYXJuOU5RUnZPUm9UbjRoMQo5NzJzUG9RRndodkFNU0prN2RaSFhJaDNwZ2Rnazk1ZmtxNmlmdW1iVUdTdTVhd0NQUERaZml3dmxVTTlJMmx1ClhVazE2ZjBNUEsvZGVhRDdWT0V1V2QrQmU4RT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2011"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 722059d2-f642-40cf-841b-bef7ee1b66c7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1413,7 +1281,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:11:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dcf9072-b2c6-4c34-8151-9bb3fa3f7d18
+      - c4e92271-2463-4bd6-9045-1b94fae92f92
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,10 +1302,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1446,7 +1314,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:11:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9221e46-21ff-4dab-a8ba-b1a4a7ee8ec9
+      - 53c4c194-5f62-4747-baf8-6d826ff62111
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,10 +1335,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases?name=test-terraform&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1207"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:03 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5026d9e4-fc6d-400d-a066-30a401fd7f7c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVSXM1MXhhdC9jTHpGMlRPdlM1OC9raysySHlBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXdNakphRncwek16RXlNVFV4TXpFd01qSmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRHM5Mk9qa2xPT1VvdHYrU0gwbytOZ3lkdDZpL0Znb3lMS3NPYXhxTytualVZYXc5T0kKTVBpbDJVNkg5aHlwSFNDdjFUTGErNmhxZUpTZk9wbEdKSkpPZENPbmNUUklldWl6WkhTZEhzWDVDR3EwUys1YwpReEgwSjNmaWY4V0k1a0IxM0Y4REFxMG82V2h2VkRkR1hKdFpBTituVmw4eXBZWG5YZnpXQWs1RlhhQURBakt0CnpsUlRITGJxWUN2NnVQcWtjVDRzcEpsUnIvdDNtbEpJNzJOMUd4S01lUWRrT0JUUzNmKzhHYVBVanNBamYwdkMKdk96VlRxMnhHTHgrYXFaNjJmcnZHVnR3dkZMVmxUbmxrQzVWM3U5ZzFKZHpNSDlaNTluRWQ5MnVrMi8xYWFMNgpqWnNYVUg1SDR0VFIxV0tEaHQ3TFpzSFdka1pBTlQwUXpUK2JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbU1Ua3dOV0ZqWVMwd05HTXdMVFE0TUdJdFlXSTMKWmkwMk1qTmtNMkUyTURFMU5qUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaakU1TURWaFkyRXRNRFJqTUMwME9EQmlMV0ZpTjJZdE5qSXpaRE5oTmpBeE5UWTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubUdaaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUE1NVllZ3ltVXR3Q3RZNGRMcnlydlVvV2ovRVlwUHM4NVRKRHdjWXYrWVRrWlIxdHM5Q2RBYQppV2o0NGRyNVFEUmFEd3IxS1M1MTFBRG5mWis0cmg1LzhhN3FXSTR3eW8xTFdHY0JQTWR1N3BoUVBKSnpxbzVTCkI3aXY3dnE3aTNveUhsdVBWNDFDbjBzYldCemxIaUIwZi9EdjVBQ3lXakxSbHdnM3EzcGZPYU1jcnJJUUJsTSsKSzE0NDQ1OXYwKytEZkw0cTJmZWVaN1NYRVV5cnIxdEExQ2k5WVJOOW16M25MekZzcGpmMG9XZnFpVE1Ea2RDQwpQVlgxZmR4R2ErNVJ6QnpQZWdJcUdIL3FtRHd5K0IxSHBtZVM4UlRGQWljend5Tm9KWGoxcDVtSmVzelJaYjJ1Cmp0R1FXR2UyamhDUmVUeWZkREMzZlRZOTdiWS9FWmtNCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2015"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ad8d284-adc1-4d32-94fd-f62f71d851bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f1905aca-04c0-480b-ab7f-623d3a601564&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5bde7c9f-54a9-4ed2-aad5-ff71a510fa92
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "113"
@@ -1479,7 +1446,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:10 GMT
+      - Mon, 18 Dec 2023 13:11:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bbf986a-a37e-40b6-ac1b-6540d158a04e
+      - f2c54c8c-beed-41be-9cd1-d593214783fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "1205"
+      - "113"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:11 GMT
+      - Mon, 18 Dec 2023 13:11:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 000142d9-4c03-475a-bb19-91460bbbd85b
+      - 2ba6f6fe-b7fe-43e7-8a0e-10a0b27a99cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,7 +1500,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6/databases/test-terraform
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases?name=test-terraform&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"test-terraform","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "113"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a4845c4-0cce-4947-b0fe-f466ec69f551
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1207"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 65fa92f9-c439-4ade-9b11-3f79b52d6788
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564/databases/test-terraform
     method: DELETE
   response:
     body: ""
@@ -1543,7 +1576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:11 GMT
+      - Mon, 18 Dec 2023 13:11:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06092858-3c8b-47dd-8eb6-b84cc63597f9
+      - b5baadb2-65bc-4da9-9c08-dfd72e087953
     status: 204 No Content
     code: 204
     duration: ""
@@ -1564,19 +1597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:11 GMT
+      - Mon, 18 Dec 2023 13:11:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 645600fc-c775-4daa-a6d6-d022d8314da6
+      - 0bc56656-82d8-4bad-8f13-6494676e2494
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,19 +1630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1205"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:12 GMT
+      - Mon, 18 Dec 2023 13:11:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f0ec141-07bc-4ca3-a2d6-900c7388a5da
+      - a39fc81a-ebd1-40ca-a14c-34ad018239f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,19 +1663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1208"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:12 GMT
+      - Mon, 18 Dec 2023 13:11:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1b885bb-dac2-42de-9df9-dbd94c548881
+      - 77a978ac-5cfb-45c4-ab09-6c67e4bada4c
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,19 +1696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.714044Z","retention":7},"created_at":"2023-12-18T13:16:02.714044Z","endpoint":{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594},"endpoints":[{"id":"f29a2807-5355-4a7f-be29-668d55b8bbe8","ip":"195.154.68.173","load_balancer":{},"name":null,"port":21594}],"engine":"PostgreSQL-15","id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:52.911951Z","retention":7},"created_at":"2023-12-18T13:06:52.911951Z","endpoint":{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842},"endpoints":[{"id":"c1616d2d-f65b-414c-a722-cf70bf485256","ip":"195.154.197.252","load_balancer":{},"name":null,"port":19842}],"engine":"PostgreSQL-15","id":"f1905aca-04c0-480b-ab7f-623d3a601564","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1208"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:12 GMT
+      - Mon, 18 Dec 2023 13:11:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1685,7 +1718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91e3d877-8235-4c15-9bc2-a389ee1611db
+      - 154a280b-8c36-4131-9780-c5fa19cb2bec
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,10 +1729,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"f1905aca-04c0-480b-ab7f-623d3a601564","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1708,7 +1741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1718,7 +1751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c573de5-88fb-436a-99df-5961f8a096ca
+      - 6f3c2879-8616-48c5-be17-3698794d5237
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1729,10 +1762,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5d172bb1-7ada-4852-98c6-92d3a3b0ddf6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f1905aca-04c0-480b-ab7f-623d3a601564
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5d172bb1-7ada-4852-98c6-92d3a3b0ddf6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"f1905aca-04c0-480b-ab7f-623d3a601564","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1741,7 +1774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:11:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1751,7 +1784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4c3f13c-7bef-4aef-872f-b79b5c1e125e
+      - d006e0eb-6f41-4146-bc16-1ab7a2923fe1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-instance-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-instance-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:01 GMT
+      - Mon, 18 Dec 2023 14:11:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e18b592-aecd-4d48-961e-002704196284
+      - 67b5acf0-5195-4f83-9dd3-a62f9f520e4a
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:33 GMT
+      - Mon, 18 Dec 2023 14:11:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9350fa85-20f4-42c1-85ac-a9af3198d94b
+      - 7e80e877-ec3f-4a2c-89f9-cc563e77f831
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:34 GMT
+      - Mon, 18 Dec 2023 14:11:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08ae3f66-2905-4dbc-83c4-d0afcf942abf
+      - 71622b7d-2798-4eab-95c4-9887269ac41b
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:04 GMT
+      - Mon, 18 Dec 2023 14:12:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 048a3151-4aa0-460f-a9c5-9afce45caf99
+      - c95f280f-3a03-44f0-a7b5-724187f34cc8
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:34 GMT
+      - Mon, 18 Dec 2023 14:13:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be94dfb8-afc2-4a58-ab1d-45767b42c36a
+      - 7c82c2ea-dff6-4523-a885-1b35201e8ae3
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:04 GMT
+      - Mon, 18 Dec 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f87316f3-ee3e-46b3-95e5-25e8af9ac370
+      - 41ec3450-5dd7-47f9-b2ab-b392231aa83d
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:34 GMT
+      - Mon, 18 Dec 2023 14:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c368238d-e582-4f3c-bb38-a044283af07b
+      - 3773e4a7-cf57-4989-aa56-0a52ffb455e2
     status: 200 OK
     code: 200
     duration: ""
@@ -539,76 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "905"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d4b4e98-ab9e-4a84-ae65-e1a643260d1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "905"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2efce72c-5dfa-425d-b2e6-ce3114ba9185
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1169"
@@ -617,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:05 GMT
+      - Mon, 18 Dec 2023 14:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9102844-9d68-4e0c-a5be-95b756c55d70
+      - f0f2af4b-aac8-4d37-bbcf-bc1a557b9160
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1e896ee-afb3-484a-b70c-16afc71770d3
+      - 5d2ba774-85d9-445e-afbc-8d0a7caad2cd
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ef95b53-a32a-47c0-aaf7-3233384025ba
+      - 9be7274c-33b2-48fd-8c66-50d06751cf79
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 139acabf-b077-4aad-aefc-9bf22ce01c10
+      - 02408d3c-9662-4cf2-bf9b-7ee1cdc11581
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2007"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2ffe50c-8ede-465b-9f80-74f281817af4
+      - a3428bbb-abb1-4aff-a3c3-f095f6df3389
     status: 200 OK
     code: 200
     duration: ""
@@ -772,7 +706,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d26385ff-9c8e-4a5e-a16c-993d866b6a4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -784,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55a6dca4-d605-4051-8976-dd586403a66a
+      - bd3cc26e-7e83-4d48-9a61-f171bec977e8
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ebb90c3-e7f0-4f9b-8f9e-b9fee4ede22a
+      - 2829c851-ba4a-48cc-a390-2cf5fd3edbc6
     status: 200 OK
     code: 200
     duration: ""
@@ -841,16 +808,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1242"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:35 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3df6cd2-5d0f-4626-85df-3b7fd1b95d13
+      - 1644b05a-a770-4cdf-a4b8-455e2ad3cfae
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2007"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac1e80cc-4a7d-4eae-9567-0dee18b01789
+      - 1fbd5f99-f4b5-4c08-8ec3-1cd8066a66d3
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6480cf3-3c57-4885-aeee-24fecf577157
+      - de01399a-9804-4073-a559-3912b6141ec2
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "26"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba3eadca-2b87-4303-ba23-881e0779df10
+      - 80f0903f-6305-490e-8187-a751c5e8720f
     status: 200 OK
     code: 200
     duration: ""
@@ -970,40 +937,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2007"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0ecc13c7-f83e-4523-8070-1d12326bb646
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1015,7 +949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85fea7e6-02c1-4e1a-a120-f4250f979926
+      - 66e18675-cead-476c-ad96-cf377fd89670
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "1210"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc435571-c09c-4db4-909c-461fb7d0e1c3
+      - 57640f41-0dd2-40c9-910c-758505491eae
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1210"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1025,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 350463cf-5a88-49c9-8058-f5f421e93f72
+      - b6b52031-d85c-4a66-a986-c868f60c037a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 05d80070-6681-4538-a125-2d931d6efb27
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1212"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 29929857-62c1-4204-ba6f-d6698445af48
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1212"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35559401-01e3-4a63-9201-e8e88f2bbf35
     status: 200 OK
     code: 200
     duration: ""
@@ -1105,16 +1138,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1242"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2e13c66-4d8e-48b1-b57d-6122d812dfbc
+      - bff28af4-5f3f-4f19-a0bb-18c619b76939
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2007"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d298d50a-fde6-477b-825f-198c0da062df
+      - 6e62ea2c-630d-4da9-a585-a349d4f66ae0
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 040ec573-e910-48e6-b188-6f4300ad69cf
+      - c24b2067-095b-4b8b-99b1-51f6e165044d
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "26"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 348f83e3-7498-44d9-a4f4-1855ea5f90c0
+      - d2a08f9d-d81b-4f33-a979-a7fc302d70d3
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2007"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:36 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61d1d6a9-e982-453c-9488-6d8160c1c961
+      - 88b081f1-9c3a-4d74-9c7b-7805c2a3094a
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,106 +1300,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "26"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - adf61847-142a-4073-a389-9cdfea9dea8c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1210"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3660a5f0-b6cf-48af-969c-e72b78564337
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2007"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8de64727-ef70-4a15-9f4a-e54208daff76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1378,7 +1312,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 454b30fd-d556-4584-a056-8f18feceddc9
+      - f1e99077-5be5-4a8d-aa3e-f1a1c0d7efac
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1210"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1355,205 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c22dcde-e5f8-4541-a675-607dd7550bfe
+      - fbc84956-fbd6-4ccf-b411-6cb747f161e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 19148bdf-1d1b-459d-ae45-f7fef053c957
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1212"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4722b0c-b70a-44eb-969e-c67d63d945b2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
+    method: GET
+  response:
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d888bb8b-ae08-459d-97d7-94e217854548
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99b37001-b024-423d-a982-205c38e4fb30
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf103b32-9d1f-44a3-993b-ae2c6724ea85
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1212"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0bcb95c1-ce61-4fe2-ac2b-cfcd5377cf53
     status: 200 OK
     code: 200
     duration: ""
@@ -1435,16 +1567,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1242"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60dc5157-7ecf-460e-a4ac-56513f221995
+      - d8cfeadf-ea89-4fb0-b7f8-a63a0065ffc5
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,19 +1597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2007"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5a959e6-c897-47c1-9d2e-080673ff401a
+      - 8a6168cb-2b4b-49eb-b14b-458af10ff8d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,19 +1630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ad916a1-29fe-42dc-a285-2a16289368b6
+      - 26feb85f-e357-4d2c-9c70-7d66390692e9
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,7 +1663,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 59e4ecfb-0d20-4fab-8f56-194f743f45f1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
+    method: GET
+  response:
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - adb62c4e-7246-4c38-8529-e7e42501b836
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1543,7 +1741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4a50dad-73d0-43d7-b578-f3c94018264c
+      - 7782df9f-fb1a-44cb-8f70-7406e20cd817
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,19 +1762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2007"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:37 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 922737fb-36c9-4186-9f32-f60ad9c51827
+      - 167b3ec6-ff56-487b-9811-23527de4f897
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,7 +1795,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1609,7 +1807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d99ab18b-1595-4dbf-bf24-146247bb0253
+      - fbed1a7d-198b-4c85-8a80-47da37b9fe12
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,19 +1828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51219755-80ce-484b-a4cb-2cd839c92159
+      - 2487e5b3-17d7-433b-8a8e-841bd7f81ca4
     status: 200 OK
     code: 200
     duration: ""
@@ -1666,16 +1864,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1242"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1685,7 +1883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab117884-8498-4c90-ad51-7f9d76b33dd1
+      - ed377538-479b-4b98-9291-33935835e563
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,19 +1894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1718,7 +1916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 724d13a3-a1a0-4e01-a7b1-b6afd6c34caf
+      - 72bfecbc-731d-41fd-9782-bf6936cb7954
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,19 +1927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2007"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1751,7 +1949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d145aa11-ff15-4505-9638-a8ba52d2ef85
+      - 67f5b31c-9aec-4e14-9d7d-6a860058f0b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,19 +1960,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2007"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1784,7 +1982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec4a4d4a-d19c-46f8-95ab-1e9fa8b2c7ec
+      - 382527fc-196a-4907-b0c4-f084159b8fb1
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,7 +1993,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/users?order_by=name_asc&page=1
+    method: GET
+  response:
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 502757c3-3468-477d-8c67-6c83d744aa29
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1807,7 +2038,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:39 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1817,7 +2048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c90746cd-f315-4147-a0fb-af5ae51cbaee
+      - 7dcefdd6-394c-4323-8b72-d21256d6137d
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,7 +2059,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUXIyVHc3VU1KUEhQaEtkWVhSaXE0MGJyVmJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFME1UUXlOMW9YRFRNek1USXhOVEUwTVRReU4xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTZYZjFRLzNYMGt0TjEzVFE3OVpqekVGaDBJZHVTOXNNNHN0eVRQcEt0K2hucnVFYXRSRysKanhUWHBETW5YdFFkWmlxMDdqMWsxZ2pjaXFpUWgxQ1ZKejVzM3RsVEtxVS81VmhCSGVMMStaWHJiOWkvVXp0ZApnRkZmc2MwWERnMzRodXR2OW05QXFQSVA1NUtFZ29QblNVelJ6eU5aNzVjS3ZyVWVKbm1TMWlQQnpXdUkyK3hECnlCbTR4emVTRmhDSi9YWi9hdXd6V3BETlVabDFlL005ZzRWdzZvSHljZHFjcE1JL1cwWllNWUVTUlFTdnZpS2cKbSsvblN6RzZuZi9sUWZpMXF0aE9FRVhlTi9nTENCZU16cXRONmhZMkdDNitRSDJndEhTYjJKTHIzUzdKTFJ5NQpFZUtmZnVROUtINEtqQlQ2d2VNTk95Nmw3MFgrckZUUEF3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFoWXpVNE9Ua3hZaTA1TWpJekxUUXdNRGt0T0RJMVl5MWsKWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxaFl6VTRPVGt4WWkwNU1qSXpMVFF3TURrdE9ESTFZeTFrWWpZM01UZG1NbUV3WVdRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUHhGZUhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDMEhjcC9oU0o3bWpmdFlxcVozVjlIbGNrU2lIL3NxNENyZ1dqLzlUM0hqMDFvYUQ3K0dIUFkvWGdKVApJQzlzdXRObmZXeGN6MkNwOHk5VWx5djc5T3N2dlZsektRSTNtdnhxV3kzTnJHeG1BdE1wTW0wZDNqQkhxckNwCk5FNkRRWmptZXFqVm1rQXhVYTNPbWZ1ZTZHdEtvaGZBTUZQWWpuUHFpS09aWTYvbmVXTGhRM1RKdWR6SklQdUQKOEV1Sklod24zeFJMT2pCclFhTngrYkxUbE40R3pIcmhTaW1PVU40ZWZwdldUUVV0bFBWNnJMaHhSQU9YWDBpbwpMVExDVkNtYW9rMHZpOEF1ZjZIZFdtR2l1VnE1ZUlEZmFFbGxEZndWdVJRdU4waEg4TUZsTDJlcmR2VFpPellVCm1ER3BJbTIvYmVVUFFGYmNXSHVDVVNVek82ST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52c150d3-a594-445d-afc1-a2dad56e86b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ac58991b-9223-4009-825c-db6717f2a0ad&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1840,7 +2104,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:39 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1850,7 +2114,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25daff2b-7f65-46f5-b6ef-cdfe1d88ea74
+      - ebbc6d46-28c3-4c6f-b343-c8100b66a3ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,19 +2125,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1210"
+      - "1212"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1883,7 +2147,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80c465b0-b7c4-4df6-88bc-9002e1cf6f3e
+      - 6c7de40b-b2ac-4d88-ad84-733587a22064
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,19 +2158,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1213"
+      - "1215"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1916,7 +2180,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30461a44-7f20-42da-806c-c6205697f66b
+      - a341d241-ea50-446d-8db9-4960f52b4dff
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,19 +2191,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:55.513341Z","retention":7},"created_at":"2023-12-18T14:11:55.513341Z","endpoint":{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753},"endpoints":[{"id":"bc00b465-764c-40d3-9ab7-0ef843bf8044","ip":"195.154.68.173","load_balancer":{},"name":null,"port":3753}],"engine":"PostgreSQL-15","id":"ac58991b-9223-4009-825c-db6717f2a0ad","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1213"
+      - "1215"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1949,7 +2213,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cee4ebe-b380-4cc6-a14a-e81289d3d34d
+      - 2248608e-39ed-4db3-b062-ef07fa01dcb5
     status: 200 OK
     code: 200
     duration: ""
@@ -1960,10 +2224,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2ab5b23-babe-4641-b261-b0f7ba384168","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ac58991b-9223-4009-825c-db6717f2a0ad","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1972,7 +2236,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:09 GMT
+      - Mon, 18 Dec 2023 14:15:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1982,7 +2246,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a05d99b-a698-4751-8fd9-ffb88e51d353
+      - 575d84e7-d965-4d56-a309-ee60a692bb46
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1993,10 +2257,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2ab5b23-babe-4641-b261-b0f7ba384168","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ac58991b-9223-4009-825c-db6717f2a0ad","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2005,7 +2269,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:10 GMT
+      - Mon, 18 Dec 2023 14:15:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2015,7 +2279,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd1b0466-2f39-40ac-a761-f85b483252a8
+      - 8e8ec511-703b-4622-bdc2-e32d3bb24aef
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2026,10 +2290,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2ab5b23-babe-4641-b261-b0f7ba384168","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ac58991b-9223-4009-825c-db6717f2a0ad","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2038,7 +2302,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:10 GMT
+      - Mon, 18 Dec 2023 14:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2048,7 +2312,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 493ecbc0-0526-4084-9821-17aa5b3a853d
+      - b08bfc1b-457a-47fe-8592-ee1bbb9586b0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2059,10 +2323,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ac58991b-9223-4009-825c-db6717f2a0ad
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2ab5b23-babe-4641-b261-b0f7ba384168","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ac58991b-9223-4009-825c-db6717f2a0ad","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2071,7 +2335,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:10 GMT
+      - Mon, 18 Dec 2023 14:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2081,7 +2345,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9a7b26c-1404-405e-af7c-249ab6a9f763
+      - 7f944dee-39c8-45f1-8c74-7850f0442aeb
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-instance-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-instance-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:45:39 GMT
+      - Mon, 18 Dec 2023 12:57:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d09e78b-af03-4ad8-b50c-234f464a11e9
+      - 2e18b592-aecd-4d48-961e-002704196284
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"data-rdb-test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"data-rdb-test-terraform","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:45:40 GMT
+      - Mon, 18 Dec 2023 13:06:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b365835e-3dfd-44ac-b6e1-26ce320a4072
+      - 9350fa85-20f4-42c1-85ac-a9af3198d94b
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:45:41 GMT
+      - Mon, 18 Dec 2023 13:06:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 292428df-0cfe-4f2b-81f0-ac4257fc1810
+      - 08ae3f66-2905-4dbc-83c4-d0afcf942abf
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:46:11 GMT
+      - Mon, 18 Dec 2023 13:07:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 309a8666-2e84-4621-a237-1e43a526f78a
+      - 048a3151-4aa0-460f-a9c5-9afce45caf99
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:46:41 GMT
+      - Mon, 18 Dec 2023 13:07:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 932ccc2e-00a6-4c98-af74-440cfe88b31e
+      - be94dfb8-afc2-4a58-ab1d-45767b42c36a
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:47:11 GMT
+      - Mon, 18 Dec 2023 13:08:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee181aa2-42c0-4c3a-a686-e8760947b18c
+      - f87316f3-ee3e-46b3-95e5-25e8af9ac370
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:47:41 GMT
+      - Mon, 18 Dec 2023 13:08:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1e803ab-0cd7-4771-b0c9-876e7010ac19
+      - c368238d-e582-4f3c-bb38-a044283af07b
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "905"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:12 GMT
+      - Mon, 18 Dec 2023 13:09:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27d91208-0386-4d81-8fa1-3011540f83e5
+      - 8d4b4e98-ab9e-4a84-ae65-e1a643260d1f
     status: 200 OK
     code: 200
     duration: ""
@@ -572,10 +572,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "905"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2efce72c-5dfa-425d-b2e6-ce3114ba9185
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1169"
@@ -584,7 +617,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:42 GMT
+      - Mon, 18 Dec 2023 13:10:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a864a0a3-3cc5-4e26-a793-8bd721ccd2f0
+      - f9102844-9d68-4e0c-a5be-95b756c55d70
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:17 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86adfd71-6a7b-4f97-8f0e-4572ae5d43cc
+      - b1e896ee-afb3-484a-b70c-16afc71770d3
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:17 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8aa94dbc-1590-4b97-a6f0-69ba8f2914b0
+      - 7ef95b53-a32a-47c0-aaf7-3233384025ba
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:17 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87359780-43fc-4dda-ad0e-820f7426f2d1
+      - 139acabf-b077-4aad-aefc-9bf22ce01c10
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:17 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34088372-3a7e-4dc6-81c2-bfbacc534835
+      - b2ffe50c-8ede-465b-9f80-74f281817af4
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:17 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8bb1901-937a-4e66-b3e1-492054863a8f
+      - 55a6dca4-d605-4051-8976-dd586403a66a
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5133a893-2789-41c9-b0bf-9a72a46d1363
+      - 1ebb90c3-e7f0-4f9b-8f9e-b9fee4ede22a
     status: 200 OK
     code: 200
     duration: ""
@@ -808,16 +841,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1246"
+      - "1242"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25e60fd2-75f5-4f47-8dec-073e0237a3e9
+      - e3df6cd2-5d0f-4626-85df-3b7fd1b95d13
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1214"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04f496c1-b878-4897-94b8-76bef65f8d26
+      - ac1e80cc-4a7d-4eae-9567-0dee18b01789
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "28"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f302565-5509-4958-9ba3-5ab120d6a241
+      - d6480cf3-3c57-4885-aeee-24fecf577157
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13feeedb-9972-45a3-9c08-6147393aa288
+      - ba3eadca-2b87-4303-ba23-881e0779df10
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - def5d774-aaf7-4e2e-9531-5803667cd462
+      - 0ecc13c7-f83e-4523-8070-1d12326bb646
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae5e0c23-a4d8-46ca-94a5-5952eb589904
+      - 85fea7e6-02c1-4e1a-a120-f4250f979926
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1058,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1e29f1d-2045-42eb-a0ec-1ce7a76e6c5d
+      - dc435571-c09c-4db4-909c-461fb7d0e1c3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1210"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:10:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 350463cf-5a88-49c9-8058-f5f421e93f72
     status: 200 OK
     code: 200
     duration: ""
@@ -1039,16 +1105,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1246"
+      - "1242"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6884abd-6946-492b-8716-771d223a4614
+      - a2e13c66-4d8e-48b1-b57d-6122d812dfbc
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1214"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:18 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1ee9698-07c7-416c-97ed-3466747da4ac
+      - d298d50a-fde6-477b-825f-198c0da062df
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:19 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71faaba4-cff0-4978-8ad2-b1f741effcda
+      - 040ec573-e910-48e6-b188-6f4300ad69cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "28"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:19 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17d47b0a-d298-4a15-af80-76ef268b1fe0
+      - 348f83e3-7498-44d9-a4f4-1855ea5f90c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2015"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:19 GMT
+      - Mon, 18 Dec 2023 13:10:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44b0c1dc-5c55-4143-a3ee-ea2f0d81e4dd
+      - 61d1d6a9-e982-453c-9488-6d8160c1c961
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "28"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:19 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f86569f2-b73d-4cfa-b8d5-357f132b393c
+      - adf61847-142a-4073-a389-9cdfea9dea8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2015"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:19 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb8b0436-e4fa-447a-b899-5431e3ef2bce
+      - 3660a5f0-b6cf-48af-969c-e72b78564337
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1214"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:19 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7de6e9d2-c14c-4d6c-8674-395f48aec0bf
+      - 8de64727-ef70-4a15-9f4a-e54208daff76
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "28"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:19 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85339f9a-1b8d-4049-85e8-c4b0ca817c33
+      - 454b30fd-d556-4584-a056-8f18feceddc9
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,19 +1399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2015"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,40 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b91c6ef-c125-41b2-9c53-421e5b0ecc03
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1214"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ceacf963-ecfc-45ba-8637-3cb57dcbf4c8
+      - 7c22dcde-e5f8-4541-a675-607dd7550bfe
     status: 200 OK
     code: 200
     duration: ""
@@ -1402,16 +1435,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1246"
+      - "1242"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b7e7926-c0a0-4f01-97a8-6ec165be9eb0
+      - 60dc5157-7ecf-460e-a4ac-56513f221995
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,19 +1465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9e97cf2-995a-4aef-9482-cd5b50193f33
+      - f5a959e6-c897-47c1-9d2e-080673ff401a
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,19 +1498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8610fd6-2081-42cd-baea-5798c0071fe3
+      - 1ad916a1-29fe-42dc-a285-2a16289368b6
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,19 +1531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 837031f6-dbb8-4ba7-ad5e-62aa7a86bb33
+      - d4a50dad-73d0-43d7-b578-f3c94018264c
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,19 +1564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31c95545-d915-48c3-af41-8e066bc62bbe
+      - 922737fb-36c9-4186-9f32-f60ad9c51827
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,19 +1597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1619,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f55f7304-5858-45a0-bceb-1c0f7bd0fd23
+      - d99ab18b-1595-4dbf-bf24-146247bb0253
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1210"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:10:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 51219755-80ce-484b-a4cb-2cd839c92159
     status: 200 OK
     code: 200
     duration: ""
@@ -1600,16 +1666,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances?name=data-rdb-test-terraform&order_by=created_at_asc
     method: GET
   response:
-    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
+    body: '{"instances":[{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}],"total_count":1}'
     headers:
       Content-Length:
-      - "1246"
+      - "1242"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08eddb4b-94ea-4f4b-95ca-21de681d7e4b
+      - ab117884-8498-4c90-ad51-7f9d76b33dd1
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,19 +1696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:20 GMT
+      - Mon, 18 Dec 2023 13:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e54659d7-8b15-4dd4-bf71-29d47cbd6c7a
+      - 724d13a3-a1a0-4e01-a7b1-b6afd6c34caf
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,19 +1729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1214"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:21 GMT
+      - Mon, 18 Dec 2023 13:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1685,7 +1751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a8dcff1-d387-443c-9e8a-2c71ad5aaeaf
+      - d145aa11-ff15-4505-9638-a8ba52d2ef85
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,19 +1762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQmFpVnozcWVDNTVDTk9ZaDBhS3lZM3JLQXpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1EQTBXaGNOTXpNeE1qRTFNVE14TURBMFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5HZHYwMHFqMzNtaUxXL054bWxYQkpmSS9wcGxkb0EwdWYwMW4rQnJaOVo3aFR0Ym5FVFNyOHcKeGJIaUtYOXhTd0ttcDNHSmczSU0wODdWT3pQNyt0V2hrK3BDTi85YVRIc3hrb3BwVWM4dGxHa2xRVzNqSzR3NAoxc0hGNWU3VFp5enMzcU1aWklreDg0SDRFQkRmSXFneWdOS2ZCZU9PT1pxY3pQWW1YcDBQUzhvdkI5UENNTGpyCkJZNnRYdmN6ckJRZlpDU2VwWllodFpzYmhkcFJlZUp5K2hVc3o3MTkxMWx6aWpubldaeFIzRHNrNGxQNC9RODUKOTlXcFlrZHlscmNtRHV4Unl4ZWlDK2VWRGJSOEVtQzY5SlN3MWdTRi9rNmNmZUZhZ2JJZlVhS2prMWJQU1hnTwp0SzlyR25PbWlVbGJoT09SM0JhN0k4QVJrNVU1NXhjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxNbUZpTldJeU15MWlZV0psTFRRMk5ERXRZakkyTVMxaU1HWTMKWW1Fek9EUXhOamd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1V5WVdJMVlqSXpMV0poWW1VdE5EWTBNUzFpTWpZeExXSXdaamRpWVRNNE5ERTJPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVIS0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbm43MEZUZUgxeFI2TTRlWVVXUGQ3RkFIUTJCRGFUNnZCc2Jjb2dMUlJFNmtYS3EwekFJTThRN1ArblBQNkFKSApuRGgyVzlsRkE1eWhHYnpqMG85QlFIUjZNUDhPcDJFUDVEdnJqRndjMXFFQzZDVGo4ajZCUG9rbnplSkxmRENuCkRmb3lOcFJiTHd6YkhoRDE3aU0wLzkrYzJtY0w5N2t6c1BleEY5clJTV2lSb05maG5lTDlVempnK256TlVQZTAKTUVITUNSVzcyZVlBYVJScmVBQ0M0dldiTEFoTy9HYTExcTh0cHZRZUo3RnQ1Vyt5RGJYR09vd05YeGhlcUxGTwprMU5qZHFPRk1DemR6aW5kQlJFbVFZanJ6MUNTQjlPT1lKbm94c1hvMC9CR0tLUmZNL2xiSmVIMUF2dWVXQk9JCjBSMHVnZy9LQzNUVXM1ZnhGYis5Znc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:21 GMT
+      - Mon, 18 Dec 2023 13:10:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1718,7 +1784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9f8e5a4-ccaa-4906-b559-04160d24f1fc
+      - ec4a4d4a-d19c-46f8-95ab-1e9fa8b2c7ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,19 +1795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "28"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:21 GMT
+      - Mon, 18 Dec 2023 13:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1751,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7221e45-fa34-4c49-87a9-0c6f38d7521c
+      - c90746cd-f315-4147-a0fb-af5ae51cbaee
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,19 +1828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2ab5b23-babe-4641-b261-b0f7ba384168&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:22 GMT
+      - Mon, 18 Dec 2023 13:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1784,7 +1850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2a7ccbf-89b7-4b46-9e59-869fd9d8efe3
+      - 25daff2b-7f65-46f5-b6ef-cdfe1d88ea74
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,19 +1861,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRW5SaDFOWngyQnJoYS85TlpIcHNXQTVQbXNnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTROREphRncwek16RXlNVFV3T1RRNE5ESmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQy8yTlRDNGtrVHpNU1h5VWc3NkRPWndUQVhQaVI1d093RGt0VVp2ZjBqNU51eDI4VWYKaWtvaHgzdVlFZVVkWExBMkt0WkIzZ3NRVnNaUzJIYXJDSVY3bm1wc3EwTHE1elFuYnA4TklDdS85ZXdoK2FIcgppbGwxanZEdDBUcG5Mc3EzL2VGN2U5ZjFIb3FyQjdMRXEyNy8zVVNVUVJtZzBCTFRLc05TR1JPekZqT2lMU0dnCkJ2V1QzSkJkOUp2V1p0ZW8vZHpRU2V2emV2cGJBR1dWV1FqOXJoaWo1aU9XemZOOUhlYzdONXFIOWxiOUMwQ1IKS2tESXd3YVFZWmxVVGRWZ2NRaFB6VWErSjUweXlmUDFrWUtKdlpSWS8xSnlJQTFpMEgxa0JDNmZXQS9OcGNhcApxdUVSRmVJUWtMclpqaFRhcDUweUZLNkVJeEgwNHJZVkIvY1pBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNU0yUmhNRFZsWmkweU1XWXdMVFJqWW1NdE9UbGoKTVMxa01qWmxZVEpqWVRCaU1qY3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPVE5rWVRBMVpXWXRNakZtTUMwMFkySmpMVGs1WXpFdFpESTJaV0V5WTJFd1lqSTNMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVML1BXaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFQbmJKT1N0dVljMGhhQ2IzdXQwMHZrN0VHczdWWXdmUmFrellFaWh4c3M3Z3FEQkZPVDZDNgpBNnlXanVPR2ZrSnVNOVFobC9qdGxjL0NKdmxKblNhMzE1N01EOTJFNEZ1aDRnWk1DNkZJb1k4bmN5VGZMR2Y5CnFBOHVzWjZQNEJ0ZGRnV2JJbnZUL1ZLYnZ1T0gxeHJSays3dTRkMlZsS1BlcThBcUFUOXQwNmJiNEt1WXVrTGoKUmhhQi93dndEZE9nZ3NBNXBFL0x5aURnbGlXS2dYK3FwWnlhSEQzR1NtUEJ0a2pDQ1NENVBWWG1vQWYwRXJjTgpEV1lqSzV2V014NGQxc2JZa1BpcTF2Tm1kV3cyQklLZ01mWGlLMUdMS0RnZHVRdGg5YUVyajNobjErbFQ2K0RKCjNPOVErNVNnQU10a3hkSjdJSzlJajNFWjkyaUYzSC9VCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2015"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:22 GMT
+      - Mon, 18 Dec 2023 13:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1817,7 +1883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 481cb33d-74d2-48a0-acf8-218b12dcbab1
+      - 80c465b0-b7c4-4df6-88bc-9002e1cf6f3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,52 +1894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1214"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:49:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 16afd6e0-0c4a-482a-b6eb-b3f7b147f217
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1217"
+      - "1213"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:22 GMT
+      - Mon, 18 Dec 2023 13:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1883,7 +1916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d4a7646-41b2-47d0-945f-031bef32063f
+      - 30461a44-7f20-42da-806c-c6205697f66b
     status: 200 OK
     code: 200
     duration: ""
@@ -1894,19 +1927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:45:40.669619Z","retention":7},"created_at":"2023-12-18T09:45:40.669619Z","endpoint":{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485},"endpoints":[{"id":"bb135095-d764-499b-8ae7-6ddb4feed474","ip":"195.154.196.110","load_balancer":{},"name":null,"port":1485}],"engine":"PostgreSQL-15","id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:06:33.119712Z","retention":7},"created_at":"2023-12-18T13:06:33.119712Z","endpoint":{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672},"endpoints":[{"id":"e3943570-436f-42fd-a8fe-1af1ef3aca4d","ip":"51.159.74.238","load_balancer":{},"name":null,"port":4672}],"engine":"PostgreSQL-15","id":"e2ab5b23-babe-4641-b261-b0f7ba384168","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"data-rdb-test-terraform","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1217"
+      - "1213"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:22 GMT
+      - Mon, 18 Dec 2023 13:10:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1916,7 +1949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 525af386-1dfd-46bc-a89a-2e65cea7e43b
+      - 3cee4ebe-b380-4cc6-a14a-e81289d3d34d
     status: 200 OK
     code: 200
     duration: ""
@@ -1927,10 +1960,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2ab5b23-babe-4641-b261-b0f7ba384168","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1939,7 +1972,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:58 GMT
+      - Mon, 18 Dec 2023 13:11:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1949,7 +1982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1574298-c5d8-4833-89f6-758c7d7d2b72
+      - 5a05d99b-a698-4751-8fd9-ffb88e51d353
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1960,10 +1993,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2ab5b23-babe-4641-b261-b0f7ba384168","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1972,7 +2005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:58 GMT
+      - Mon, 18 Dec 2023 13:11:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1982,7 +2015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f24c1546-535f-4ba0-bfbf-e2023056666c
+      - fd1b0466-2f39-40ac-a761-f85b483252a8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1993,10 +2026,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2ab5b23-babe-4641-b261-b0f7ba384168","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2005,7 +2038,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:59 GMT
+      - Mon, 18 Dec 2023 13:11:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2015,7 +2048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2f51ee1-e477-4aed-92bb-b36377a154d4
+      - 493ecbc0-0526-4084-9821-17aa5b3a853d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2026,10 +2059,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/93da05ef-21f0-4cbc-99c1-d26ea2ca0b27
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2ab5b23-babe-4641-b261-b0f7ba384168
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"93da05ef-21f0-4cbc-99c1-d26ea2ca0b27","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2ab5b23-babe-4641-b261-b0f7ba384168","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2038,7 +2071,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:59 GMT
+      - Mon, 18 Dec 2023 13:11:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2048,7 +2081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 588609e0-57f1-495f-a1e6-381aae33f9d1
+      - f9a7b26c-1404-405e-af7c-249ab6a9f763
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-privilege-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-privilege-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:44:22 GMT
+      - Mon, 18 Dec 2023 12:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41b2475d-b2ef-439b-aea0-0ca7ba63200c
+      - c0fd2ea4-fbf3-4f74-adea-b28aa64792ad
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-privilege","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-privilege","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:44:26 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce6eb752-7903-4a16-823d-2504cc2e99f3
+      - 78027890-9ee2-4d73-bdf3-a49239339fd2
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:44:26 GMT
+      - Mon, 18 Dec 2023 13:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b2c8a96-2e15-4470-b6b8-5a68b256c9dd
+      - cc0551a1-b125-42ad-9923-805c7330c53b
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:44:56 GMT
+      - Mon, 18 Dec 2023 13:06:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65756c58-347b-40b0-890b-7011992437fe
+      - 733f6fa7-bc97-4b67-9b98-6807e32f9424
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:45:27 GMT
+      - Mon, 18 Dec 2023 13:06:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e775abf9-7446-4491-9c66-c62d45b74243
+      - e0e4cd04-e94a-4086-a73e-cd1586f00d84
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:45:57 GMT
+      - Mon, 18 Dec 2023 13:07:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce470240-cd9d-4c14-87aa-edc867d688b7
+      - c544f5fb-af54-4b30-a6e6-bf0725473854
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:46:29 GMT
+      - Mon, 18 Dec 2023 13:07:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de5dd07a-48ba-4a11-b06c-cbd0ed0665ab
+      - 5f479e90-d3e5-4fe8-a060-02533269d42a
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:46:59 GMT
+      - Mon, 18 Dec 2023 13:08:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ab54a2a-7ade-44ed-9522-3fee4cd191c6
+      - 9b13d124-11c2-401f-a491-48fb5a7dab76
     status: 200 OK
     code: 200
     duration: ""
@@ -572,10 +572,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1206"
@@ -584,7 +584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:47:30 GMT
+      - Mon, 18 Dec 2023 13:08:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97a4c0f8-ee58-41d2-8f0e-ca148199b37d
+      - d76c418b-1b70-4923-8b4a-0f65ca568bad
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:00 GMT
+      - Mon, 18 Dec 2023 13:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c4e1c18-2e9f-48dc-8119-37b38c25c055
+      - e35f5b03-9acb-4666-b605-8e9eaa858229
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:00 GMT
+      - Mon, 18 Dec 2023 13:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23410ae3-4e08-4186-8b29-94915a008401
+      - 3a25a174-e00d-4c34-b598-23bb91233413
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:00 GMT
+      - Mon, 18 Dec 2023 13:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c8a3206-b1c1-46e1-9189-bdb113b664f4
+      - e63e6e78-5500-4f16-96a4-2bdfd99bea56
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:00 GMT
+      - Mon, 18 Dec 2023 13:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 724d74b5-929e-4908-aa6b-6c60edf4005b
+      - b36f0b70-f467-4c76-a708-97f8e437d2c9
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:00 GMT
+      - Mon, 18 Dec 2023 13:09:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8331e52-d929-4a4c-a51e-4654360f3466
+      - 5f9770e1-e7d6-418c-b987-4c960229f079
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:01 GMT
+      - Mon, 18 Dec 2023 13:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7803522-51dd-4ffb-8b6e-c35a34e873e9
+      - d8d002c0-b8f2-4560-b57a-74c4b29629cb
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:01 GMT
+      - Mon, 18 Dec 2023 13:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bbf8577-0418-41f9-98ce-0fedecadb111
+      - e4528866-4ac4-4bad-8982-38f1899f2d99
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:01 GMT
+      - Mon, 18 Dec 2023 13:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99432843-f0ad-40de-8209-a13cfa3c1d90
+      - b1f6f54e-f9c7-4a82-af9d-1d612386c00f
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:01 GMT
+      - Mon, 18 Dec 2023 13:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d969da6d-9608-4efc-af94-0e67b7b5ca39
+      - e11bb204-c15b-4e9c-b22d-dce24746ec96
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:02 GMT
+      - Mon, 18 Dec 2023 13:09:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f67a96e-d1b0-4fd8-bb93-374e213d369c
+      - 03d85098-bd4a-4cff-bdae-93b0ae14cb59
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:02 GMT
+      - Mon, 18 Dec 2023 13:09:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a9cc523-f15a-48f1-9e7b-9862e33104a2
+      - 9384d4c6-b6ae-476d-9072-8327c9957f99
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:02 GMT
+      - Mon, 18 Dec 2023 13:09:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9a618f4-27df-4ea8-9fc6-77b3baee95c3
+      - f87f2ccb-3dc7-4ecc-b182-b16761404dff
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,7 +1005,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
@@ -1017,7 +1017,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:02 GMT
+      - Mon, 18 Dec 2023 13:09:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cc53f01-3b37-413f-ab35-38c0159c7cee
+      - dd6e0293-15a7-4e5a-8eb9-f9bede419996
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:02 GMT
+      - Mon, 18 Dec 2023 13:09:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02764b06-27b9-4132-a765-fcfa8c5178e5
+      - 7fa1798f-683f-42b7-b07d-47537d56f83b
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,142 +1071,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5c72aaf1-09c4-490b-a069-ccbe1e901149
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1251"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0fa03124-fcf6-4617-beb4-c284f296275e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
-    method: GET
-  response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 55c7f67d-e76d-4301-a3a4-b0214b96ce82
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2015"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e88c711a-2ffe-4110-9012-2ca291a646e1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1215,7 +1083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:04 GMT
+      - Mon, 18 Dec 2023 13:09:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce585c95-2192-4376-a164-6bc9315d0b13
+      - f56390f8-d174-4bb6-87df-b52233f89873
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:04 GMT
+      - Mon, 18 Dec 2023 13:09:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 103c21c6-e4ec-43ad-9551-81b89e10aaa1
+      - b1746f1d-86b1-4390-99af-94287cde1a2e
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:04 GMT
+      - Mon, 18 Dec 2023 13:09:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5833273-85e1-4264-a3af-5491399831ef
+      - 79c25f07-761a-4f0c-9e2f-c46b3e0ca43f
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:06 GMT
+      - Mon, 18 Dec 2023 13:09:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9575669-b872-4090-bd9c-a49e3ccf56c1
+      - f546eaee-be88-4b70-a9be-8de46cd52479
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,10 +1203,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1347,7 +1215,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:06 GMT
+      - Mon, 18 Dec 2023 13:09:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c246f708-eee7-4c67-a1a6-7d42f6044e89
+      - 39591a5e-20c6-4624-8179-923bcf811d9d
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1236,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:06 GMT
+      - Mon, 18 Dec 2023 13:09:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1258,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86598548-8afa-44e2-a49c-7a913c4d735d
+      - e38e46ef-ccb0-4f4c-bd22-e62c2a1625c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3b2b09d3-6012-470d-bf3a-ad0e6f6da99f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae01f61b-73e2-4eeb-9954-4cc1052f1067
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "102"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ac8fdfb-4807-47cb-ae73-4c103b2fbe7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1247"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 57ebce7f-b7fe-4168-9d36-15acd09d24a7
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,7 +1403,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"foo"}'
@@ -1415,7 +1415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:06 GMT
+      - Mon, 18 Dec 2023 13:09:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdaea894-7008-4437-b625-accac7b9d74c
+      - 90d75fe5-c08b-43db-8fad-409415a78723
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,19 +1436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:07 GMT
+      - Mon, 18 Dec 2023 13:09:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3838e80e-c172-48a6-a5df-579d0923d549
+      - ae3cb1e7-593c-44f4-a9a4-55540df181c5
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,7 +1469,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -1481,7 +1481,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:07 GMT
+      - Mon, 18 Dec 2023 13:09:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecdd8143-f64c-46e1-9e65-970b1d6b8c4a
+      - 8a8e057f-c1f9-4c5c-a3c5-761b2da51792
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,19 +1502,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:07 GMT
+      - Mon, 18 Dec 2023 13:09:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d9e023f-95dd-412b-920c-77c8ca8e1a77
+      - 3b8ef940-cd99-4cf1-9081-540ced83540c
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,19 +1535,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "59"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:07 GMT
+      - Mon, 18 Dec 2023 13:09:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e04c1cc8-d5dd-4cd9-ba63-21fdc4bec199
+      - 3f391739-5bc9-4cd8-936e-6d9de44fe7fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,19 +1568,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:08 GMT
+      - Mon, 18 Dec 2023 13:09:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b81646dd-b1be-475f-b0d6-aa4c5701125c
+      - d9287d9c-921b-43a8-89be-34d059a095d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,10 +1601,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1247"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77c9158a-a927-4602-8d7e-a726a3a7921e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1613,7 +1646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:08 GMT
+      - Mon, 18 Dec 2023 13:09:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e99c53ad-cd13-413d-b49c-af9f5a18e724
+      - 8352a248-5249-4bda-84f5-dbdda99d6bcd
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,40 +1667,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1251"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9060a910-8459-4d8b-a1cc-1e62f64911fd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -1679,7 +1679,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:08 GMT
+      - Mon, 18 Dec 2023 13:09:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5d296d2-a0e5-4b8d-a453-3a72c3ce67f1
+      - 2a8ad7b0-5575-4d8b-9cbb-e17bcc2ece41
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:09 GMT
+      - Mon, 18 Dec 2023 13:09:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 164bc34e-56e3-4c39-b5ee-3d21e335d824
+      - f930266e-3ee7-4ea5-bbbc-4a62beb73eab
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "59"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:09 GMT
+      - Mon, 18 Dec 2023 13:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c3979b5-2a2e-4554-866b-b69686f1e356
+      - 340bc212-afd9-4084-97ee-c0876145f824
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1766,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:09 GMT
+      - Mon, 18 Dec 2023 13:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f336f8ac-32f2-454f-8781-eb0940442e40
+      - 516d7400-1a05-465f-8169-213b30ce2b25
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,43 +1799,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1251"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d1394f0-aabe-41b1-8e04-67dafdc60ee2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1844,7 +1811,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:09 GMT
+      - Mon, 18 Dec 2023 13:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83fafffc-332b-4377-a9ec-58c801777e0b
+      - b366fff9-bcd7-4977-a95d-a445f3db1754
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,7 +1832,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1247"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83332db2-c8e5-4275-8fea-42ff3c7ef230
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -1877,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:09 GMT
+      - Mon, 18 Dec 2023 13:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ca6cbd7-9e80-49b1-93bb-334d17f13b6f
+      - 7e3ef6db-865a-4fa7-8092-0842d9709138
     status: 200 OK
     code: 200
     duration: ""
@@ -1898,19 +1898,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:10 GMT
+      - Mon, 18 Dec 2023 13:09:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1920,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a069ce03-2a49-4910-bafe-ca7bf7d6a950
+      - dcb557cc-46a9-4c66-abd5-0da1cbd9b385
     status: 200 OK
     code: 200
     duration: ""
@@ -1933,7 +1933,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"all","user_name":"foo"}'
@@ -1945,7 +1945,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:10 GMT
+      - Mon, 18 Dec 2023 13:09:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1955,7 +1955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 363eab83-b1fd-441a-b772-383f63dea103
+      - 3894cb9a-9f62-4748-9f6e-6041ffc15bc1
     status: 200 OK
     code: 200
     duration: ""
@@ -1966,19 +1966,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:10 GMT
+      - Mon, 18 Dec 2023 13:09:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1988,7 +1988,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53ccc7e1-4206-4493-b107-16b209226fac
+      - 3aadb6dd-3805-4478-8de7-1fb9a896d535
     status: 200 OK
     code: 200
     duration: ""
@@ -1999,19 +1999,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:10 GMT
+      - Mon, 18 Dec 2023 13:09:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2021,7 +2021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b31c6be6-9de7-4c5a-87ad-991c55d85e1e
+      - 97111a9a-9d57-40e6-8368-dcb4bd861407
     status: 200 OK
     code: 200
     duration: ""
@@ -2032,7 +2032,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2044,7 +2044,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:10 GMT
+      - Mon, 18 Dec 2023 13:09:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2054,7 +2054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c0bf54b-73d8-4c60-9dbf-d6fe35f5a698
+      - 8df11b81-1f4c-4bf3-bef6-ad3820558a5b
     status: 200 OK
     code: 200
     duration: ""
@@ -2065,7 +2065,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2077,7 +2077,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:11 GMT
+      - Mon, 18 Dec 2023 13:09:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2087,7 +2087,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 039ec749-b603-4e7c-be1d-a7a009d2e96e
+      - f103e455-8bcb-449e-bf7f-562b1764f72b
     status: 200 OK
     code: 200
     duration: ""
@@ -2098,19 +2098,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:11 GMT
+      - Mon, 18 Dec 2023 13:09:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2120,7 +2120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa4bbc57-0130-4697-9797-b9f4c4f34dd6
+      - ea16299f-ccab-4cac-b932-3b14d18854ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2131,19 +2131,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "59"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:11 GMT
+      - Mon, 18 Dec 2023 13:09:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2153,7 +2153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 868beaf3-1e4b-48ae-9b0a-2f1e9d93e378
+      - 70008fcf-ae47-450b-adfe-58df374d5963
     status: 200 OK
     code: 200
     duration: ""
@@ -2164,19 +2164,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:11 GMT
+      - Mon, 18 Dec 2023 13:09:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2186,7 +2186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ecd0da5-426e-4064-bff0-e717902a8639
+      - b62d7dcc-655a-41e1-a822-2e8b49f9c06e
     status: 200 OK
     code: 200
     duration: ""
@@ -2197,43 +2197,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1251"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f8a92d3-ce6a-4cc1-a776-95278da676ef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -2242,7 +2209,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:12 GMT
+      - Mon, 18 Dec 2023 13:09:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2252,7 +2219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcafa19a-f501-463d-83e6-b1bffea251f7
+      - fbb86451-d905-44a2-8037-7fafeaa86ff4
     status: 200 OK
     code: 200
     duration: ""
@@ -2263,7 +2230,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1247"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3bd908b-f741-48cc-bfcc-7bf04aeb421d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2275,7 +2275,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:12 GMT
+      - Mon, 18 Dec 2023 13:09:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2285,7 +2285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6fa77d9-ed4f-41be-bacf-8a4a43267148
+      - 541a3098-920b-47b3-8218-7c3abea4e15a
     status: 200 OK
     code: 200
     duration: ""
@@ -2296,19 +2296,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:12 GMT
+      - Mon, 18 Dec 2023 13:09:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2318,7 +2318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55c9ea82-c968-4092-ba1a-afe9708ec340
+      - 05ac62a7-33af-47e2-af60-3632f980bced
     status: 200 OK
     code: 200
     duration: ""
@@ -2329,7 +2329,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2341,7 +2341,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:12 GMT
+      - Mon, 18 Dec 2023 13:09:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2351,7 +2351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42fd535f-ea11-4cf0-acc1-848f6554fbc4
+      - d418c97b-1afd-44dc-ab4d-3ef9f2061a1a
     status: 200 OK
     code: 200
     duration: ""
@@ -2362,7 +2362,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2374,7 +2374,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:12 GMT
+      - Mon, 18 Dec 2023 13:09:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2384,7 +2384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32366c4a-454c-4f12-9a7a-2066e81a9e8c
+      - 5f04595a-03f6-405e-96d5-b1cff5295b2a
     status: 200 OK
     code: 200
     duration: ""
@@ -2395,19 +2395,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:13 GMT
+      - Mon, 18 Dec 2023 13:09:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2417,7 +2417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab699c61-a215-4357-b44b-1beaa2dc2c5b
+      - 06a6258d-ca54-46eb-838a-746bd5b38605
     status: 200 OK
     code: 200
     duration: ""
@@ -2428,19 +2428,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "59"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:13 GMT
+      - Mon, 18 Dec 2023 13:09:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2450,7 +2450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a08ec7a-efd2-4ceb-9442-df0ce5e9c1de
+      - 9ba367e9-6d25-48c8-a074-c2ddda182218
     status: 200 OK
     code: 200
     duration: ""
@@ -2461,19 +2461,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:13 GMT
+      - Mon, 18 Dec 2023 13:09:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2483,7 +2483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcc9f6b8-949d-4211-b582-62b530b2c42f
+      - ad35d426-03d7-4ef0-a978-7b1cf410faa7
     status: 200 OK
     code: 200
     duration: ""
@@ -2494,43 +2494,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1251"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4931a615-b21d-482c-bd10-c3fb2aefe45b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -2539,7 +2506,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:13 GMT
+      - Mon, 18 Dec 2023 13:09:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2549,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0f75465-6ab2-4390-95a6-5591bdc5fb3f
+      - a42d6eda-944e-4bf6-a749-aa58c800f6ad
     status: 200 OK
     code: 200
     duration: ""
@@ -2560,7 +2527,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1247"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed9f7183-82b6-458c-ae14-95a23c2080ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2572,7 +2572,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:13 GMT
+      - Mon, 18 Dec 2023 13:09:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2582,7 +2582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 468204a8-dc5f-4039-aadb-304078ec5249
+      - 95d87521-87c0-4813-8ec2-4636a8431d39
     status: 200 OK
     code: 200
     duration: ""
@@ -2593,19 +2593,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:13 GMT
+      - Mon, 18 Dec 2023 13:09:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2615,7 +2615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba62af8e-c1f5-408b-ac91-9589ad6b564b
+      - ad2cf0ff-b9cf-4873-acbf-fb6cf0ed04d1
     status: 200 OK
     code: 200
     duration: ""
@@ -2626,19 +2626,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:13 GMT
+      - Mon, 18 Dec 2023 13:09:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2648,7 +2648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74e8bd31-4d06-4970-af2b-8195cf31d208
+      - 91cd05d8-6b4e-4a79-ba92-a31bef0a98a2
     status: 200 OK
     code: 200
     duration: ""
@@ -2659,40 +2659,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 03918618-a25b-411e-853a-2373d4d53b2c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2704,7 +2671,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:14 GMT
+      - Mon, 18 Dec 2023 13:09:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2714,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a027adcc-4028-4e19-8ac9-e5a567eedce5
+      - 919fed72-c91b-4a1c-8a39-ed9882391170
     status: 200 OK
     code: 200
     duration: ""
@@ -2725,7 +2692,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85b01e2e-e014-46f2-bebd-94dd8005786e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2737,7 +2737,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:14 GMT
+      - Mon, 18 Dec 2023 13:09:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2747,7 +2747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d43f7110-7344-43b7-9599-20f1d9829959
+      - b098edb4-53ed-4aef-a7f0-b48290572af0
     status: 200 OK
     code: 200
     duration: ""
@@ -2758,7 +2758,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2770,7 +2770,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:14 GMT
+      - Mon, 18 Dec 2023 13:09:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2780,7 +2780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 659af0b7-bb2f-4579-895f-c5be8b2e2cdc
+      - d88b2d30-163d-486b-954b-5c8801b46787
     status: 200 OK
     code: 200
     duration: ""
@@ -2791,19 +2791,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:14 GMT
+      - Mon, 18 Dec 2023 13:09:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2813,7 +2813,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 413ce552-b1c5-4d11-bafe-9437845b07c7
+      - 2920de9b-dcef-4e08-b5ae-cec13d79c70d
     status: 200 OK
     code: 200
     duration: ""
@@ -2824,7 +2824,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2836,7 +2836,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:14 GMT
+      - Mon, 18 Dec 2023 13:09:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2846,7 +2846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9461ed7c-3048-4b7f-bb8c-f292c0039906
+      - 38518aae-56bc-4a25-be03-eb80ae7b9ae1
     status: 200 OK
     code: 200
     duration: ""
@@ -2857,7 +2857,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2869,7 +2869,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:15 GMT
+      - Mon, 18 Dec 2023 13:09:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2879,7 +2879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9675e91-b9f0-445b-a147-a0b2b9897990
+      - cb10fa4f-0641-4de9-8524-9ac3e7186456
     status: 200 OK
     code: 200
     duration: ""
@@ -2890,10 +2890,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -2902,7 +2902,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:15 GMT
+      - Mon, 18 Dec 2023 13:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2912,7 +2912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d79dc122-7a80-4661-81a3-bf27fc0796f7
+      - 5a07565b-d318-4bba-b56f-f2349d1bdbd1
     status: 200 OK
     code: 200
     duration: ""
@@ -2923,19 +2923,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:16 GMT
+      - Mon, 18 Dec 2023 13:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2945,7 +2945,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f25ec5f6-740b-46f4-a5d2-48d96a420b94
+      - c1bee461-451c-4556-8cf2-1a2cc5cbcb61
     status: 200 OK
     code: 200
     duration: ""
@@ -2956,7 +2956,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2968,7 +2968,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:16 GMT
+      - Mon, 18 Dec 2023 13:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2978,7 +2978,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f30c334a-9126-4a9f-a961-9a8b8c7a3892
+      - 420b4283-5e63-4593-9728-0d771d6bfe89
     status: 200 OK
     code: 200
     duration: ""
@@ -2989,7 +2989,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3001,7 +3001,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:16 GMT
+      - Mon, 18 Dec 2023 13:09:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3011,7 +3011,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db06afc1-8239-4956-8965-61f2218e0ce1
+      - 560bbd54-a8aa-4455-817c-315ea8193ff2
     status: 200 OK
     code: 200
     duration: ""
@@ -3022,19 +3022,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:17 GMT
+      - Mon, 18 Dec 2023 13:09:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3044,7 +3044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49f6cd34-e610-47ca-9f50-a45ef2cf9aeb
+      - 2909b22f-2f50-477e-ae0a-0a49d84d3831
     status: 200 OK
     code: 200
     duration: ""
@@ -3055,19 +3055,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "59"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:17 GMT
+      - Mon, 18 Dec 2023 13:09:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3077,7 +3077,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 787786d1-834c-41fb-aed2-a12766e1cd5a
+      - 96c259f7-1fe4-484d-88e0-e148658ac32c
     status: 200 OK
     code: 200
     duration: ""
@@ -3088,19 +3088,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:17 GMT
+      - Mon, 18 Dec 2023 13:09:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3110,7 +3110,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01cd16a3-8eb3-47ca-a90d-b49758111184
+      - 01c8ad1f-e04d-4edc-825d-49bb5c6a4a05
     status: 200 OK
     code: 200
     duration: ""
@@ -3121,19 +3121,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:17 GMT
+      - Mon, 18 Dec 2023 13:09:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3143,7 +3143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecadd27f-acfc-49aa-8209-d4cda6c92636
+      - 65697e61-a92c-4717-ae17-d48be3ba4acd
     status: 200 OK
     code: 200
     duration: ""
@@ -3154,10 +3154,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -3166,7 +3166,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:17 GMT
+      - Mon, 18 Dec 2023 13:09:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3176,7 +3176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95703d8a-bae7-4122-a61e-d26323ef7f9b
+      - c2df5e79-4e54-480b-92b9-fc80e669b197
     status: 200 OK
     code: 200
     duration: ""
@@ -3187,7 +3187,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3199,7 +3199,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:17 GMT
+      - Mon, 18 Dec 2023 13:09:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3209,7 +3209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7606eb1b-657b-457e-ab2e-f578030d6bec
+      - a726a5ba-2d79-4d18-80d0-d18c24916781
     status: 200 OK
     code: 200
     duration: ""
@@ -3220,19 +3220,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:18 GMT
+      - Mon, 18 Dec 2023 13:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3242,7 +3242,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7669bf6d-4aef-4c51-b406-d7dad429e293
+      - 73ee6c63-61cf-451e-9e71-35a788bb318f
     status: 200 OK
     code: 200
     duration: ""
@@ -3253,19 +3253,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:18 GMT
+      - Mon, 18 Dec 2023 13:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3275,7 +3275,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71da3aa6-e5f7-496b-bca4-6983e986ea7f
+      - a888a21e-ae3e-4ce9-9d87-dc713eb08f23
     status: 200 OK
     code: 200
     duration: ""
@@ -3286,40 +3286,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb59e904-94fc-4cf6-86cc-66d89f262582
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3331,7 +3298,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:18 GMT
+      - Mon, 18 Dec 2023 13:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3341,7 +3308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eebea110-6bef-4c9d-9619-0d809c076d1f
+      - ad45bd20-ecb4-45b9-a95a-d07c8489ed9e
     status: 200 OK
     code: 200
     duration: ""
@@ -3352,7 +3319,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9b36b341-f760-4ca8-8428-14871f686c22
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3364,7 +3364,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:18 GMT
+      - Mon, 18 Dec 2023 13:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3374,7 +3374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf2bf18d-3477-4948-857c-3918386951f1
+      - a7e0003e-19fb-4c3e-8920-2ade1ca9c7ca
     status: 200 OK
     code: 200
     duration: ""
@@ -3385,7 +3385,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3397,7 +3397,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:18 GMT
+      - Mon, 18 Dec 2023 13:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3407,7 +3407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 146b6db7-5f08-4485-b60c-da69bcb64443
+      - 18486b20-bf0e-47ec-b844-18cf932cf2aa
     status: 200 OK
     code: 200
     duration: ""
@@ -3418,19 +3418,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:19 GMT
+      - Mon, 18 Dec 2023 13:09:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3440,7 +3440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d35f854-42ee-4a9d-9d79-bf54ab549802
+      - 8b89d657-565b-4868-826c-21709894bc57
     status: 200 OK
     code: 200
     duration: ""
@@ -3451,7 +3451,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3463,7 +3463,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:19 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3473,7 +3473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f940929-f971-4283-be35-f261efbf6ab3
+      - f75c7edd-4c03-4d10-a3ba-2c80a3af67f1
     status: 200 OK
     code: 200
     duration: ""
@@ -3484,7 +3484,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3496,7 +3496,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:19 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3506,7 +3506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5121154-fb8e-4c13-a05f-ba402d99ccc0
+      - 34fcc17f-2964-443d-9aa2-73ffe77809fb
     status: 200 OK
     code: 200
     duration: ""
@@ -3517,19 +3517,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3539,7 +3539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee724b22-46cc-4219-be66-ef59dc062604
+      - 82fb15a8-5a49-4c1b-aeda-d434d1939733
     status: 200 OK
     code: 200
     duration: ""
@@ -3550,19 +3550,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3572,7 +3572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 650203a1-0d4f-4dee-9a9e-1d0930535ecc
+      - dcdb08c2-de92-4930-b2df-ccc37f731497
     status: 200 OK
     code: 200
     duration: ""
@@ -3583,10 +3583,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1247"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8015896d-7b7c-40be-88a2-25922d4507f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -3595,7 +3628,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3605,7 +3638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4527aa9e-dc1e-4732-a1fe-895c74d0e62c
+      - 461ae199-a992-495a-a756-e62b1e6ca9e1
     status: 200 OK
     code: 200
     duration: ""
@@ -3616,19 +3649,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1251"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3638,7 +3671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0b02530-5b6b-449e-abce-10b82ddb4120
+      - e5abdd7b-22e2-49e7-a7df-bcf5e99eace4
     status: 200 OK
     code: 200
     duration: ""
@@ -3649,40 +3682,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be1b38de-b9f1-40c9-93aa-5522db297cbc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3694,7 +3694,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3704,7 +3704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32be3ffd-76b6-4fd7-8787-f3b66be7ee00
+      - 7c385033-7c72-4c91-8407-f9b33000ff71
     status: 200 OK
     code: 200
     duration: ""
@@ -3715,7 +3715,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3727,7 +3727,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3737,7 +3737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbeb5422-1301-4c74-bd42-76052104700a
+      - 03490410-f493-4684-a96d-ea5c52bc374d
     status: 200 OK
     code: 200
     duration: ""
@@ -3748,19 +3748,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3770,7 +3770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 764d5e18-f9cd-47a1-b8c9-0026efcba0d2
+      - b3371e09-7fc7-4032-9e10-5f9e41ba4a1b
     status: 200 OK
     code: 200
     duration: ""
@@ -3781,7 +3781,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3793,7 +3793,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3803,7 +3803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73b1c2e4-4d6a-47f5-844b-dd1a93119c7d
+      - 3ba445fc-d776-4d62-8f5a-836a4fe7a3d0
     status: 200 OK
     code: 200
     duration: ""
@@ -3814,19 +3814,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
+      - Mon, 18 Dec 2023 13:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3836,7 +3836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79c8d209-33ea-4e7f-bb5c-7226affb9ade
+      - 5480e9df-6fc0-4cd7-bc93-a6f68350ac35
     status: 200 OK
     code: 200
     duration: ""
@@ -3847,40 +3847,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:48:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2b9b805-8d39-4efd-b63f-73af2af6457d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3892,7 +3859,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:21 GMT
+      - Mon, 18 Dec 2023 13:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3902,7 +3869,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26ed751b-09fc-4b06-b2a5-70c32c5313f3
+      - fd095af5-9060-446a-8a17-b9e47f372319
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:09:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 827ec380-2cf9-473e-88db-b2219eae6be3
     status: 200 OK
     code: 200
     duration: ""
@@ -3915,7 +3915,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"foo"}'
@@ -3927,7 +3927,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:21 GMT
+      - Mon, 18 Dec 2023 13:09:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3937,7 +3937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f696217-b5ea-43c6-8c81-afc5ca1f9df6
+      - 51912f73-0924-4189-aecd-76fec310d0f2
     status: 200 OK
     code: 200
     duration: ""
@@ -3948,19 +3948,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:21 GMT
+      - Mon, 18 Dec 2023 13:09:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3970,7 +3970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74993488-4727-4a59-9516-2bb5caf02ac4
+      - f9cc3ebc-bdfd-4f39-9ac1-4f739145b3e3
     status: 200 OK
     code: 200
     duration: ""
@@ -3981,19 +3981,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:21 GMT
+      - Mon, 18 Dec 2023 13:09:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4003,7 +4003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc3bb5e1-0bbd-456c-a8d0-98570bfd8b75
+      - 7edab1f3-eebf-4b90-be75-1fc12d337d3b
     status: 200 OK
     code: 200
     duration: ""
@@ -4014,19 +4014,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:21 GMT
+      - Mon, 18 Dec 2023 13:09:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4036,7 +4036,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ae99065-53e6-4467-a4f2-795d8dd061e8
+      - 847513d9-4baa-4b50-a6da-eda92eb2fa93
     status: 200 OK
     code: 200
     duration: ""
@@ -4047,7 +4047,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users/foo
     method: DELETE
   response:
     body: ""
@@ -4057,7 +4057,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:21 GMT
+      - Mon, 18 Dec 2023 13:09:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4067,7 +4067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b6896e5-8733-492f-bf09-3de5d748fb2e
+      - 5cce3a89-459e-474e-8f69-6da92635c186
     status: 204 No Content
     code: 204
     duration: ""
@@ -4078,7 +4078,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases/foo
     method: DELETE
   response:
     body: ""
@@ -4088,7 +4088,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:22 GMT
+      - Mon, 18 Dec 2023 13:09:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4098,7 +4098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0233e3b1-e1fe-44d0-a970-576e99c8d93c
+      - 5e683de9-e1c9-42d4-b7da-ad35e1e3c68d
     status: 204 No Content
     code: 204
     duration: ""
@@ -4109,19 +4109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:22 GMT
+      - Mon, 18 Dec 2023 13:09:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4131,7 +4131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ab6a983-fae8-4f36-b354-4d1c55e6a854
+      - 44385390-3b0d-45df-9f3d-b5d82d928d67
     status: 200 OK
     code: 200
     duration: ""
@@ -4142,19 +4142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:23 GMT
+      - Mon, 18 Dec 2023 13:09:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4164,7 +4164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66256226-e09b-4e3f-9aee-9a6e05310df6
+      - 6366e6d6-9e2e-4732-ad37-2737c9bf3852
     status: 200 OK
     code: 200
     duration: ""
@@ -4175,19 +4175,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:23 GMT
+      - Mon, 18 Dec 2023 13:09:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4197,7 +4197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e42dfff-dcb8-455e-a733-54cc344402e6
+      - 012e43cd-1b78-4793-ab72-bb094c17bf37
     status: 200 OK
     code: 200
     duration: ""
@@ -4208,19 +4208,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZTZPdUgvWXljNnQ1akJON1kvbEZHeERCSzhrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRnd09UUTNNVFJhRncwek16RXlNVFV3T1RRM01UUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3JmYllPcnRzbWI2a1lTcW11RWZVOGFuaGVHdFpQUllWVDBETERqRlJlak5KTEJySjkKVitnV1FXRzNYMzR5NUFkUTVRWjhtdStrNkVDZmc0c3BWNjBlQkpnZVhsTk1FODZqOHZWZWo5UUFOOVN6UThYTApPMWRZRG5Ia2p1UFdkNXF4QlBpeURrWC9NbDlobGZrN2JGdWNlblVlY2ZZL25seUFFOVRNY1lDUEg2SUF1U2tBCnhCYWZyd0RkaDk3K0g1S0JrLzVvZmdmZFJVVXlZWVhJbnhFTGNTd1gzQVk1T3dMR0QwU0tUZkpnTVR1NmYreWIKY1ZVNm1XSnBEOTc3TmdaRFQ0cmovUW1aL3RlZVRBNVc3QVN6NTFrY1BTUkdoU09oR2xFaEpGUkhURjJCSG5NSQpVVkRuK1hmUFp6UDBKMkhiNFJCT1ZRTWk1RTF3Q1VBeDJ6OS9BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwelpHSmtaRFUxTUMwNE5UazVMVFEzTlRVdE9EVTEKTmkwME4ySmlaVFV4WW1VMlpUWXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RNMlJpWkdRMU5UQXRPRFU1T1MwME56VTFMVGcxTlRZdE5EZGlZbVUxTVdKbE5tVTJMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOTBsaHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFXcmxEcEhWQ3cwaVJZSm85YlNrbU9ma0hTQS9xeVRpamRla1FkVnM1Q3NFZSsweWU2emZ4Ywo2UTdSK3FnMzJtMituL1JuQ3ZReG1PMUx5bHRseDJGVmJWL1YwMHJlbDNHVGpKc1E3NlRDVCtuVU4xWG5EaHFrCmpyYktCeEcyZytBVnRSMDRFZ013cUk0WnNPcDZvMHBLVTVkVUxwWHNlL2x6RnFLMis0QkhJaUFNcmZaT3ZKbkUKYk5jT0JMeWJncStoaU51ZWFYYkRxcnFway9YM3dGbmZNOHdLdDcrbThKV3hlMTBLZVFrNkFOVEwwaWtpMFFqZApCUm5GSTZGbENXNmprZ2xVUjhWbXFXVlEyUGJBSnk3cTVjZUVGbWsvK0RIRU82Y215QWZGajdUWEVqdFIwTmlNCkJWQVF3c1hxdGFpVVVoMm8yL003VEpydkFSN3c1NEo0Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:24 GMT
+      - Mon, 18 Dec 2023 13:09:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4230,7 +4230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a172845-bf55-4f4d-bca3-32e1c0c5f3e9
+      - f840ce87-c07c-4f18-81d3-5ffb17bf38e4
     status: 200 OK
     code: 200
     duration: ""
@@ -4241,19 +4241,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1251"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:24 GMT
+      - Mon, 18 Dec 2023 13:09:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4263,7 +4263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25cef661-507b-40b7-8be9-2c89dbb85ab9
+      - 67f2152d-36ac-489e-b74f-deeda01aa003
     status: 200 OK
     code: 200
     duration: ""
@@ -4274,19 +4274,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1254"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:25 GMT
+      - Mon, 18 Dec 2023 13:09:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4296,7 +4296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd076aa1-fb24-4777-88d0-303a9e6e0b3e
+      - de2d69df-1d69-4b59-b10c-ae7b7f25b727
     status: 200 OK
     code: 200
     duration: ""
@@ -4307,19 +4307,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:44:26.387407Z","retention":7},"created_at":"2023-12-18T09:44:26.387407Z","endpoint":{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561},"endpoints":[{"id":"85401316-e995-4de9-b544-9dbe9f9a237e","ip":"195.154.196.110","load_balancer":{},"name":null,"port":9561}],"engine":"PostgreSQL-15","id":"3dbdd550-8599-4755-8556-47bbe51be6e6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1254"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:25 GMT
+      - Mon, 18 Dec 2023 13:09:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4329,7 +4329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de141aa9-1b6f-4905-a93e-73bc4461d311
+      - 4ac10380-ad38-48b9-9b85-5448dac0ba11
     status: 200 OK
     code: 200
     duration: ""
@@ -4340,10 +4340,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"3dbdd550-8599-4755-8556-47bbe51be6e6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"22d02f16-8e6f-499b-b895-9a55142758fe","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4352,7 +4352,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:55 GMT
+      - Mon, 18 Dec 2023 13:10:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4362,7 +4362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be933f9d-d832-4f36-bf17-5e7ed07fda72
+      - 4a579ad0-6dcc-466d-acc3-4b7a2d4b3cd6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4373,10 +4373,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3dbdd550-8599-4755-8556-47bbe51be6e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"3dbdd550-8599-4755-8556-47bbe51be6e6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"22d02f16-8e6f-499b-b895-9a55142758fe","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4385,7 +4385,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:48:57 GMT
+      - Mon, 18 Dec 2023 13:10:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4395,7 +4395,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c0d9d9c-382c-4e6c-b4c0-4ec3e0b2f520
+      - 1b0d7071-6ac0-4ef1-a7e1-a73851e3f542
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-rdb-privilege-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-rdb-privilege-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:02 GMT
+      - Mon, 18 Dec 2023 14:11:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0fd2ea4-fbf3-4f74-adea-b28aa64792ad
+      - fdc34655-7b8a-40eb-a8c9-b3eb914bb27c
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:05:44 GMT
+      - Mon, 18 Dec 2023 14:11:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78027890-9ee2-4d73-bdf3-a49239339fd2
+      - 325f6ebc-c211-4e3b-b00d-a3ea3657ebfc
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:05:45 GMT
+      - Mon, 18 Dec 2023 14:11:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc0551a1-b125-42ad-9923-805c7330c53b
+      - 61381ea8-3e64-45d1-a082-09694f84b0bd
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:15 GMT
+      - Mon, 18 Dec 2023 14:11:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 733f6fa7-bc97-4b67-9b98-6807e32f9424
+      - 9ce2114d-0a21-4aac-9164-a63dcd9ff28a
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:45 GMT
+      - Mon, 18 Dec 2023 14:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0e4cd04-e94a-4086-a73e-cd1586f00d84
+      - 308ab331-4e3f-46eb-996e-201d6436f6c9
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:15 GMT
+      - Mon, 18 Dec 2023 14:12:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c544f5fb-af54-4b30-a6e6-bf0725473854
+      - d1c06604-610e-4075-acad-0be50fd79f68
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:45 GMT
+      - Mon, 18 Dec 2023 14:13:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f479e90-d3e5-4fe8-a060-02533269d42a
+      - d8347b2c-df5f-4520-94bb-f3c95a3c978a
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "942"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:16 GMT
+      - Mon, 18 Dec 2023 14:13:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b13d124-11c2-401f-a491-48fb5a7dab76
+      - 1febd80f-c158-42a0-85f8-38826bb1f56f
     status: 200 OK
     code: 200
     duration: ""
@@ -572,10 +572,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1206"
@@ -584,7 +584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:47 GMT
+      - Mon, 18 Dec 2023 14:14:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d76c418b-1b70-4923-8b4a-0f65ca568bad
+      - 1014050e-3485-427d-a96d-e5a9c8ca8eaf
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:17 GMT
+      - Mon, 18 Dec 2023 14:14:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e35f5b03-9acb-4666-b605-8e9eaa858229
+      - 22aa6ca1-19f7-47b8-bfc4-9c214a8296aa
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:17 GMT
+      - Mon, 18 Dec 2023 14:14:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a25a174-e00d-4c34-b598-23bb91233413
+      - ea321060-7f74-40ce-94da-a7a7d64522df
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:17 GMT
+      - Mon, 18 Dec 2023 14:14:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e63e6e78-5500-4f16-96a4-2bdfd99bea56
+      - a5253f24-48fe-47bf-8366-f837e4f12bc3
     status: 200 OK
     code: 200
     duration: ""
@@ -706,10 +706,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:14:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ab9dc22-cf51-41d3-8f02-3e27256061bf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -718,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:17 GMT
+      - Mon, 18 Dec 2023 14:14:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b36f0b70-f467-4c76-a708-97f8e437d2c9
+      - 982f25f6-25f9-4ca9-bc5a-13829133dfdf
     status: 200 OK
     code: 200
     duration: ""
@@ -739,7 +772,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -751,7 +784,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:17 GMT
+      - Mon, 18 Dec 2023 14:14:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f9770e1-e7d6-418c-b987-4c960229f079
+      - 3cfc654e-d98a-4b11-baf8-2627dbde8577
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:18 GMT
+      - Mon, 18 Dec 2023 14:14:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8d002c0-b8f2-4560-b57a-74c4b29629cb
+      - a5ed0b11-2c3d-48df-abb0-52034493cc33
     status: 200 OK
     code: 200
     duration: ""
@@ -805,10 +838,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:14:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 628c1d7a-0fa6-4ff6-a8f3-21c42d6e7f7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -817,7 +883,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:18 GMT
+      - Mon, 18 Dec 2023 14:14:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4528866-4ac4-4bad-8982-38f1899f2d99
+      - 3ca1039b-bde3-47e3-a756-3dc69a6b615a
     status: 200 OK
     code: 200
     duration: ""
@@ -838,7 +904,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -850,7 +916,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:18 GMT
+      - Mon, 18 Dec 2023 14:14:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1f6f54e-f9c7-4a82-af9d-1d612386c00f
+      - 0b0e1b91-c2cb-4a27-97e6-d50eba6e4e77
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:18 GMT
+      - Mon, 18 Dec 2023 14:14:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e11bb204-c15b-4e9c-b22d-dce24746ec96
+      - aceb92fd-6d76-4dfa-814b-597fcb4df760
     status: 200 OK
     code: 200
     duration: ""
@@ -904,10 +970,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:14:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 03d8e671-b08b-4087-bbf8-bc7bbaa05490
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -916,7 +1015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:18 GMT
+      - Mon, 18 Dec 2023 14:14:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03d85098-bd4a-4cff-bdae-93b0ae14cb59
+      - e45a3eac-7bd8-4e47-b1de-4836356b2614
     status: 200 OK
     code: 200
     duration: ""
@@ -937,7 +1036,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -949,7 +1048,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:19 GMT
+      - Mon, 18 Dec 2023 14:14:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9384d4c6-b6ae-476d-9072-8327c9957f99
+      - ac5ad47b-4bdc-47bd-a534-9ef7bd40defd
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:19 GMT
+      - Mon, 18 Dec 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f87f2ccb-3dc7-4ecc-b182-b16761404dff
+      - 9bee5a6c-7396-4d91-bf91-ab2d421000b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,7 +1104,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
@@ -1017,7 +1116,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:19 GMT
+      - Mon, 18 Dec 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd6e0293-15a7-4e5a-8eb9-f9bede419996
+      - 62d02e99-521e-42c2-9dfa-797f38e2b534
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:19 GMT
+      - Mon, 18 Dec 2023 14:14:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fa1798f-683f-42b7-b07d-47537d56f83b
+      - 897f2bad-a785-42af-8896-38790e50d165
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,7 +1170,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -1083,7 +1182,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:20 GMT
+      - Mon, 18 Dec 2023 14:15:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f56390f8-d174-4bb6-87df-b52233f89873
+      - 2b9e6b19-c85f-44a1-9fd7-31d9db6c6bcc
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:20 GMT
+      - Mon, 18 Dec 2023 14:15:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1746f1d-86b1-4390-99af-94287cde1a2e
+      - 9d0b75d7-6062-4f26-977b-a2ab1c88e2aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,10 +1236,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 20fc8e59-dc3a-4948-98aa-15948941d18b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -1149,7 +1281,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:20 GMT
+      - Mon, 18 Dec 2023 14:15:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79c25f07-761a-4f0c-9e2f-c46b3e0ca43f
+      - 98182b05-8437-41d4-9d29-34b84db916bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,7 +1302,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1182,7 +1314,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:21 GMT
+      - Mon, 18 Dec 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f546eaee-be88-4b70-a9be-8de46cd52479
+      - a8795590-9912-4191-8ea3-b75c1e078827
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,7 +1335,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -1215,7 +1347,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:21 GMT
+      - Mon, 18 Dec 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39591a5e-20c6-4624-8179-923bcf811d9d
+      - 0bf9a018-f0ef-4ff2-b719-3902e0a4d89d
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1368,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:21 GMT
+      - Mon, 18 Dec 2023 14:15:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e38e46ef-ccb0-4f4c-bd22-e62c2a1625c1
+      - 7006560e-ee49-4d30-aab8-415a78550689
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,10 +1401,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:01 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0173dabb-a432-477b-86ba-b1655699e62e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -1281,7 +1446,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:21 GMT
+      - Mon, 18 Dec 2023 14:15:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b2b09d3-6012-470d-bf3a-ad0e6f6da99f
+      - a7627382-90c5-4df2-ab57-f3a8cbc1d236
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,7 +1467,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1314,7 +1479,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:22 GMT
+      - Mon, 18 Dec 2023 14:15:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae01f61b-73e2-4eeb-9954-4cc1052f1067
+      - 9e74577b-3e6f-4c7d-b4b9-e23693049b14
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,7 +1500,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -1347,7 +1512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:22 GMT
+      - Mon, 18 Dec 2023 14:15:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ac8fdfb-4807-47cb-ae73-4c103b2fbe7d
+      - 9537917a-7d49-45e9-b49d-d0a9e2150a06
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:22 GMT
+      - Mon, 18 Dec 2023 14:15:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57ebce7f-b7fe-4168-9d36-15acd09d24a7
+      - a76ed7be-c917-42c1-9bba-523f1ee4d71d
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,7 +1568,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"foo"}'
@@ -1415,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:23 GMT
+      - Mon, 18 Dec 2023 14:15:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90d75fe5-c08b-43db-8fad-409415a78723
+      - 6e0015ea-ec1d-42b3-b9a2-59e3f45c8746
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,19 +1601,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:23 GMT
+      - Mon, 18 Dec 2023 14:15:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae3cb1e7-593c-44f4-a9a4-55540df181c5
+      - fe8e1a97-b609-49d2-84db-aeb5ca896fff
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,7 +1634,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -1481,7 +1646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:23 GMT
+      - Mon, 18 Dec 2023 14:15:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a8e057f-c1f9-4c5c-a3c5-761b2da51792
+      - 713f61e5-8d06-4f5d-bee9-4ee5caf8882e
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:23 GMT
+      - Mon, 18 Dec 2023 14:15:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b8ef940-cd99-4cf1-9081-540ced83540c
+      - 36a59a0c-a43e-4025-a692-b882d89bfc4b
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,10 +1700,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8de7198d-b144-42ff-96ee-de723dafec39
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -1547,7 +1745,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:24 GMT
+      - Mon, 18 Dec 2023 14:15:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f391739-5bc9-4cd8-936e-6d9de44fe7fa
+      - 2fde74c6-92dc-4c0c-820d-507d7dbbf0a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,7 +1766,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1580,7 +1778,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:24 GMT
+      - Mon, 18 Dec 2023 14:15:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9287d9c-921b-43a8-89be-34d059a095d9
+      - 37375711-274f-4246-8e21-eb48ee4b5038
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,19 +1799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:24 GMT
+      - Mon, 18 Dec 2023 14:15:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77c9158a-a927-4602-8d7e-a726a3a7921e
+      - dea9fc07-ae09-47cb-ad9b-6748ce2cf926
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,7 +1832,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -1646,7 +1844,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:24 GMT
+      - Mon, 18 Dec 2023 14:15:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8352a248-5249-4bda-84f5-dbdda99d6bcd
+      - e36dfc52-275e-4841-a77d-66e0883f86c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,7 +1865,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -1679,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:24 GMT
+      - Mon, 18 Dec 2023 14:15:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a8ad7b0-5575-4d8b-9cbb-e17bcc2ece41
+      - f50e14ab-93f1-4507-9124-1417be80b38e
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1898,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:24 GMT
+      - Mon, 18 Dec 2023 14:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f930266e-3ee7-4ea5-bbbc-4a62beb73eab
+      - 8fdff95b-61fa-4e81-b2f2-be21e8e92ad0
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,10 +1931,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 00820a5c-e7fe-497b-824d-353f4eb6e0bb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -1745,7 +1976,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:25 GMT
+      - Mon, 18 Dec 2023 14:15:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 340bc212-afd9-4084-97ee-c0876145f824
+      - ceda7acb-ebde-435f-9b86-1ffd35f7bd49
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,7 +1997,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1778,7 +2009,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:25 GMT
+      - Mon, 18 Dec 2023 14:15:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +2019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 516d7400-1a05-465f-8169-213b30ce2b25
+      - 236a1650-3baa-42ac-b3bb-d478708412aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,7 +2030,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce866691-d393-41c1-b6c3-a04f276be00e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
@@ -1811,7 +2075,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:25 GMT
+      - Mon, 18 Dec 2023 14:15:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +2085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b366fff9-bcd7-4977-a95d-a445f3db1754
+      - da9be524-398f-476a-8423-6f31baef8c9d
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,40 +2096,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1247"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 83332db2-c8e5-4275-8fea-42ff3c7ef230
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -1877,7 +2108,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:25 GMT
+      - Mon, 18 Dec 2023 14:15:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e3ef6db-865a-4fa7-8092-0842d9709138
+      - c971dcf4-8b3a-4daf-acb1-8243ade9a639
     status: 200 OK
     code: 200
     duration: ""
@@ -1898,19 +2129,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:25 GMT
+      - Mon, 18 Dec 2023 14:15:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1920,7 +2151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcb557cc-46a9-4c66-abd5-0da1cbd9b385
+      - bff7a4d1-e9be-4ad4-86af-2b662861535a
     status: 200 OK
     code: 200
     duration: ""
@@ -1933,7 +2164,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"all","user_name":"foo"}'
@@ -1945,7 +2176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:26 GMT
+      - Mon, 18 Dec 2023 14:15:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1955,7 +2186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3894cb9a-9f62-4748-9f6e-6041ffc15bc1
+      - 5f38590c-78c7-451d-ad23-89ffd9de699a
     status: 200 OK
     code: 200
     duration: ""
@@ -1966,19 +2197,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:26 GMT
+      - Mon, 18 Dec 2023 14:15:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1988,7 +2219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3aadb6dd-3805-4478-8de7-1fb9a896d535
+      - 42a4358c-5267-468e-95d9-c7c3f781223c
     status: 200 OK
     code: 200
     duration: ""
@@ -1999,19 +2230,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:26 GMT
+      - Mon, 18 Dec 2023 14:15:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2021,7 +2252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97111a9a-9d57-40e6-8368-dcb4bd861407
+      - 336c62a8-81c4-4043-b086-ffdb5452a66c
     status: 200 OK
     code: 200
     duration: ""
@@ -2032,7 +2263,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2044,7 +2275,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:27 GMT
+      - Mon, 18 Dec 2023 14:15:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2054,7 +2285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8df11b81-1f4c-4bf3-bef6-ad3820558a5b
+      - 04be5fde-4d87-4c46-9d4e-8dffd722925e
     status: 200 OK
     code: 200
     duration: ""
@@ -2065,7 +2296,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2077,7 +2308,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:27 GMT
+      - Mon, 18 Dec 2023 14:15:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2087,7 +2318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f103e455-8bcb-449e-bf7f-562b1764f72b
+      - 5a59d8f2-9b29-4c2f-a4cb-196745401863
     status: 200 OK
     code: 200
     duration: ""
@@ -2098,19 +2329,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:28 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2120,7 +2351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea16299f-ccab-4cac-b932-3b14d18854ce
+      - 5705b684-c74f-4345-b12e-c5a535c9346e
     status: 200 OK
     code: 200
     duration: ""
@@ -2131,10 +2362,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1307da2a-37bd-4158-b9df-117ea13b1359
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -2143,7 +2407,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:30 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2153,7 +2417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70008fcf-ae47-450b-adfe-58df374d5963
+      - 2e311f87-f0ea-4459-bcab-c81460ebb385
     status: 200 OK
     code: 200
     duration: ""
@@ -2164,7 +2428,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -2176,7 +2440,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:30 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2186,7 +2450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b62d7dcc-655a-41e1-a822-2e8b49f9c06e
+      - c0679258-b8eb-4072-832d-79d5e7854f59
     status: 200 OK
     code: 200
     duration: ""
@@ -2197,7 +2461,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d614c847-8402-4dfc-8803-1cd56055d550
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
@@ -2209,7 +2506,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:31 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2219,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbb86451-d905-44a2-8037-7fafeaa86ff4
+      - e7bdf52a-e9d2-4b88-b86e-993e1697a41e
     status: 200 OK
     code: 200
     duration: ""
@@ -2230,40 +2527,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1247"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e3bd908b-f741-48cc-bfcc-7bf04aeb421d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2275,7 +2539,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:33 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2285,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 541a3098-920b-47b3-8218-7c3abea4e15a
+      - 2e6259fc-6028-4010-8431-f33abf4576ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2296,19 +2560,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:33 GMT
+      - Mon, 18 Dec 2023 14:15:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2318,7 +2582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05ac62a7-33af-47e2-af60-3632f980bced
+      - 10200d72-010e-4c02-af8b-2e93e981f93f
     status: 200 OK
     code: 200
     duration: ""
@@ -2329,7 +2593,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2341,7 +2605,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:33 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2351,7 +2615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d418c97b-1afd-44dc-ab4d-3ef9f2061a1a
+      - cc15df23-d2ca-47e8-b315-bce925b15fcb
     status: 200 OK
     code: 200
     duration: ""
@@ -2362,7 +2626,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2374,7 +2638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:33 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2384,7 +2648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f04595a-03f6-405e-96d5-b1cff5295b2a
+      - 534d85a6-1fd0-46e1-985d-e29b8887483d
     status: 200 OK
     code: 200
     duration: ""
@@ -2395,19 +2659,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:34 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2417,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06a6258d-ca54-46eb-838a-746bd5b38605
+      - ea360196-d52b-472f-a50a-58f115ee7936
     status: 200 OK
     code: 200
     duration: ""
@@ -2428,10 +2692,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 80abf682-a4b8-4be1-bccc-4de680dd0c61
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -2440,7 +2737,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:34 GMT
+      - Mon, 18 Dec 2023 14:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2450,7 +2747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ba367e9-6d25-48c8-a074-c2ddda182218
+      - cab53cd6-de41-4d62-a2db-2bec77f70d34
     status: 200 OK
     code: 200
     duration: ""
@@ -2461,7 +2758,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -2473,7 +2770,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:34 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2483,7 +2780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad35d426-03d7-4ef0-a978-7b1cf410faa7
+      - 31ff637d-6b4d-4f46-ac70-d48b54ce547f
     status: 200 OK
     code: 200
     duration: ""
@@ -2494,7 +2791,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e22f6ef3-0bbb-48ce-9f4a-71c991f203d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
@@ -2506,7 +2836,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:34 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2516,7 +2846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a42d6eda-944e-4bf6-a749-aa58c800f6ad
+      - 8760359a-0d9c-456e-b189-ca7a215b0022
     status: 200 OK
     code: 200
     duration: ""
@@ -2527,40 +2857,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1247"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ed9f7183-82b6-458c-ae14-95a23c2080ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2572,7 +2869,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:34 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2582,7 +2879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95d87521-87c0-4813-8ec2-4636a8431d39
+      - 93c7a938-b651-4672-87af-f7257aefcf6c
     status: 200 OK
     code: 200
     duration: ""
@@ -2593,19 +2890,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:35 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2615,7 +2912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad2cf0ff-b9cf-4873-acbf-fb6cf0ed04d1
+      - 8c4e2418-b106-4d6f-b0c9-615cbf1f2a32
     status: 200 OK
     code: 200
     duration: ""
@@ -2626,19 +2923,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:35 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2648,7 +2945,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91cd05d8-6b4e-4a79-ba92-a31bef0a98a2
+      - e533fbe9-873b-4cbd-8ef0-71859603a6f4
     status: 200 OK
     code: 200
     duration: ""
@@ -2659,40 +2956,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 919fed72-c91b-4a1c-8a39-ed9882391170
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2704,7 +2968,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:35 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2714,7 +2978,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85b01e2e-e014-46f2-bebd-94dd8005786e
+      - 6bb637c3-9ad9-4b08-8cfd-8be68b6b721f
     status: 200 OK
     code: 200
     duration: ""
@@ -2725,7 +2989,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60e2e1f1-a7f9-48b6-8bb5-d187929eee60
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2737,7 +3034,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:35 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2747,7 +3044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b098edb4-53ed-4aef-a7f0-b48290572af0
+      - e27a2c12-ef08-4a69-902e-5a4ac193cb20
     status: 200 OK
     code: 200
     duration: ""
@@ -2758,7 +3055,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2770,7 +3067,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:36 GMT
+      - Mon, 18 Dec 2023 14:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2780,7 +3077,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d88b2d30-163d-486b-954b-5c8801b46787
+      - aa5a6a5b-0588-4f1a-841d-23e98d4d7333
     status: 200 OK
     code: 200
     duration: ""
@@ -2791,19 +3088,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:36 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2813,7 +3110,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2920de9b-dcef-4e08-b5ae-cec13d79c70d
+      - 90b5ea11-8ddd-493e-a59c-6870cbd62dbd
     status: 200 OK
     code: 200
     duration: ""
@@ -2824,7 +3121,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2836,7 +3133,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:36 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2846,7 +3143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38518aae-56bc-4a25-be03-eb80ae7b9ae1
+      - cbe6e448-8a87-4ac4-8c95-d05a3a39f46b
     status: 200 OK
     code: 200
     duration: ""
@@ -2857,7 +3154,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -2869,7 +3166,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:36 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2879,7 +3176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb10fa4f-0641-4de9-8524-9ac3e7186456
+      - a951d6c9-8d82-48d0-a3a7-b5fdeffdc711
     status: 200 OK
     code: 200
     duration: ""
@@ -2890,7 +3187,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
@@ -2902,7 +3199,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:37 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2912,7 +3209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a07565b-d318-4bba-b56f-f2349d1bdbd1
+      - 4cc42b12-5cc6-412e-a8f1-803ac5c0fc49
     status: 200 OK
     code: 200
     duration: ""
@@ -2923,19 +3220,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:37 GMT
+      - Mon, 18 Dec 2023 14:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2945,7 +3242,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1bee461-451c-4556-8cf2-1a2cc5cbcb61
+      - fdd05789-731a-42c9-b395-146e36968a24
     status: 200 OK
     code: 200
     duration: ""
@@ -2956,7 +3253,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -2968,7 +3265,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:37 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2978,7 +3275,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 420b4283-5e63-4593-9728-0d771d6bfe89
+      - 7c3154f5-b32f-44bc-acd4-51f180d4bb4c
     status: 200 OK
     code: 200
     duration: ""
@@ -2989,7 +3286,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3001,7 +3298,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:37 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3011,7 +3308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 560bbd54-a8aa-4455-817c-315ea8193ff2
+      - 677df747-9efa-4378-af08-50a79e340c22
     status: 200 OK
     code: 200
     duration: ""
@@ -3022,19 +3319,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3044,7 +3341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2909b22f-2f50-477e-ae0a-0a49d84d3831
+      - 0200d16a-5423-438a-a6b4-ab41cadd226f
     status: 200 OK
     code: 200
     duration: ""
@@ -3055,10 +3352,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01ad19af-bc8b-49d1-899b-fd9a616fd995
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -3067,7 +3397,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3077,7 +3407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96c259f7-1fe4-484d-88e0-e148658ac32c
+      - 06668763-90e8-474d-8d81-78f38f181084
     status: 200 OK
     code: 200
     duration: ""
@@ -3088,7 +3418,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -3100,7 +3430,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:38 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3110,7 +3440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01c8ad1f-e04d-4edc-825d-49bb5c6a4a05
+      - 0f45592a-c3e5-4595-aac0-5dc178a5da79
     status: 200 OK
     code: 200
     duration: ""
@@ -3121,19 +3451,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:38 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3143,7 +3473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65697e61-a92c-4717-ae17-d48be3ba4acd
+      - 319c9187-cd1d-4212-9ae6-76cd8ff3cdaa
     status: 200 OK
     code: 200
     duration: ""
@@ -3154,7 +3484,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
@@ -3166,7 +3496,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:38 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3176,7 +3506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2df5e79-4e54-480b-92b9-fc80e669b197
+      - ab15f0a9-ac7c-4a2e-b953-ecb284a4f352
     status: 200 OK
     code: 200
     duration: ""
@@ -3187,7 +3517,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3199,7 +3529,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:38 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3209,7 +3539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a726a5ba-2d79-4d18-80d0-d18c24916781
+      - 74464356-a550-40b2-a62c-80e0f45809c8
     status: 200 OK
     code: 200
     duration: ""
@@ -3220,19 +3550,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3242,7 +3572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73ee6c63-61cf-451e-9e71-35a788bb318f
+      - a6fb9192-a57a-48b7-a18b-d2e59e6b9d14
     status: 200 OK
     code: 200
     duration: ""
@@ -3253,19 +3583,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3275,7 +3605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a888a21e-ae3e-4ce9-9d87-dc713eb08f23
+      - 70b480bb-a0d6-48fb-aa1e-f5f4aec2d602
     status: 200 OK
     code: 200
     duration: ""
@@ -3286,40 +3616,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ad45bd20-ecb4-45b9-a95a-d07c8489ed9e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3331,7 +3628,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3341,7 +3638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b36b341-f760-4ca8-8428-14871f686c22
+      - 8a8e1955-1e98-4bc5-b8af-f00c2dc1ef78
     status: 200 OK
     code: 200
     duration: ""
@@ -3352,7 +3649,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 09e51cc5-dadf-4003-871e-065a6f777166
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3364,7 +3694,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3374,7 +3704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7e0003e-19fb-4c3e-8920-2ade1ca9c7ca
+      - 69981e7d-3dc8-46c0-9a68-3543474a1f08
     status: 200 OK
     code: 200
     duration: ""
@@ -3385,7 +3715,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3397,7 +3727,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3407,7 +3737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18486b20-bf0e-47ec-b844-18cf932cf2aa
+      - 1f14faba-1fce-43b3-b72e-6cb25f37aa86
     status: 200 OK
     code: 200
     duration: ""
@@ -3418,19 +3748,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:39 GMT
+      - Mon, 18 Dec 2023 14:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3440,7 +3770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b89d657-565b-4868-826c-21709894bc57
+      - dd743a10-ef29-4cbc-93f6-506c07c95447
     status: 200 OK
     code: 200
     duration: ""
@@ -3451,7 +3781,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3463,7 +3793,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
+      - Mon, 18 Dec 2023 14:15:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3473,7 +3803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f75c7edd-4c03-4d10-a3ba-2c80a3af67f1
+      - 3f042354-c40a-4f07-9e36-2ff206eb7d9d
     status: 200 OK
     code: 200
     duration: ""
@@ -3484,7 +3814,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3496,7 +3826,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
+      - Mon, 18 Dec 2023 14:15:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3506,7 +3836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34fcc17f-2964-443d-9aa2-73ffe77809fb
+      - 5da25818-e4b2-4ed9-809d-091d257dc68b
     status: 200 OK
     code: 200
     duration: ""
@@ -3517,19 +3847,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
+      - Mon, 18 Dec 2023 14:15:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3539,7 +3869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82fb15a8-5a49-4c1b-aeda-d434d1939733
+      - 88c1fe69-5495-416b-a00a-f68782e3a792
     status: 200 OK
     code: 200
     duration: ""
@@ -3550,19 +3880,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
+      - Mon, 18 Dec 2023 14:15:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3572,7 +3902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcdb08c2-de92-4930-b2df-ccc37f731497
+      - cc8f76f8-665d-496b-ba32-a9e3e22b881f
     status: 200 OK
     code: 200
     duration: ""
@@ -3583,40 +3913,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1247"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8015896d-7b7c-40be-88a2-25922d4507f8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
@@ -3628,7 +3925,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
+      - Mon, 18 Dec 2023 14:15:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3638,7 +3935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 461ae199-a992-495a-a756-e62b1e6ca9e1
+      - 747c69b2-a4f3-4549-ad0c-c962f958ba4b
     status: 200 OK
     code: 200
     duration: ""
@@ -3649,10 +3946,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1249"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb8ad014-451a-4406-be6e-82e4026f9669
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c647624-2ce5-43c4-81d5-0f5156f0ba58
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9c1bb95-ac54-4b34-9469-dcde8676ba02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dfa2f3e7-487b-4a56-899b-b45e75116d34
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -3661,7 +4090,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
+      - Mon, 18 Dec 2023 14:15:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3671,7 +4100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5abdd7b-22e2-49e7-a7df-bcf5e99eace4
+      - 784b5b85-09d4-4608-a55a-81e51c77bf13
     status: 200 OK
     code: 200
     duration: ""
@@ -3682,73 +4111,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7c385033-7c72-4c91-8407-f9b33000ff71
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 03490410-f493-4684-a96d-ea5c52bc374d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -3760,7 +4123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:40 GMT
+      - Mon, 18 Dec 2023 14:15:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3770,7 +4133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3371e09-7fc7-4032-9e10-5f9e41ba4a1b
+      - 868f5356-f25b-42cf-87ce-1b728cd95860
     status: 200 OK
     code: 200
     duration: ""
@@ -3781,7 +4144,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges?database_name=foo&order_by=user_name_asc&user_name=foo
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"foo"}],"total_count":1}'
@@ -3793,7 +4156,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:41 GMT
+      - Mon, 18 Dec 2023 14:15:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3803,7 +4166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ba445fc-d776-4d62-8f5a-836a4fe7a3d0
+      - 664ebae1-7c88-4e17-ae61-9f369156e402
     status: 200 OK
     code: 200
     duration: ""
@@ -3814,19 +4177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:41 GMT
+      - Mon, 18 Dec 2023 14:15:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3836,7 +4199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5480e9df-6fc0-4cd7-bc93-a6f68350ac35
+      - 5cc92e4b-f185-46ac-b20f-f43159a160cf
     status: 200 OK
     code: 200
     duration: ""
@@ -3847,40 +4210,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:09:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd095af5-9060-446a-8a17-b9e47f372319
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
@@ -3892,7 +4222,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:41 GMT
+      - Mon, 18 Dec 2023 14:15:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3902,7 +4232,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 827ec380-2cf9-473e-88db-b2219eae6be3
+      - e21b984b-9f40-4b35-9d92-19e8a53798c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7239ba33-0ae5-440c-9b78-c6b5f5b3e4d8
     status: 200 OK
     code: 200
     duration: ""
@@ -3915,7 +4278,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"foo"}'
@@ -3927,7 +4290,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:42 GMT
+      - Mon, 18 Dec 2023 14:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3937,7 +4300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51912f73-0924-4189-aecd-76fec310d0f2
+      - 4b23299b-2e3f-4892-ab30-1110cdba8c9a
     status: 200 OK
     code: 200
     duration: ""
@@ -3948,19 +4311,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:42 GMT
+      - Mon, 18 Dec 2023 14:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3970,7 +4333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9cc3ebc-bdfd-4f39-9ac1-4f739145b3e3
+      - e4d56b35-5729-4245-a2f7-ffc815198599
     status: 200 OK
     code: 200
     duration: ""
@@ -3981,19 +4344,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:42 GMT
+      - Mon, 18 Dec 2023 14:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4003,7 +4366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7edab1f3-eebf-4b90-be75-1fc12d337d3b
+      - 61b7724d-e612-4807-baa9-d5c46efa3fbd
     status: 200 OK
     code: 200
     duration: ""
@@ -4014,19 +4377,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:42 GMT
+      - Mon, 18 Dec 2023 14:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4036,7 +4399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 847513d9-4baa-4b50-a6da-eda92eb2fa93
+      - d26ed87e-4ce8-46bd-8c12-5ccfe00bc085
     status: 200 OK
     code: 200
     duration: ""
@@ -4047,7 +4410,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/users/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users/foo
     method: DELETE
   response:
     body: ""
@@ -4057,7 +4420,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:42 GMT
+      - Mon, 18 Dec 2023 14:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4067,7 +4430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cce3a89-459e-474e-8f69-6da92635c186
+      - d2a7ec6a-5206-4fd9-a8f3-f8d2eeb4bfb0
     status: 204 No Content
     code: 204
     duration: ""
@@ -4078,7 +4441,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/databases/foo
     method: DELETE
   response:
     body: ""
@@ -4088,7 +4451,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:42 GMT
+      - Mon, 18 Dec 2023 14:15:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4098,7 +4461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e683de9-e1c9-42d4-b7da-ad35e1e3c68d
+      - 7a54184b-3ed3-44cb-8099-302d63d1aecf
     status: 204 No Content
     code: 204
     duration: ""
@@ -4109,19 +4472,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:43 GMT
+      - Mon, 18 Dec 2023 14:15:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4131,7 +4494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44385390-3b0d-45df-9f3d-b5d82d928d67
+      - 01c7cf04-5b71-4db0-acce-07339e4724b5
     status: 200 OK
     code: 200
     duration: ""
@@ -4142,19 +4505,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:43 GMT
+      - Mon, 18 Dec 2023 14:15:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4164,7 +4527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6366e6d6-9e2e-4732-ad37-2737c9bf3852
+      - 16efaba6-2572-4b5e-8589-d7eaf0f8a960
     status: 200 OK
     code: 200
     duration: ""
@@ -4175,10 +4538,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVUENwYVBRc2VvRDcxTGxBQjlVYVV1aGhaKzU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNd09ETTFXaGNOTXpNeE1qRTFNVE13T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtrbVlJWGtQNGRQNkVqRDFTUkorM3NxRkdkaDBjOEdrNDJiMi9hRlI3YUQrU3kvTE5SK0gzQkgKYjN1ZHlxZnFBU3poTGh2NWMvakl1dmNLbDNEUzk4UlBSdlNBT2M4aGpxam5JdHF2MWdkVmZtbGVUNUtHQmc4UApjQUNMMEgyOW9LdlB3TUZyRkxTU1dYek5QTWVRaG5uOWZOUS9hT052WlczcHZOeXBQZXQ1djZIWWxXcytYSHBXCkdLdFpWWHdJNWplSDFZRFZnZktCREFCRWFoUWRnYWhLZ3ZZK0VVdHd0ck9FdGszMTkrQVppK1Z6aTBuaDBmVEMKc2dnWTRPRExlV2YrZkROZktjcVRtYWFlWExBVWNGekQvTytlZXMyL2NSSDY5RGlJdGQ4Y29lSjM5c2lEald4Qgp5VjJVR3FvRjlldThkMFlLbXB4ODM3aVZVYW5QN1lrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHlNbVF3TW1ZeE5pMDRaVFptTFRRNU9XSXRZamc1TlMwNVlUVTEKTVRReU56VTRabVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEl5WkRBeVpqRTJMVGhsTm1ZdE5EazVZaTFpT0RrMUxUbGhOVFV4TkRJM05UaG1aUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytCUTRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKYk4wRStLaHVhdnJhSUs3ZG9MdzZ6SVVJUDNMblllL1pxZ2dzSDBUZVpXa3h6cThhMnozNVJwMitHVGk1VUFaQgo1c0hqVUdzdzhXdG1zaU9icUtyQWNnRzc4Ui9HUzd0aE15Unk2UkNsS2wwcS90SXZkdE5VWVE5YWRSQThZTm01ClB3VlFhd3YxT3YvUU44VWxHVFlpZ2Z2OGE4WTFlL0t2bmhlUjBCaHlzNTJ1VEltcGwvRmZiZkIrSUVnKzF2T1cKYWpmUGk5WHA4MmJ5cnRtZ3htY0JOazR6Z3NXd3ZFbWRTcmg2UmVBM3VTUXBsa3YzT2t5YjV4cmpsdUlZME80NApNYjFudXZXLzRPNk1sQ2tMaG00WjRWWWlMLzVhTUtoTUFPUEdmbHZwcG94QWYrSTJtZ3hYN2ZZdHk2UzBnbVZTCkVIUnZSd0xYKzdYWEl3cGwxSHBaa2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 147bcfd4-5b81-449f-a688-9b26d152cda6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRFd6Vk5HbTJDYnlRV2prdUhwZVkzYVR1d3Ewd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5ESXlXaGNOTXpNeE1qRTFNVFF4TkRJeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtb1gyVWVDYWtDbHdab3NNUS9TS1Uwbk9NZTc0OFpFWXRVNjkzMjIxb1IzRG1aL3NPeEg5cDUKMWR2ZmlkZTNkR0xrNFJpdjdib0NUOS8zejdSWEdnbytLMkFsdkQ1K0REZFVvWVpiZDJjVEtJcENHd29RNUs3WQo0aEJBWk56NWcyT2tjN3NLN0t5N0hldGVNcDlZVXI0V1dzemNMZUcyOEVDWDB4dU5vT1FYOFh6Q2IzcWdpMWhpCjVwS0xtTjlqTjAxQ2VNYklERVQ1NkZyNjNDaWpBMnN1OHVBNG9nUzE1M1ZRN2loYm11c3dIdTV4T0UyQTd6aDAKc1hySUVtQnNwN3FBclFWaU1EQzFJZVJCa1dxUlNyYjZ0K0ZtNlYvdWRPYnRtenlSNzhrdGJvMGpyUnpoVzdSMwplK1VHSFpPcDB2ZVlwaEQwVkhqM3JmbDRzVzdnOWUwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MWtPRGRtTlRrM055MHpaVFl3TFRSa01XVXRZbU5rTnkwNU16ZzEKWTJSbE5HRXdZbVV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMV1E0TjJZMU9UYzNMVE5sTmpBdE5HUXhaUzFpWTJRM0xUa3pPRFZqWkdVMFlUQmlaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdytDNm9jRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbHhyUzF2M1lNMnk4VVlJSTV5aHJXQVp1RFZjUmg2RWRqMlcwZUxlZHNxR0s2ZlZrenpsM1BqNVc0WEp6VEZDdQp3U3J5VFlReVpxUEVyM2ZlOWxDOEhPVFgxN29YRmJubDcrMC9HdnplVHNVV1FHd3Z2OXlydXMyQ3hXbkwxQ2ttCnZaekVEN2J4WnBTdXVCaDl4blRHaG1iVDBVTE5aaGVHaUVreWl2RnBlMUM1VGVCUmVFUGp1aVFyT2tVSWpkeXcKZzZZOGRNQlNtNmxSYVM2czBLK2c1Y3hncFQyRUo5cmoyQnpiMDhZTEdBL0R3MnlPcGVaeEVsOS91OWFZcWZDNgpKd2FQTVZpNVFBNHI2THZSTHZwWmd4MCt1SWE0b1VBbzVoK2hrdFBKOXcra3BqVUxrOHo0MC93NDBqMVNNeDRUCnJQcHF4dUZGMU1EaG5TUzE2WHJJQ0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2007"
@@ -4187,7 +4583,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:43 GMT
+      - Mon, 18 Dec 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4197,7 +4593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 012e43cd-1b78-4793-ab72-bb094c17bf37
+      - a19cb6b4-bd99-4b8c-bd58-a1d7f6e53b93
     status: 200 OK
     code: 200
     duration: ""
@@ -4208,7 +4604,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=22d02f16-8e6f-499b-b895-9a55142758fe&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d87f5977-3e60-4d1e-bcd7-9385cde4a0be&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -4220,7 +4616,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:43 GMT
+      - Mon, 18 Dec 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4230,7 +4626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f840ce87-c07c-4f18-81d3-5ffb17bf38e4
+      - cbfa7c26-f2b6-41b7-af3f-1108390fe5c3
     status: 200 OK
     code: 200
     duration: ""
@@ -4241,19 +4637,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:44 GMT
+      - Mon, 18 Dec 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4263,7 +4659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67f2152d-36ac-489e-b74f-deeda01aa003
+      - 823bc6a0-5151-4c49-b383-3408aec656bc
     status: 200 OK
     code: 200
     duration: ""
@@ -4274,19 +4670,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1252"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:44 GMT
+      - Mon, 18 Dec 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4296,7 +4692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de2d69df-1d69-4b59-b10c-ae7b7f25b727
+      - f2516030-9bb9-47ac-a5f9-05b90b60d7ed
     status: 200 OK
     code: 200
     duration: ""
@@ -4307,19 +4703,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:05:44.752482Z","retention":7},"created_at":"2023-12-18T13:05:44.752482Z","endpoint":{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174},"endpoints":[{"id":"d38e25a2-bffe-4d47-8cbe-36acb2d24a31","ip":"51.159.74.238","load_balancer":{},"name":null,"port":6174}],"engine":"PostgreSQL-15","id":"22d02f16-8e6f-499b-b895-9a55142758fe","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:11:18.985257Z","retention":7},"created_at":"2023-12-18T14:11:18.985257Z","endpoint":{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884},"endpoints":[{"id":"feaa002e-462d-4aa5-b798-91d4ca1aed30","ip":"51.159.112.97","load_balancer":{},"name":null,"port":16884}],"engine":"PostgreSQL-15","id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-privilege","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1252"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:44 GMT
+      - Mon, 18 Dec 2023 14:15:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4329,7 +4725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ac10380-ad38-48b9-9b85-5448dac0ba11
+      - 4751282d-37a2-433d-a32b-23dade2d3ca3
     status: 200 OK
     code: 200
     duration: ""
@@ -4340,10 +4736,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"22d02f16-8e6f-499b-b895-9a55142758fe","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4352,7 +4748,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:15 GMT
+      - Mon, 18 Dec 2023 14:15:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4362,7 +4758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a579ad0-6dcc-466d-acc3-4b7a2d4b3cd6
+      - a0466f04-ed66-4ec2-9447-518c944b5559
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4373,10 +4769,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/22d02f16-8e6f-499b-b895-9a55142758fe
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d87f5977-3e60-4d1e-bcd7-9385cde4a0be
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"22d02f16-8e6f-499b-b895-9a55142758fe","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"d87f5977-3e60-4d1e-bcd7-9385cde4a0be","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4385,7 +4781,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:15 GMT
+      - Mon, 18 Dec 2023 14:15:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4395,7 +4791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b0d7071-6ac0-4ef1-a7e1-a73851e3f542
+      - 1ba9503b-e0af-4fdd-bcd6-4bb116d8259b
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/iot-route-rdb.cassette.yaml
+++ b/scaleway/testdata/iot-route-rdb.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:22:44 GMT
+      - Mon, 18 Dec 2023 10:26:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58bb7ffa-72b5-4f24-ae59-28ffce972af8
+      - 416523a7-cdef-4984-aa02-6c57f1b11bc7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"minimal","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","disable_events":null,"events_topic_prefix":"$SCW/events"}'
+    body: '{"name":"minimal","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","events_topic_prefix":"$SCW/events"}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs
     method: POST
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"enabling","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"enabling","updated_at":"2023-12-18T10:26:35.746Z"}'
     headers:
       Content-Length:
-      - "548"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:22:47 GMT
+      - Mon, 18 Dec 2023 10:26:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e885a82-9f89-466a-9aba-a25aa90bfcb9
+      - 98854915-c481-47f7-bd8c-93c77baf14c3
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: GET
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"enabling","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","updated_at":"2023-12-18T10:26:35.746Z"}'
     headers:
       Content-Length:
-      - "548"
+      - "529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:22:47 GMT
+      - Mon, 18 Dec 2023 10:26:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e93ee33-ff83-4e19-8f9f-a7a98050aecf
+      - 692b6014-2d25-4211-adb1-e2614ec63293
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: GET
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","updated_at":"2023-12-18T10:26:35.746Z"}'
     headers:
       Content-Length:
-      - "545"
+      - "529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:22:52 GMT
+      - Mon, 18 Dec 2023 10:26:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,45 +429,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25b25ed0-d314-49c3-96be-cf20f7ed08b0
+      - b59eb837-7ff3-4fb4-b757-0a670e4cf188
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
-    method: GET
-  response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","updated_at":"2023-10-20T16:22:46.933Z"}'
-    headers:
-      Content-Length:
-      - "545"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 20 Oct 2023 16:22:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cc5ec8fd-0663-4a76-bd3f-f7e3d697b49d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"minimal","engine":"PostgreSQL-15","user_name":"root","password":"T3stP4ssw0rdD0N0tUs3!","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"minimal","engine":"PostgreSQL-15","user_name":"root","password":"T3stP4ssw0rdD0N0tUs3!","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -478,16 +445,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "724"
+      - "863"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:22:53 GMT
+      - Mon, 18 Dec 2023 10:26:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - beb30cfe-9c53-4368-a3f5-c5441b6f639d
+      - 30a1ae49-ccfb-488f-a47d-dcdc210c7adf
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "724"
+      - "863"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:22:54 GMT
+      - Mon, 18 Dec 2023 10:26:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61c4a1f3-33b8-4268-857b-c08e72f9b749
+      - 3636f0c9-4cda-4f0a-9009-47acd8662966
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "724"
+      - "863"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:23:24 GMT
+      - Mon, 18 Dec 2023 10:27:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a779a556-b399-4b95-9bd7-b3cce9245aff
+      - 5cf715b6-aac9-4c0d-9f37-b8fed78bfb94
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "724"
+      - "863"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:23:54 GMT
+      - Mon, 18 Dec 2023 10:27:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22c444e9-b012-445e-9b3a-738de0754572
+      - 8e1e5014-5670-4f4c-8b59-3818ccb18369
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "724"
+      - "863"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:24:25 GMT
+      - Mon, 18 Dec 2023 10:28:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df9a0bd2-ac67-4876-af43-5f933f91503f
+      - 811963ab-8c05-455a-b7ba-cc8ece234506
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "724"
+      - "863"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:24:55 GMT
+      - Mon, 18 Dec 2023 10:28:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e582848-ed12-43b9-8c37-d6a14fb56404
+      - 8c61def2-a589-4c27-90ca-213406fc142d
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "724"
+      - "863"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:25 GMT
+      - Mon, 18 Dec 2023 10:29:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20458f63-7eba-4ba3-ab70-2d2407c5e1ea
+      - 33901cb8-ec5d-4f86-8691-beb3c87cc597
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086},"endpoints":[{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086}],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1127"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:56 GMT
+      - Mon, 18 Dec 2023 10:29:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53075bcd-a518-437f-8651-bed44db07289
+      - 082c773e-6ce0-4967-a919-d2962de47a6d
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVWXF5RzZ5cFZnTU1SQnBNNE8rWTJZZU52NGlVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxT1M0eE5EQWVGdzB5Ck16RXdNakF4TmpJek16SmFGdzB6TXpFd01UY3hOakl6TXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5Ua3VNVFF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURmT1ptckdKY2FGbUcrTkZ3NWo1ODRBeXBkSG9ycjlDOThXY2NyTTdUcGV0WHpaQTJ4Wm9sUnRHUVcKTmc5Qkx5Tlhad1NnR0Jmb1JvdnZ4dngyNlNwR0xpTmpsMzRHQnRqQk9KTUFCdnN5bStxSFdVRys1Umt5bm9USwpUQTErd0tCa1pza29YWGpWYy9sVGJYczZucDh4cTFaVlRocHIxNDByanlKSTIvbnIxNWFFL0srNjdKUyt4T002CnpidEdXMmI5d1BCam0vdGdIbUJDUURUbFBacjMyRHdsK3cvaEIzMjBxWlM5aVpkMk81S25TTXNVUzVSNmFVQzUKdjNic28yQ3pnVDVjUzVVTUJzSUJTUzB4TWZBdlRYV3FYOEdFMXhKWFNCVkhyRnJNTGR6MXUreXRGQlMyV0lGagp2NVNMeXVIT21lRk42UmM4NkNoQzN3U1NCMmxoQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9DNDFPUzR4TklJOGNuY3RaRGhsTmpJNU56RXRPVEl3T1MwME1UVTVMVGc0WkRRdFpHRmlObU5sTWpFMlpURmsKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOERYaHdRem5qc09NQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFDSWFNWCt3TFVMQWtzTFZIZi9TVS9PMy9ydVRMbWY3a2VqcTdxRWV3Rll4WHplNm9jWWwzN2FwK1hxCjl6Z3ZKbVZOWXJUTjRCazlWSHN0aUhRWk4xMHlDaFZXM1JNT0MrMGVoQTRnQzV0T2F4ZEJKdzBGdDdQc0J5OUsKaThzUlpsWnc0UVlmd0t2ZEI5bHpQM1RSQ3FxTkg0V3J5YmxKdThHYU1VcW00cjZMeXljUWVKeEVKcnhORTNwcgpHY0F6K3dQM1J5Nk1vSFNlYktKdncwUUJteFJOOXhaZHdUbU5hcnUzeTdzUElNNC9seVFYWFUxSGZNNldiR28vCksvSkJ6UzBsOC85cE5FeEVEZnRkN2ZJTlVjWTdhemdDSUVtRTVybVdCY08rRTZJZm13SktMZEVYQkZVcHZDR24KY3l1L002S2FkSkN2UmFuV1VGZjdCV01RWnhtVAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1841"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:57 GMT
+      - Mon, 18 Dec 2023 10:30:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d74e81e1-2b1d-49d3-8c69-8a7016fe4713
+      - 4def826b-4aa6-4665-8b45-8bc957afd73e
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849/certificate
     method: GET
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRFZma2owZWpMdUViVy93Y1kweDNYVzJRekk4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRneE1ESTVNalZhRncwek16RXlNVFV4TURJNU1qVmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ1FVUWRaVXgzYnVZSE5ueW95RkhjMk9FY2VNWExtRlNRTzlyNkUxeEdWbmF1K0ltcVUKcG52UllST1d1UksxVlpZTUpPZXFxVlJpckxOWFJwRTgyVERDRUxaOFp0NmUzc0VYYVJBZWRqbDR3TzVOSHcyQwpTWFN4bTFCNnpxOElNOEFFMlJsTy9PNXlNdXcrVFc5LzFKcGFWSDlvL2JBWm52dk9zallPZkJqTUhIc2VMT1RtCnBKNGtibFdaVFJUUnhQdnFya3I5UDBCM0RrQlBYWXVqQ1RFM0kxZG1RV29xbTVjVUdWYStrZU82blplaXJTZ1kKay9KYXpGdmk5SU1peDFxU0lEMDY4ZFpnZVo0Y2NtY3BzSmUzUGdyNzlRakxhYVdCR2Zqc1NrUzE4amNWUFV4dQpmdm5RSVgzTVFFVmtkaG1CeUlkTjhxZHJBZXc3TlZjTG1XUkZBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNE5qaGxaamcwWXkwNFpUZGtMVFEyWXpndE9UVmwKTlMweE4ySTBNekkxTnpBNE5Ea3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPRFk0WldZNE5HTXRPR1UzWkMwME5tTTRMVGsxWlRVdE1UZGlORE15TlRjd09EUTVMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpublE5aHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNGYWFRRnRBMmwvQSs4RWRnOVhWMFdPbWFQWDNHaGNRT2x2bWd1SmpRUW10RWNEOU01aGNVTQoreDVhVjIxUDNIZlNodWczSWhvS1RWemd0dGVScUVaMzVJTVZ3aFpPUW9YUUlKUnpKbEZ1eVN0OWRPSnNBcnBICnBxZnJXUGIrK05TQ1hmTGt6ZHIyakEzZmQzR1Q0YTJicFRDT0dydWVNVlRMeVFqdkhlYi9Pbm80cVRLZ2dnVTgKRnI5SWVRbnNTL2EwUVk5OU43WTI2eTR1K0NlWW5NbC9ncTZ6dUtjaFRiRHU0a3BGTFpDdlc2WEJ2Q0NKQ2ZENwovL1RYYWpodWxFaGE1aDRjNDRHM3dXcEVkNm5KUHc3dTdXT1VaUlE4elRXVy9DT0VVT2RZUmV2Ryt2dTN6SG1IClFIa0VZVEFsVzI4TkNwbFlIbHlRYlEvcW5tbFFnQVpKCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "545"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:58 GMT
+      - Mon, 18 Dec 2023 10:30:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,12 +761,78 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b13cb95-6e86-4aa8-b171-a2ad2b0c4376
+      - 41dcc221-1416-4f07-982b-be571d93a4b4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"default","hub_id":"af349c53-39aa-4f58-9883-25c72a28794c","topic":"#","db_config":{"host":"51.158.59.14","port":19086,"dbname":"rdb","username":"root","password":"T3stP4ssw0rdD0N0tUs3!","query":"SELECT
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=868ef84c-8e7d-46c8-95e5-17b432570849&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 10:30:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0eb42823-fbba-4c0d-93e7-940adb9d17fb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
+    method: GET
+  response:
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","updated_at":"2023-12-18T10:26:35.746Z"}'
+    headers:
+      Content-Length:
+      - "529"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 10:30:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b200080a-ca6e-4ecf-9862-ec136b67ffb8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"default","hub_id":"c869d62f-2201-422a-b639-9f6a567ff4e9","topic":"#","db_config":{"host":"195.154.196.110","port":18004,"dbname":"rdb","username":"root","password":"T3stP4ssw0rdD0N0tUs3!","query":"SELECT
       NOW()","engine":"unknown"}}'
     form: {}
     headers:
@@ -811,17 +844,17 @@ interactions:
     url: https://api.scaleway.com/iot/v1/regions/fr-par/routes
     method: POST
   response:
-    body: '{"created_at":"2023-10-20T16:25:58.687Z","db_config":{"dbname":"rdb","engine":"postgresql","host":"51.158.59.14","password":"T3stP4ssw0rdD0N0tUs3!","port":19086,"query":"SELECT
-      NOW()","username":"root"},"hub_id":"af349c53-39aa-4f58-9883-25c72a28794c","id":"3dd05a00-d761-41bf-802f-ebda4ca09211","name":"default","topic":"#","type":"database","updated_at":"2023-10-20T16:25:58.687Z"}'
+    body: '{"created_at":"2023-12-18T10:30:09.063Z","db_config":{"dbname":"rdb","engine":"postgresql","host":"195.154.196.110","password":"T3stP4ssw0rdD0N0tUs3!","port":18004,"query":"SELECT
+      NOW()","username":"root"},"hub_id":"c869d62f-2201-422a-b639-9f6a567ff4e9","id":"cc844cc1-37b5-47cd-8db3-e34cdb060c2b","name":"default","topic":"#","type":"database","updated_at":"2023-12-18T10:30:09.063Z"}'
     headers:
       Content-Length:
-      - "395"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:58 GMT
+      - Mon, 18 Dec 2023 10:30:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -831,7 +864,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 455cd87a-3ddc-40fd-98ae-62773232ee89
+      - a93b741c-eaf2-40d4-8d21-d7588acdd40c
     status: 200 OK
     code: 200
     duration: ""
@@ -842,19 +875,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: GET
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","updated_at":"2023-12-18T10:26:35.746Z"}'
     headers:
       Content-Length:
-      - "545"
+      - "529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:59 GMT
+      - Mon, 18 Dec 2023 10:30:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -864,7 +897,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63868a55-ec29-4cf2-b4ac-cc5eff32277a
+      - 304ab8a4-a895-434a-ac15-1d6e76b766e9
     status: 200 OK
     code: 200
     duration: ""
@@ -875,20 +908,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/routes/3dd05a00-d761-41bf-802f-ebda4ca09211
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/routes/cc844cc1-37b5-47cd-8db3-e34cdb060c2b
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:25:58.687Z","db_config":{"dbname":"rdb","engine":"postgresql","host":"51.158.59.14","password":"","port":19086,"query":"SELECT
-      NOW()","username":"root"},"hub_id":"af349c53-39aa-4f58-9883-25c72a28794c","id":"3dd05a00-d761-41bf-802f-ebda4ca09211","name":"default","topic":"#","type":"database","updated_at":"2023-10-20T16:25:58.687Z"}'
+    body: '{"created_at":"2023-12-18T10:30:09.063Z","db_config":{"dbname":"rdb","engine":"postgresql","host":"195.154.196.110","password":"","port":18004,"query":"SELECT
+      NOW()","username":"root"},"hub_id":"c869d62f-2201-422a-b639-9f6a567ff4e9","id":"cc844cc1-37b5-47cd-8db3-e34cdb060c2b","name":"default","topic":"#","type":"database","updated_at":"2023-12-18T10:30:09.063Z"}'
     headers:
       Content-Length:
-      - "374"
+      - "364"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:59 GMT
+      - Mon, 18 Dec 2023 10:30:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -898,7 +931,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fec1f366-9c92-4da2-9942-be93c539ebb5
+      - 917e9aca-0afb-40d2-a380-0caea0764b75
     status: 200 OK
     code: 200
     duration: ""
@@ -909,19 +942,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: GET
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","updated_at":"2023-12-18T10:26:35.746Z"}'
     headers:
       Content-Length:
-      - "545"
+      - "529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:59 GMT
+      - Mon, 18 Dec 2023 10:30:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -931,7 +964,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 291dbbba-c783-4988-b151-72565b36a77c
+      - 32c3956c-d36d-43a1-a1d5-b11622959099
     status: 200 OK
     code: 200
     duration: ""
@@ -942,20 +975,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/routes/3dd05a00-d761-41bf-802f-ebda4ca09211
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/routes/cc844cc1-37b5-47cd-8db3-e34cdb060c2b
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:25:58.687Z","db_config":{"dbname":"rdb","engine":"postgresql","host":"51.158.59.14","password":"","port":19086,"query":"SELECT
-      NOW()","username":"root"},"hub_id":"af349c53-39aa-4f58-9883-25c72a28794c","id":"3dd05a00-d761-41bf-802f-ebda4ca09211","name":"default","topic":"#","type":"database","updated_at":"2023-10-20T16:25:58.687Z"}'
+    body: '{"created_at":"2023-12-18T10:30:09.063Z","db_config":{"dbname":"rdb","engine":"postgresql","host":"195.154.196.110","password":"","port":18004,"query":"SELECT
+      NOW()","username":"root"},"hub_id":"c869d62f-2201-422a-b639-9f6a567ff4e9","id":"cc844cc1-37b5-47cd-8db3-e34cdb060c2b","name":"default","topic":"#","type":"database","updated_at":"2023-12-18T10:30:09.063Z"}'
     headers:
       Content-Length:
-      - "374"
+      - "364"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:25:59 GMT
+      - Mon, 18 Dec 2023 10:30:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -965,7 +998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e344ad30-0af8-41be-8cad-1d269cf7d7b7
+      - 8ea5211a-5f50-4051-a786-4c58bdd72bdf
     status: 200 OK
     code: 200
     duration: ""
@@ -976,19 +1009,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: GET
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","updated_at":"2023-12-18T10:26:35.746Z"}'
     headers:
       Content-Length:
-      - "545"
+      - "529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:00 GMT
+      - Mon, 18 Dec 2023 10:30:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -998,7 +1031,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 525a116c-94ec-4034-84d9-42a82406bc56
+      - 2a5dd722-adf7-47ab-b2bc-338ad1da07b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1009,19 +1042,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086},"endpoints":[{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086}],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:00 GMT
+      - Mon, 18 Dec 2023 10:30:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1031,7 +1064,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb04417f-286b-4cc9-9265-7d178b9495b9
+      - 0ee6eb20-8a00-41d1-94e2-eb6b972faceb
     status: 200 OK
     code: 200
     duration: ""
@@ -1042,19 +1075,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVWXF5RzZ5cFZnTU1SQnBNNE8rWTJZZU52NGlVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxT1M0eE5EQWVGdzB5Ck16RXdNakF4TmpJek16SmFGdzB6TXpFd01UY3hOakl6TXpKYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5Ua3VNVFF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURmT1ptckdKY2FGbUcrTkZ3NWo1ODRBeXBkSG9ycjlDOThXY2NyTTdUcGV0WHpaQTJ4Wm9sUnRHUVcKTmc5Qkx5Tlhad1NnR0Jmb1JvdnZ4dngyNlNwR0xpTmpsMzRHQnRqQk9KTUFCdnN5bStxSFdVRys1Umt5bm9USwpUQTErd0tCa1pza29YWGpWYy9sVGJYczZucDh4cTFaVlRocHIxNDByanlKSTIvbnIxNWFFL0srNjdKUyt4T002CnpidEdXMmI5d1BCam0vdGdIbUJDUURUbFBacjMyRHdsK3cvaEIzMjBxWlM5aVpkMk81S25TTXNVUzVSNmFVQzUKdjNic28yQ3pnVDVjUzVVTUJzSUJTUzB4TWZBdlRYV3FYOEdFMXhKWFNCVkhyRnJNTGR6MXUreXRGQlMyV0lGagp2NVNMeXVIT21lRk42UmM4NkNoQzN3U1NCMmxoQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9DNDFPUzR4TklJOGNuY3RaRGhsTmpJNU56RXRPVEl3T1MwME1UVTVMVGc0WkRRdFpHRmlObU5sTWpFMlpURmsKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOERYaHdRem5qc09NQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFDSWFNWCt3TFVMQWtzTFZIZi9TVS9PMy9ydVRMbWY3a2VqcTdxRWV3Rll4WHplNm9jWWwzN2FwK1hxCjl6Z3ZKbVZOWXJUTjRCazlWSHN0aUhRWk4xMHlDaFZXM1JNT0MrMGVoQTRnQzV0T2F4ZEJKdzBGdDdQc0J5OUsKaThzUlpsWnc0UVlmd0t2ZEI5bHpQM1RSQ3FxTkg0V3J5YmxKdThHYU1VcW00cjZMeXljUWVKeEVKcnhORTNwcgpHY0F6K3dQM1J5Nk1vSFNlYktKdncwUUJteFJOOXhaZHdUbU5hcnUzeTdzUElNNC9seVFYWFUxSGZNNldiR28vCksvSkJ6UzBsOC85cE5FeEVEZnRkN2ZJTlVjWTdhemdDSUVtRTVybVdCY08rRTZJZm13SktMZEVYQkZVcHZDR24KY3l1L002S2FkSkN2UmFuV1VGZjdCV01RWnhtVAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRFZma2owZWpMdUViVy93Y1kweDNYVzJRekk4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqRXhNREFlCkZ3MHlNekV5TVRneE1ESTVNalZhRncwek16RXlNVFV4TURJNU1qVmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eE1UQXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ1FVUWRaVXgzYnVZSE5ueW95RkhjMk9FY2VNWExtRlNRTzlyNkUxeEdWbmF1K0ltcVUKcG52UllST1d1UksxVlpZTUpPZXFxVlJpckxOWFJwRTgyVERDRUxaOFp0NmUzc0VYYVJBZWRqbDR3TzVOSHcyQwpTWFN4bTFCNnpxOElNOEFFMlJsTy9PNXlNdXcrVFc5LzFKcGFWSDlvL2JBWm52dk9zallPZkJqTUhIc2VMT1RtCnBKNGtibFdaVFJUUnhQdnFya3I5UDBCM0RrQlBYWXVqQ1RFM0kxZG1RV29xbTVjVUdWYStrZU82blplaXJTZ1kKay9KYXpGdmk5SU1peDFxU0lEMDY4ZFpnZVo0Y2NtY3BzSmUzUGdyNzlRakxhYVdCR2Zqc1NrUzE4amNWUFV4dQpmdm5RSVgzTVFFVmtkaG1CeUlkTjhxZHJBZXc3TlZjTG1XUkZBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1URXdnanh5ZHkwNE5qaGxaamcwWXkwNFpUZGtMVFEyWXpndE9UVmwKTlMweE4ySTBNekkxTnpBNE5Ea3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakV4TUlJOGNuY3RPRFk0WldZNE5HTXRPR1UzWkMwME5tTTRMVGsxWlRVdE1UZGlORE15TlRjd09EUTVMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpublE5aHdURG1zUnVod1REbXNSdU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNGYWFRRnRBMmwvQSs4RWRnOVhWMFdPbWFQWDNHaGNRT2x2bWd1SmpRUW10RWNEOU01aGNVTQoreDVhVjIxUDNIZlNodWczSWhvS1RWemd0dGVScUVaMzVJTVZ3aFpPUW9YUUlKUnpKbEZ1eVN0OWRPSnNBcnBICnBxZnJXUGIrK05TQ1hmTGt6ZHIyakEzZmQzR1Q0YTJicFRDT0dydWVNVlRMeVFqdkhlYi9Pbm80cVRLZ2dnVTgKRnI5SWVRbnNTL2EwUVk5OU43WTI2eTR1K0NlWW5NbC9ncTZ6dUtjaFRiRHU0a3BGTFpDdlc2WEJ2Q0NKQ2ZENwovL1RYYWpodWxFaGE1aDRjNDRHM3dXcEVkNm5KUHc3dTdXT1VaUlE4elRXVy9DT0VVT2RZUmV2Ryt2dTN6SG1IClFIa0VZVEFsVzI4TkNwbFlIbHlRYlEvcW5tbFFnQVpKCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1841"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:00 GMT
+      - Mon, 18 Dec 2023 10:30:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1064,7 +1097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b0eb40d-f5c0-4544-9269-5ee37ca2bd20
+      - d891ff9b-7933-4090-9c3a-dd42adf6eec7
     status: 200 OK
     code: 200
     duration: ""
@@ -1075,20 +1108,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/routes/3dd05a00-d761-41bf-802f-ebda4ca09211
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=868ef84c-8e7d-46c8-95e5-17b432570849&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2023-10-20T16:25:58.687Z","db_config":{"dbname":"rdb","engine":"postgresql","host":"51.158.59.14","password":"","port":19086,"query":"SELECT
-      NOW()","username":"root"},"hub_id":"af349c53-39aa-4f58-9883-25c72a28794c","id":"3dd05a00-d761-41bf-802f-ebda4ca09211","name":"default","topic":"#","type":"database","updated_at":"2023-10-20T16:25:58.687Z"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "374"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:00 GMT
+      - Mon, 18 Dec 2023 10:30:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1098,7 +1130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ec4c13e-b91b-47ca-b4ca-35c9db1242db
+      - 6ebf1ddb-832e-4772-815c-7c162cd50f2a
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,19 +1141,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/routes/cc844cc1-37b5-47cd-8db3-e34cdb060c2b
     method: GET
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"created_at":"2023-12-18T10:30:09.063Z","db_config":{"dbname":"rdb","engine":"postgresql","host":"195.154.196.110","password":"","port":18004,"query":"SELECT
+      NOW()","username":"root"},"hub_id":"c869d62f-2201-422a-b639-9f6a567ff4e9","id":"cc844cc1-37b5-47cd-8db3-e34cdb060c2b","name":"default","topic":"#","type":"database","updated_at":"2023-12-18T10:30:09.063Z"}'
     headers:
       Content-Length:
-      - "545"
+      - "364"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:01 GMT
+      - Mon, 18 Dec 2023 10:30:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1131,7 +1164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d79a5e76-2383-418e-abf7-0282f10e0298
+      - 7dc3242d-0f35-4afc-a7f8-b91288fdd095
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,7 +1175,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/routes/3dd05a00-d761-41bf-802f-ebda4ca09211
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
+    method: GET
+  response:
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","updated_at":"2023-12-18T10:26:35.746Z"}'
+    headers:
+      Content-Length:
+      - "529"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 10:30:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22632a9c-02fb-4273-8b90-1fbd18a509ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/routes/cc844cc1-37b5-47cd-8db3-e34cdb060c2b
     method: DELETE
   response:
     body: ""
@@ -1152,7 +1218,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:01 GMT
+      - Mon, 18 Dec 2023 10:30:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1162,7 +1228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6981386b-16bf-42fe-8c4d-d918ce741899
+      - 6b01a10d-a7cf-4196-b725-0117d3b41855
     status: 204 No Content
     code: 204
     duration: ""
@@ -1173,19 +1239,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: GET
   response:
-    body: '{"connected_device_count":0,"created_at":"2023-10-20T16:22:46.933Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"af349c53-39aa-4f58-9883-25c72a28794c","name":"minimal","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","product_plan":"plan_shared","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","status":"ready","updated_at":"2023-10-20T16:22:46.933Z"}'
+    body: '{"connected_device_count":0,"created_at":"2023-12-18T10:26:35.746Z","device_count":0,"disable_events":false,"enable_device_auto_provisioning":false,"enabled":true,"endpoint":"iot.fr-par.scw.cloud","events_topic_prefix":"$SCW/events","has_custom_ca":false,"id":"c869d62f-2201-422a-b639-9f6a567ff4e9","name":"minimal","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","product_plan":"plan_shared","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","status":"ready","updated_at":"2023-12-18T10:26:35.746Z"}'
     headers:
       Content-Length:
-      - "545"
+      - "529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:01 GMT
+      - Mon, 18 Dec 2023 10:30:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1195,7 +1261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f845eb48-bafa-431c-9034-e0a1f6218b03
+      - d288b4b5-8b42-4d75-a8a1-ead3d4fc31f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,7 +1272,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: DELETE
   response:
     body: ""
@@ -1216,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:01 GMT
+      - Mon, 18 Dec 2023 10:30:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1226,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 094319bd-43c8-499f-84e2-054510f02ec9
+      - 5b958f2e-8258-4314-83c3-86f05960e330
     status: 204 No Content
     code: 204
     duration: ""
@@ -1237,10 +1303,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"hub","resource_id":"af349c53-39aa-4f58-9883-25c72a28794c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"hub","resource_id":"c869d62f-2201-422a-b639-9f6a567ff4e9","type":"not_found"}'
     headers:
       Content-Length:
       - "124"
@@ -1249,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:01 GMT
+      - Mon, 18 Dec 2023 10:30:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1259,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 571dc264-d117-42b1-8758-ed2a23ce6278
+      - b5c8aceb-4d91-4e02-9aef-c0fa77ce4601
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1270,19 +1336,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086},"endpoints":[{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086}],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1214"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:01 GMT
+      - Mon, 18 Dec 2023 10:30:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1292,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 415083e0-8df0-409c-bf10-fd3ae0516850
+      - d3a3be88-7f4a-444d-b261-c4396efc19d6
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,19 +1369,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086},"endpoints":[{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086}],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1217"
+      - "1177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:02 GMT
+      - Mon, 18 Dec 2023 10:30:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef57a29f-9663-4ac2-ace3-1731dcf9c59d
+      - a4693f70-88d8-459d-a52d-b15a216201d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,19 +1402,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-10-20T16:22:53.461448Z","endpoint":{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086},"endpoints":[{"id":"4bd569cd-622b-4937-a0fb-96f8fcd1d668","ip":"51.158.59.14","load_balancer":{},"name":null,"port":19086}],"engine":"PostgreSQL-15","id":"d8e62971-9209-4159-88d4-dab6ce216e1d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T10:26:36.106253Z","endpoint":{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004},"endpoints":[{"id":"55cbf017-df06-4d8a-b754-fb48c9b355af","ip":"195.154.196.110","load_balancer":{},"name":null,"port":18004}],"engine":"PostgreSQL-15","id":"868ef84c-8e7d-46c8-95e5-17b432570849","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"minimal","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1217"
+      - "1177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:02 GMT
+      - Mon, 18 Dec 2023 10:30:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4a70197-315d-42b9-ac5b-809f4ac9c88f
+      - c4a3774e-9cbc-4328-88ba-052bf3447e09
     status: 200 OK
     code: 200
     duration: ""
@@ -1369,10 +1435,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"d8e62971-9209-4159-88d4-dab6ce216e1d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"868ef84c-8e7d-46c8-95e5-17b432570849","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1381,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:32 GMT
+      - Mon, 18 Dec 2023 10:30:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8da8496-2902-4562-8cd6-d651d32c6570
+      - 5a0c6fc4-64bc-4688-9bcd-32a14d7c9957
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1402,10 +1468,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/af349c53-39aa-4f58-9883-25c72a28794c
+    url: https://api.scaleway.com/iot/v1/regions/fr-par/hubs/c869d62f-2201-422a-b639-9f6a567ff4e9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"hub","resource_id":"af349c53-39aa-4f58-9883-25c72a28794c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"hub","resource_id":"c869d62f-2201-422a-b639-9f6a567ff4e9","type":"not_found"}'
     headers:
       Content-Length:
       - "124"
@@ -1414,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:32 GMT
+      - Mon, 18 Dec 2023 10:30:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 142195ec-ae1d-4168-a468-887afecdfd2f
+      - 8f05d82c-a9d8-46f0-a5eb-9f7fb43b88ab
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1435,10 +1501,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d8e62971-9209-4159-88d4-dab6ce216e1d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/868ef84c-8e7d-46c8-95e5-17b432570849
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"d8e62971-9209-4159-88d4-dab6ce216e1d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"868ef84c-8e7d-46c8-95e5-17b432570849","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1447,7 +1513,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 20 Oct 2023 16:26:32 GMT
+      - Mon, 18 Dec 2023 10:30:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1457,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02bc36f4-f933-4bdb-9024-4d46ea721325
+      - c9550aae-daf8-49df-9d57-3141d85f2efe
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-acl-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-acl-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:57:54 GMT
+      - Mon, 18 Dec 2023 16:43:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,86 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0272208e-25a5-4031-ae6c-3915979d09e9
+      - 7cb1a3aa-5039-49f2-a541-11c8c748e74c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"rdb-acl-basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"ip":{"address":"51.15.210.198","id":"8856b9bc-2183-4d62-9465-3998345d05a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "306"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:43:38 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8856b9bc-2183-4d62-9465-3998345d05a7
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5f4c1ca5-8282-4aa1-bc1d-383da743668e
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"ip":{"address":"163.172.141.142","id":"8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "308"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:43:38 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4962a781-967d-467b-b994-643eb05738c8
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"rdb-acl-basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +418,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "895"
@@ -353,7 +427,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:57:55 GMT
+      - Mon, 18 Dec 2023 16:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,23 +437,21 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bc84c1e-a4fe-462e-8c17-e9bc0a1ba9b7
+      - 0c78f7de-569f-4487-9f45-c276c69b39ca
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    body: ""
     form: {}
     headers:
-      Content-Type:
-      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
-    method: POST
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8
+    method: GET
   response:
-    body: '{"ip":{"address":"163.172.149.194","id":"de3de4a0-04c5-44f6-9251-b27fa180ea9c","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.141.142","id":"8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "308"
@@ -388,9 +460,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:57:55 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/de3de4a0-04c5-44f6-9251-b27fa180ea9c
+      - Mon, 18 Dec 2023 16:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -400,23 +470,21 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9a64fc2-fbfb-461b-9f1f-e4e630b2365a
-    status: 201 Created
-    code: 201
+      - 011ba906-cb81-450c-925f-a4935195b4b3
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
-    body: '{"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552"}'
+    body: ""
     form: {}
     headers:
-      Content-Type:
-      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
-    method: POST
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8856b9bc-2183-4d62-9465-3998345d05a7
+    method: GET
   response:
-    body: '{"ip":{"address":"51.158.79.120","id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.210.198","id":"8856b9bc-2183-4d62-9465-3998345d05a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "306"
@@ -425,9 +493,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:57:55 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
+      - Mon, 18 Dec 2023 16:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -437,40 +503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f794d335-4ffa-4ec9-8ac3-ec12afffdf1a
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/de3de4a0-04c5-44f6-9251-b27fa180ea9c
-    method: GET
-  response:
-    body: '{"ip":{"address":"163.172.149.194","id":"de3de4a0-04c5-44f6-9251-b27fa180ea9c","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "308"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:57:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6519b9ce-6b14-45f2-8234-a1138b2b5eb9
+      - b093e83b-9a23-4e03-aacf-a94cce7ce219
     status: 200 OK
     code: 200
     duration: ""
@@ -481,43 +514,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.79.120","id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "306"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 14:57:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b84a9a34-c489-49d7-86c6-10ba0a7cb034
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "895"
@@ -526,7 +526,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:57:55 GMT
+      - Mon, 18 Dec 2023 16:43:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -536,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e804902c-3aa1-42fd-9bf1-f54fd30fd005
+      - f5c1cc59-3ba6-44b5-aa10-1746e972b194
     status: 200 OK
     code: 200
     duration: ""
@@ -547,10 +547,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "895"
@@ -559,7 +559,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:25 GMT
+      - Mon, 18 Dec 2023 16:44:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -569,7 +569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81f478ac-22f2-4d2d-b374-ca4b61329272
+      - 6a685027-5305-4bb6-834c-705bc5a50f20
     status: 200 OK
     code: 200
     duration: ""
@@ -580,10 +580,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "895"
@@ -592,7 +592,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:58:56 GMT
+      - Mon, 18 Dec 2023 16:44:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -602,7 +602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53211f4d-a10f-41f5-9682-fce45e22f365
+      - 93ac09b3-a93d-438e-886c-076e599dd004
     status: 200 OK
     code: 200
     duration: ""
@@ -613,10 +613,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "895"
@@ -625,7 +625,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:27 GMT
+      - Mon, 18 Dec 2023 16:45:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -635,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a77a35a3-3f8c-4843-97b5-f05520e7f174
+      - 2f83fc93-54c9-4f93-b8fd-ea30f51d1a36
     status: 200 OK
     code: 200
     duration: ""
@@ -646,10 +646,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "895"
@@ -658,7 +658,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 14:59:58 GMT
+      - Mon, 18 Dec 2023 16:45:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -668,7 +668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cf92fdc-e79a-45a9-bb0d-52d770637251
+      - e0534eaa-133f-45f0-94ae-3f04d31fdc08
     status: 200 OK
     code: 200
     duration: ""
@@ -679,10 +679,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "895"
@@ -691,7 +691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:00:32 GMT
+      - Mon, 18 Dec 2023 16:46:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -701,7 +701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 719c835c-4e2d-41cd-af7e-3e1dbc95737f
+      - e86aa5c4-6030-44e8-9344-538a9cfa0445
     status: 200 OK
     code: 200
     duration: ""
@@ -712,19 +712,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "895"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:01:03 GMT
+      - Mon, 18 Dec 2023 16:46:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -734,106 +734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ec02c8f-9db4-4a6b-81f5-bfe46d08ab60
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "895"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 15:01:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be7122e9-e97e-4e75-af17-57ebfde631cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1159"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 15:02:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 19172805-3911-4d91-a2e9-d8fbb664e41b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1200"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 15:02:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd5ed9a2-e0aa-45dc-902c-3a62d552996f
+      - 0f1fdc82-a266-43cc-a33e-90fe178aecc8
     status: 200 OK
     code: 200
     duration: ""
@@ -846,19 +747,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:02:35 GMT
+      - Mon, 18 Dec 2023 16:46:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -868,7 +769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 762c2fa8-6bd1-4c80-a3d0-efde8ae3674a
+      - d13a5ca4-eb2b-4510-8255-476c7e4889eb
     status: 200 OK
     code: 200
     duration: ""
@@ -879,19 +780,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:02:35 GMT
+      - Mon, 18 Dec 2023 16:46:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -901,7 +802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a401f8a-96de-4c64-a3b0-899247fabd3e
+      - cee08cd2-76b4-48c7-9487-ef98a120ddc4
     status: 200 OK
     code: 200
     duration: ""
@@ -912,7 +813,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -924,7 +825,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:02:36 GMT
+      - Mon, 18 Dec 2023 16:46:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -934,7 +835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95ffe377-bf08-4cc8-ab39-f2fb6ba59490
+      - 8a809490-c0be-40e7-b69a-90f1168f31e5
     status: 200 OK
     code: 200
     duration: ""
@@ -945,19 +846,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRnRnbURpaHVVbFdqV0ttRDhWUzJnSUxrZkxrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TlRBeE5UQmFGdzB6TXpFeU1UVXhOVEF4TlRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNHTmNqR08rSHBJRUxmSFNiQ05STjF3dkJnSDFuU0hkcHo1aWx4cmhYOG0rcWM2WnZUc2JGTHZ1TkcKYlZDamdNU1NpSFdBNUNSV0F5ZVZIdytkQmhKS1dhU0srTnp3M2d6emhnQlVOSmRhRWFaenVKeUhDR0x2c1l3dgpnVEZ1S2Fsem5qenJWTkhxRkt5N3pDZE9BV3VYbHJuMjVrRjk1eCtHcWNoQ01BYW1MZU5vOUh4Skx0Z0Q1Wkg2CklJdU13VGhnbUtMR2gxNTg1R0dTYUZMTGFaQ0F2RURsRjN6eTRETlBFWjBjQWN1eXlNbElaRCtsNm5uZ0NXSkkKK1RYWGg5cnRLdjcyYTAvbUtjdmZqL2V4ODRjTkZyZ3JmMnFkdnhzaTQvM2JDbldlR1FXS2c2bXhlYkZtMTNObgpBeFVFMVFmcHd1eTJXMG94aEVWSFRnbFZjQjdQQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkwd1pERXdZV1ZpTnkxa1lqVm1MVFJtT1RFdE9XVTNaQzFrWWpNeFkyVmoKTldZMk9XSXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TUdReApNR0ZsWWpjdFpHSTFaaTAwWmpreExUbGxOMlF0WkdJek1XTmxZelZtTmpsaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvMW5od1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCaGRFRnQKaERSNXZ0SWVoMzNIMkJ0QXIwZXRiRlNEeFNsQURKcElyQXBqZXN0NUFEeXN0R0RHUit6cFRDZGpPaXQ4aHhmWgo1UzdBNzBMMEtQVzZHWVQyenlKQlF4M3NTbGpPUTl4VTFGR0FGMXdHRkNhK0p6QXhGdFBOWDNWZ1NYanZwMEVxCkxRRWNYc3IycU4xZjNHZzF0MHRiL2h5VnpRdmxJVituMUJONStmbnlJOFh6dUY4Q0xEdEY2RmxWZkV1NmQxZDAKanR5QmRKY0txZzVIcmFGOXRmVW1nbXo4UU5mbEwxbWFJNEhUbVFFVmpuMVJZd1NwUXprV0lVUlFxcXZkTEdiUwpFTktSOXJPTXpMaG5sclB3dnVVVktsYXlBRDRLanF3MWh5OCtRZ3dPYXRqTjJEa1lxK1J1cXF5algyVWcxdDVxCjVGZHloZTNQVlZUamNQTS8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUEJHVEVZbUkyeWpTQy85OVl3WEFtNzZYTURzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EWXlNRm9YRFRNek1USXhOVEUyTkRZeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXUxbTFlUWRXei8zZzZKSER0L3kxNW9DbXBtM3FlWkVvb1lNZXZnMnB3WFVhcDFrT3ZnY2wKUkVHWWpuRDJQZkg5ZCs2RlYyU0dFam1FR1labUE1ZnBON3FzSC9ubkdsOE95YTFYS0dsV3lFSGd3cUJ2a2hVdwowak9mSjI1SVpDdEp0dXhaRFJWYzJPcDFzTlhpWVJuckxwWTg2K2JyMGpHN3dCOTRyUlU2a01CQ3hWSXhNMXJ1CmxETEN2SFQxNTlFK0tEUDZESWlhV29nN0xyREdIYmh1ZXpGdDR0aWdlY25FZW14WS9mTkhienNRb3BhaXJ4MEUKNnV6c0N0azA1Q0dHOXRMWFRQN2dlMVdOOStCcCtPeGl1RVpOMjJlYkduakVQbU5xQWMwanl2QS9JSlhIV0ZkegpuR0ZldngrZU9xcWFFbEU1Q3Rna0x3YmFQRDV0VktEUE5RSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB4TlRJMlpXVTNPQzA0T0RVNUxUUTBOR1F0T0Rnd1pTMHoKTVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkweE5USTJaV1UzT0MwNE9EVTVMVFEwTkdRdE9EZ3daUzB6TVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZWNFU0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIT1F3bk9Oc3YwelhkZzlzczJIbTVnYmtMZG9sRXR4ZlhuNk10OGVPUWpOUkU5YzRhZzZZS3A4KzFJSgo0U3FpSFB6Uld5WFJtcHhrcmNPT0dLbEF6VGs2MkhLam8zUkZHM2tMZEtjK2NycWw4akxabityVGl0NjdNMDdxCkE3d0dVdkxmMnJwV2NpRm5OSTl1dWFnb2RTUVdNRVFubUdFOU9IZTl5MnVXREpRbGRwLzlZRmRYZktZUXRwcjQKSUJjdkdYQndXbUJSLzgyOUVVeFlQRU9udlAwRjQ4emFhdzRwQjhUZ1RtUGJTMkFsN0dPK2NOTTVXZy9aZkVqVAorVEl1WndreWRjN1ZxUCtpVWwydkdDY3hPYUFGd0xFL3hRTjh3b1hDY3dyaXFMMmVvdmExS3p2Z051aEZtUDA0CkFmbGlZQ3VSUDNqM0l4TnNCM0xSd2tiK2dCOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:02:36 GMT
+      - Mon, 18 Dec 2023 16:46:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -967,7 +868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e078f943-223a-4a03-892f-e504c8c6f3ee
+      - 0f93fa03-d66a-4b2c-9cdd-a9d8fd675edd
     status: 200 OK
     code: 200
     duration: ""
@@ -978,19 +879,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1526ee78-8859-444d-880e-312871f1f4c3&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1200"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:02:36 GMT
+      - Mon, 18 Dec 2023 16:46:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1000,12 +901,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d49a44e-2c61-4bd7-875a-4161debec330
+      - 2092f80c-caa9-44ba-9dc1-a64ef72b9950
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"rules":[{"ip":"51.158.79.120/32","description":""},{"ip":"163.172.149.194/32","description":""}]}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:46:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9b045550-dbaa-4f38-8552-129d59a304c2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"rules":[{"ip":"51.15.210.198/32","description":""},{"ip":"163.172.141.142/32","description":""}]}'
     form: {}
     headers:
       Content-Type:
@@ -1013,11 +947,11 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.158.79.120/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"163.172.149.194/32","port":20932,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.210.198/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"163.172.141.142/32","port":12244,"protocol":"tcp"}]}'
     headers:
       Content-Length:
       - "257"
@@ -1026,7 +960,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:02:36 GMT
+      - Mon, 18 Dec 2023 16:46:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1036,7 +970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f816871c-a8e1-451c-9787-de123ef0dc5e
+      - 2d840cad-cb54-44ca-8d4c-029e28b50f17
     status: 200 OK
     code: 200
     duration: ""
@@ -1047,19 +981,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:02:36 GMT
+      - Mon, 18 Dec 2023 16:46:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1069,7 +1003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b29d2ff2-a662-478e-a164-ba2cb7c32066
+      - 8b6270b0-9704-44a6-8bd8-570b06b9e04f
     status: 200 OK
     code: 200
     duration: ""
@@ -1080,19 +1014,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:07 GMT
+      - Mon, 18 Dec 2023 16:47:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1102,7 +1036,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1a38abe-ac38-4402-a0e5-50f24daf2475
+      - 24b367d7-1be2-437d-b626-394bf267d648
     status: 200 OK
     code: 200
     duration: ""
@@ -1113,11 +1047,11 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.158.79.120/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"163.172.149.194/32","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.210.198/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"163.172.141.142/32","port":12244,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "273"
@@ -1126,7 +1060,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:07 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1136,7 +1070,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 798bc984-c2dd-40fd-bd0a-e76e0de22471
+      - f5890c25-a2fb-46f0-ae6f-59d98873d57c
     status: 200 OK
     code: 200
     duration: ""
@@ -1147,10 +1081,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8856b9bc-2183-4d62-9465-3998345d05a7
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.79.120","id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.210.198","id":"8856b9bc-2183-4d62-9465-3998345d05a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "306"
@@ -1159,7 +1093,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:07 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1169,7 +1103,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51781043-e2ac-4077-be12-c4265f25abab
+      - cf2ce1d1-4bd0-4c8b-81fc-b21f839bf23e
     status: 200 OK
     code: 200
     duration: ""
@@ -1180,10 +1114,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/de3de4a0-04c5-44f6-9251-b27fa180ea9c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8
     method: GET
   response:
-    body: '{"ip":{"address":"163.172.149.194","id":"de3de4a0-04c5-44f6-9251-b27fa180ea9c","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.141.142","id":"8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "308"
@@ -1192,7 +1126,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:07 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1202,7 +1136,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fdd199d-8a4e-4353-9366-583917bf9b9e
+      - 35cf902a-ae69-4d14-a06d-2df467a60ef0
     status: 200 OK
     code: 200
     duration: ""
@@ -1213,19 +1147,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:07 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1235,7 +1169,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 011dbf1e-1a40-49af-8a92-868ad44a0dd3
+      - b5a25e79-4295-4b77-b2bb-26ad73e7281c
     status: 200 OK
     code: 200
     duration: ""
@@ -1246,7 +1180,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -1258,7 +1192,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:08 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1268,7 +1202,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1932664-55f1-48fc-8842-7cce2b0b7e81
+      - 34074282-f5d6-491e-a0ef-1f793f0f1314
     status: 200 OK
     code: 200
     duration: ""
@@ -1279,19 +1213,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRnRnbURpaHVVbFdqV0ttRDhWUzJnSUxrZkxrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TlRBeE5UQmFGdzB6TXpFeU1UVXhOVEF4TlRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNHTmNqR08rSHBJRUxmSFNiQ05STjF3dkJnSDFuU0hkcHo1aWx4cmhYOG0rcWM2WnZUc2JGTHZ1TkcKYlZDamdNU1NpSFdBNUNSV0F5ZVZIdytkQmhKS1dhU0srTnp3M2d6emhnQlVOSmRhRWFaenVKeUhDR0x2c1l3dgpnVEZ1S2Fsem5qenJWTkhxRkt5N3pDZE9BV3VYbHJuMjVrRjk1eCtHcWNoQ01BYW1MZU5vOUh4Skx0Z0Q1Wkg2CklJdU13VGhnbUtMR2gxNTg1R0dTYUZMTGFaQ0F2RURsRjN6eTRETlBFWjBjQWN1eXlNbElaRCtsNm5uZ0NXSkkKK1RYWGg5cnRLdjcyYTAvbUtjdmZqL2V4ODRjTkZyZ3JmMnFkdnhzaTQvM2JDbldlR1FXS2c2bXhlYkZtMTNObgpBeFVFMVFmcHd1eTJXMG94aEVWSFRnbFZjQjdQQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkwd1pERXdZV1ZpTnkxa1lqVm1MVFJtT1RFdE9XVTNaQzFrWWpNeFkyVmoKTldZMk9XSXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TUdReApNR0ZsWWpjdFpHSTFaaTAwWmpreExUbGxOMlF0WkdJek1XTmxZelZtTmpsaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvMW5od1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCaGRFRnQKaERSNXZ0SWVoMzNIMkJ0QXIwZXRiRlNEeFNsQURKcElyQXBqZXN0NUFEeXN0R0RHUit6cFRDZGpPaXQ4aHhmWgo1UzdBNzBMMEtQVzZHWVQyenlKQlF4M3NTbGpPUTl4VTFGR0FGMXdHRkNhK0p6QXhGdFBOWDNWZ1NYanZwMEVxCkxRRWNYc3IycU4xZjNHZzF0MHRiL2h5VnpRdmxJVituMUJONStmbnlJOFh6dUY4Q0xEdEY2RmxWZkV1NmQxZDAKanR5QmRKY0txZzVIcmFGOXRmVW1nbXo4UU5mbEwxbWFJNEhUbVFFVmpuMVJZd1NwUXprV0lVUlFxcXZkTEdiUwpFTktSOXJPTXpMaG5sclB3dnVVVktsYXlBRDRLanF3MWh5OCtRZ3dPYXRqTjJEa1lxK1J1cXF5algyVWcxdDVxCjVGZHloZTNQVlZUamNQTS8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUEJHVEVZbUkyeWpTQy85OVl3WEFtNzZYTURzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EWXlNRm9YRFRNek1USXhOVEUyTkRZeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXUxbTFlUWRXei8zZzZKSER0L3kxNW9DbXBtM3FlWkVvb1lNZXZnMnB3WFVhcDFrT3ZnY2wKUkVHWWpuRDJQZkg5ZCs2RlYyU0dFam1FR1labUE1ZnBON3FzSC9ubkdsOE95YTFYS0dsV3lFSGd3cUJ2a2hVdwowak9mSjI1SVpDdEp0dXhaRFJWYzJPcDFzTlhpWVJuckxwWTg2K2JyMGpHN3dCOTRyUlU2a01CQ3hWSXhNMXJ1CmxETEN2SFQxNTlFK0tEUDZESWlhV29nN0xyREdIYmh1ZXpGdDR0aWdlY25FZW14WS9mTkhienNRb3BhaXJ4MEUKNnV6c0N0azA1Q0dHOXRMWFRQN2dlMVdOOStCcCtPeGl1RVpOMjJlYkduakVQbU5xQWMwanl2QS9JSlhIV0ZkegpuR0ZldngrZU9xcWFFbEU1Q3Rna0x3YmFQRDV0VktEUE5RSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB4TlRJMlpXVTNPQzA0T0RVNUxUUTBOR1F0T0Rnd1pTMHoKTVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkweE5USTJaV1UzT0MwNE9EVTVMVFEwTkdRdE9EZ3daUzB6TVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZWNFU0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIT1F3bk9Oc3YwelhkZzlzczJIbTVnYmtMZG9sRXR4ZlhuNk10OGVPUWpOUkU5YzRhZzZZS3A4KzFJSgo0U3FpSFB6Uld5WFJtcHhrcmNPT0dLbEF6VGs2MkhLam8zUkZHM2tMZEtjK2NycWw4akxabityVGl0NjdNMDdxCkE3d0dVdkxmMnJwV2NpRm5OSTl1dWFnb2RTUVdNRVFubUdFOU9IZTl5MnVXREpRbGRwLzlZRmRYZktZUXRwcjQKSUJjdkdYQndXbUJSLzgyOUVVeFlQRU9udlAwRjQ4emFhdzRwQjhUZ1RtUGJTMkFsN0dPK2NOTTVXZy9aZkVqVAorVEl1WndreWRjN1ZxUCtpVWwydkdDY3hPYUFGd0xFL3hRTjh3b1hDY3dyaXFMMmVvdmExS3p2Z051aEZtUDA0CkFmbGlZQ3VSUDNqM0l4TnNCM0xSd2tiK2dCOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:08 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1301,7 +1235,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 313de250-515d-46e8-8968-ba1544d3d5ec
+      - 4a7a33d9-086d-41f7-ab3c-75d9d894c2d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1312,19 +1246,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1526ee78-8859-444d-880e-312871f1f4c3&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1200"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:08 GMT
+      - Mon, 18 Dec 2023 16:47:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1334,7 +1268,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 338d9cf2-5f48-449b-af25-cc89a7410710
+      - 3bbb4674-4e36-40d7-8d26-6868c964416f
     status: 200 OK
     code: 200
     duration: ""
@@ -1345,11 +1279,44 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.158.79.120/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"163.172.149.194/32","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0801c24e-3c44-469c-abb6-936c4db3d4b9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.210.198/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"163.172.141.142/32","port":12244,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "273"
@@ -1358,7 +1325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:08 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1368,7 +1335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1e1ed31-f7e3-4143-8ac6-2569465d9711
+      - c7eeb6a0-f7e3-4fdd-98df-64392d4834ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1379,10 +1346,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.79.120","id":"78d361b7-6c7d-44f0-9176-ad85c1726d1b","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.141.142","id":"8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "308"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 370edf90-d74b-4a5a-89b0-e312551b5059
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8856b9bc-2183-4d62-9465-3998345d05a7
+    method: GET
+  response:
+    body: '{"ip":{"address":"51.15.210.198","id":"8856b9bc-2183-4d62-9465-3998345d05a7","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "306"
@@ -1391,7 +1391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:09 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1401,7 +1401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 266a122c-288d-4fe7-9579-effd43f4191c
+      - 2fcfc40e-c3d4-4d0c-bae2-b6560358fd3a
     status: 200 OK
     code: 200
     duration: ""
@@ -1412,19 +1412,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:09 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1434,7 +1434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5fa8caf-4c22-4138-8bad-01ad39c0fad3
+      - da7e0cbf-8c92-456d-833d-250a9015b634
     status: 200 OK
     code: 200
     duration: ""
@@ -1445,7 +1445,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -1457,7 +1457,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:09 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1467,7 +1467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c12861c-f7d6-4b81-975d-e80f4b599fbf
+      - bda80e55-cc08-49f6-8664-1b1da7b6d868
     status: 200 OK
     code: 200
     duration: ""
@@ -1478,19 +1478,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRnRnbURpaHVVbFdqV0ttRDhWUzJnSUxrZkxrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TlRBeE5UQmFGdzB6TXpFeU1UVXhOVEF4TlRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNHTmNqR08rSHBJRUxmSFNiQ05STjF3dkJnSDFuU0hkcHo1aWx4cmhYOG0rcWM2WnZUc2JGTHZ1TkcKYlZDamdNU1NpSFdBNUNSV0F5ZVZIdytkQmhKS1dhU0srTnp3M2d6emhnQlVOSmRhRWFaenVKeUhDR0x2c1l3dgpnVEZ1S2Fsem5qenJWTkhxRkt5N3pDZE9BV3VYbHJuMjVrRjk1eCtHcWNoQ01BYW1MZU5vOUh4Skx0Z0Q1Wkg2CklJdU13VGhnbUtMR2gxNTg1R0dTYUZMTGFaQ0F2RURsRjN6eTRETlBFWjBjQWN1eXlNbElaRCtsNm5uZ0NXSkkKK1RYWGg5cnRLdjcyYTAvbUtjdmZqL2V4ODRjTkZyZ3JmMnFkdnhzaTQvM2JDbldlR1FXS2c2bXhlYkZtMTNObgpBeFVFMVFmcHd1eTJXMG94aEVWSFRnbFZjQjdQQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkwd1pERXdZV1ZpTnkxa1lqVm1MVFJtT1RFdE9XVTNaQzFrWWpNeFkyVmoKTldZMk9XSXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TUdReApNR0ZsWWpjdFpHSTFaaTAwWmpreExUbGxOMlF0WkdJek1XTmxZelZtTmpsaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvMW5od1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCaGRFRnQKaERSNXZ0SWVoMzNIMkJ0QXIwZXRiRlNEeFNsQURKcElyQXBqZXN0NUFEeXN0R0RHUit6cFRDZGpPaXQ4aHhmWgo1UzdBNzBMMEtQVzZHWVQyenlKQlF4M3NTbGpPUTl4VTFGR0FGMXdHRkNhK0p6QXhGdFBOWDNWZ1NYanZwMEVxCkxRRWNYc3IycU4xZjNHZzF0MHRiL2h5VnpRdmxJVituMUJONStmbnlJOFh6dUY4Q0xEdEY2RmxWZkV1NmQxZDAKanR5QmRKY0txZzVIcmFGOXRmVW1nbXo4UU5mbEwxbWFJNEhUbVFFVmpuMVJZd1NwUXprV0lVUlFxcXZkTEdiUwpFTktSOXJPTXpMaG5sclB3dnVVVktsYXlBRDRLanF3MWh5OCtRZ3dPYXRqTjJEa1lxK1J1cXF5algyVWcxdDVxCjVGZHloZTNQVlZUamNQTS8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUEJHVEVZbUkyeWpTQy85OVl3WEFtNzZYTURzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EWXlNRm9YRFRNek1USXhOVEUyTkRZeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXUxbTFlUWRXei8zZzZKSER0L3kxNW9DbXBtM3FlWkVvb1lNZXZnMnB3WFVhcDFrT3ZnY2wKUkVHWWpuRDJQZkg5ZCs2RlYyU0dFam1FR1labUE1ZnBON3FzSC9ubkdsOE95YTFYS0dsV3lFSGd3cUJ2a2hVdwowak9mSjI1SVpDdEp0dXhaRFJWYzJPcDFzTlhpWVJuckxwWTg2K2JyMGpHN3dCOTRyUlU2a01CQ3hWSXhNMXJ1CmxETEN2SFQxNTlFK0tEUDZESWlhV29nN0xyREdIYmh1ZXpGdDR0aWdlY25FZW14WS9mTkhienNRb3BhaXJ4MEUKNnV6c0N0azA1Q0dHOXRMWFRQN2dlMVdOOStCcCtPeGl1RVpOMjJlYkduakVQbU5xQWMwanl2QS9JSlhIV0ZkegpuR0ZldngrZU9xcWFFbEU1Q3Rna0x3YmFQRDV0VktEUE5RSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB4TlRJMlpXVTNPQzA0T0RVNUxUUTBOR1F0T0Rnd1pTMHoKTVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkweE5USTJaV1UzT0MwNE9EVTVMVFEwTkdRdE9EZ3daUzB6TVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZWNFU0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIT1F3bk9Oc3YwelhkZzlzczJIbTVnYmtMZG9sRXR4ZlhuNk10OGVPUWpOUkU5YzRhZzZZS3A4KzFJSgo0U3FpSFB6Uld5WFJtcHhrcmNPT0dLbEF6VGs2MkhLam8zUkZHM2tMZEtjK2NycWw4akxabityVGl0NjdNMDdxCkE3d0dVdkxmMnJwV2NpRm5OSTl1dWFnb2RTUVdNRVFubUdFOU9IZTl5MnVXREpRbGRwLzlZRmRYZktZUXRwcjQKSUJjdkdYQndXbUJSLzgyOUVVeFlQRU9udlAwRjQ4emFhdzRwQjhUZ1RtUGJTMkFsN0dPK2NOTTVXZy9aZkVqVAorVEl1WndreWRjN1ZxUCtpVWwydkdDY3hPYUFGd0xFL3hRTjh3b1hDY3dyaXFMMmVvdmExS3p2Z051aEZtUDA0CkFmbGlZQ3VSUDNqM0l4TnNCM0xSd2tiK2dCOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:09 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1500,7 +1500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f63a485-8216-4519-9119-c24aeb22af40
+      - 792a5d93-b80c-4074-9492-0313b9c90f0b
     status: 200 OK
     code: 200
     duration: ""
@@ -1511,19 +1511,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1526ee78-8859-444d-880e-312871f1f4c3&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1200"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:09 GMT
+      - Mon, 18 Dec 2023 16:47:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1533,7 +1533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16eab4a3-efa9-40fd-a284-d0638007c127
+      - f392ce4a-db2d-46ef-ac88-37711cfd1800
     status: 200 OK
     code: 200
     duration: ""
@@ -1544,11 +1544,44 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.158.79.120/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"IP
-      allowed","direction":"inbound","ip":"163.172.149.194/32","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dce13e86-4655-4e6d-b680-3220df0412b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"IP allowed","direction":"inbound","ip":"51.15.210.198/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"IP
+      allowed","direction":"inbound","ip":"163.172.141.142/32","port":12244,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "273"
@@ -1557,7 +1590,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:09 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1567,7 +1600,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b630272-94b9-49a3-be8a-37f8567756dc
+      - e99ad99b-5521-4d7d-baf5-273868618ebb
     status: 200 OK
     code: 200
     duration: ""
@@ -1578,40 +1611,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/de3de4a0-04c5-44f6-9251-b27fa180ea9c
-    method: GET
-  response:
-    body: '{"ip":{"address":"163.172.149.194","id":"de3de4a0-04c5-44f6-9251-b27fa180ea9c","organization":"fa1e3217-dc80-42ac-85c3-3f034b78b552","prefix":null,"project":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "308"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 15:03:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 696f7287-263c-4297-b639-3cead7e7d7cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/78d361b7-6c7d-44f0-9176-ad85c1726d1b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8856b9bc-2183-4d62-9465-3998345d05a7
     method: DELETE
   response:
     body: ""
@@ -1619,7 +1619,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Mon, 18 Dec 2023 15:03:11 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1629,7 +1629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eafd75f6-7495-4145-9174-9e48745b22a3
+      - 11c45423-dcbe-4e7f-9aa6-d52e8cee1da3
     status: 204 No Content
     code: 204
     duration: ""
@@ -1640,7 +1640,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/de3de4a0-04c5-44f6-9251-b27fa180ea9c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/8569ea09-d0ac-4b3b-80b9-6f6ed67ca4e8
     method: DELETE
   response:
     body: ""
@@ -1648,7 +1648,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Mon, 18 Dec 2023 15:03:11 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90941573-a5d1-434d-9069-824d17ae7781
+      - ecbfbb6a-d36d-40c9-8bea-4d05f1ff5d46
     status: 204 No Content
     code: 204
     duration: ""
@@ -1669,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:11 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 787cf04d-6180-4d61-bddf-330f0bd97dc9
+      - 1e7b31df-7a6f-4889-b6d5-e0728193a7cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,19 +1702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:11 GMT
+      - Mon, 18 Dec 2023 16:47:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6634bd79-5389-4fd5-bf7f-794524aaa39f
+      - 051d6a80-b765-4947-9a62-9e3f2d2715f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1737,10 +1737,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":20932,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12244,"protocol":"tcp"}]}'
     headers:
       Content-Length:
       - "229"
@@ -1749,7 +1749,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:12 GMT
+      - Mon, 18 Dec 2023 16:47:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1759,7 +1759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b889b33e-db4f-4994-baaa-abb17829ce4a
+      - 12711471-5291-444d-9f75-bf23fac87fe9
     status: 200 OK
     code: 200
     duration: ""
@@ -1770,19 +1770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:12 GMT
+      - Mon, 18 Dec 2023 16:47:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1792,7 +1792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb2c5160-2dc6-4c89-acff-919b06ee5705
+      - e6c93e12-d2b0-496a-89ec-3775a039ac9e
     status: 200 OK
     code: 200
     duration: ""
@@ -1803,19 +1803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:42 GMT
+      - Mon, 18 Dec 2023 16:47:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1825,7 +1825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16e33894-c922-4f87-8c21-f7aaeb69205e
+      - 03d95cab-00a2-4640-b6d8-490ea9733b20
     status: 200 OK
     code: 200
     duration: ""
@@ -1836,10 +1836,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12244,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -1848,7 +1848,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:42 GMT
+      - Mon, 18 Dec 2023 16:47:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1858,7 +1858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6815b91-f823-4ba9-b70c-64a921020f3f
+      - c8d63767-a4d1-400a-a5c8-658fde422807
     status: 200 OK
     code: 200
     duration: ""
@@ -1869,19 +1869,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:43 GMT
+      - Mon, 18 Dec 2023 16:47:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1891,7 +1891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5768558e-a52a-40f5-bf68-19ed6d793dde
+      - 90600d7d-4245-44de-a454-0efbec4ba8c6
     status: 200 OK
     code: 200
     duration: ""
@@ -1902,7 +1902,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -1914,7 +1914,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:43 GMT
+      - Mon, 18 Dec 2023 16:47:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1924,7 +1924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34170562-8eaa-44d7-a604-2d178c84da69
+      - 12aa4b06-a8e2-4fce-8231-b4efd421fe65
     status: 200 OK
     code: 200
     duration: ""
@@ -1935,19 +1935,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRnRnbURpaHVVbFdqV0ttRDhWUzJnSUxrZkxrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TlRBeE5UQmFGdzB6TXpFeU1UVXhOVEF4TlRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNHTmNqR08rSHBJRUxmSFNiQ05STjF3dkJnSDFuU0hkcHo1aWx4cmhYOG0rcWM2WnZUc2JGTHZ1TkcKYlZDamdNU1NpSFdBNUNSV0F5ZVZIdytkQmhKS1dhU0srTnp3M2d6emhnQlVOSmRhRWFaenVKeUhDR0x2c1l3dgpnVEZ1S2Fsem5qenJWTkhxRkt5N3pDZE9BV3VYbHJuMjVrRjk1eCtHcWNoQ01BYW1MZU5vOUh4Skx0Z0Q1Wkg2CklJdU13VGhnbUtMR2gxNTg1R0dTYUZMTGFaQ0F2RURsRjN6eTRETlBFWjBjQWN1eXlNbElaRCtsNm5uZ0NXSkkKK1RYWGg5cnRLdjcyYTAvbUtjdmZqL2V4ODRjTkZyZ3JmMnFkdnhzaTQvM2JDbldlR1FXS2c2bXhlYkZtMTNObgpBeFVFMVFmcHd1eTJXMG94aEVWSFRnbFZjQjdQQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkwd1pERXdZV1ZpTnkxa1lqVm1MVFJtT1RFdE9XVTNaQzFrWWpNeFkyVmoKTldZMk9XSXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TUdReApNR0ZsWWpjdFpHSTFaaTAwWmpreExUbGxOMlF0WkdJek1XTmxZelZtTmpsaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvMW5od1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCaGRFRnQKaERSNXZ0SWVoMzNIMkJ0QXIwZXRiRlNEeFNsQURKcElyQXBqZXN0NUFEeXN0R0RHUit6cFRDZGpPaXQ4aHhmWgo1UzdBNzBMMEtQVzZHWVQyenlKQlF4M3NTbGpPUTl4VTFGR0FGMXdHRkNhK0p6QXhGdFBOWDNWZ1NYanZwMEVxCkxRRWNYc3IycU4xZjNHZzF0MHRiL2h5VnpRdmxJVituMUJONStmbnlJOFh6dUY4Q0xEdEY2RmxWZkV1NmQxZDAKanR5QmRKY0txZzVIcmFGOXRmVW1nbXo4UU5mbEwxbWFJNEhUbVFFVmpuMVJZd1NwUXprV0lVUlFxcXZkTEdiUwpFTktSOXJPTXpMaG5sclB3dnVVVktsYXlBRDRLanF3MWh5OCtRZ3dPYXRqTjJEa1lxK1J1cXF5algyVWcxdDVxCjVGZHloZTNQVlZUamNQTS8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUEJHVEVZbUkyeWpTQy85OVl3WEFtNzZYTURzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EWXlNRm9YRFRNek1USXhOVEUyTkRZeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXUxbTFlUWRXei8zZzZKSER0L3kxNW9DbXBtM3FlWkVvb1lNZXZnMnB3WFVhcDFrT3ZnY2wKUkVHWWpuRDJQZkg5ZCs2RlYyU0dFam1FR1labUE1ZnBON3FzSC9ubkdsOE95YTFYS0dsV3lFSGd3cUJ2a2hVdwowak9mSjI1SVpDdEp0dXhaRFJWYzJPcDFzTlhpWVJuckxwWTg2K2JyMGpHN3dCOTRyUlU2a01CQ3hWSXhNMXJ1CmxETEN2SFQxNTlFK0tEUDZESWlhV29nN0xyREdIYmh1ZXpGdDR0aWdlY25FZW14WS9mTkhienNRb3BhaXJ4MEUKNnV6c0N0azA1Q0dHOXRMWFRQN2dlMVdOOStCcCtPeGl1RVpOMjJlYkduakVQbU5xQWMwanl2QS9JSlhIV0ZkegpuR0ZldngrZU9xcWFFbEU1Q3Rna0x3YmFQRDV0VktEUE5RSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB4TlRJMlpXVTNPQzA0T0RVNUxUUTBOR1F0T0Rnd1pTMHoKTVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkweE5USTJaV1UzT0MwNE9EVTVMVFEwTkdRdE9EZ3daUzB6TVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZWNFU0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIT1F3bk9Oc3YwelhkZzlzczJIbTVnYmtMZG9sRXR4ZlhuNk10OGVPUWpOUkU5YzRhZzZZS3A4KzFJSgo0U3FpSFB6Uld5WFJtcHhrcmNPT0dLbEF6VGs2MkhLam8zUkZHM2tMZEtjK2NycWw4akxabityVGl0NjdNMDdxCkE3d0dVdkxmMnJwV2NpRm5OSTl1dWFnb2RTUVdNRVFubUdFOU9IZTl5MnVXREpRbGRwLzlZRmRYZktZUXRwcjQKSUJjdkdYQndXbUJSLzgyOUVVeFlQRU9udlAwRjQ4emFhdzRwQjhUZ1RtUGJTMkFsN0dPK2NOTTVXZy9aZkVqVAorVEl1WndreWRjN1ZxUCtpVWwydkdDY3hPYUFGd0xFL3hRTjh3b1hDY3dyaXFMMmVvdmExS3p2Z051aEZtUDA0CkFmbGlZQ3VSUDNqM0l4TnNCM0xSd2tiK2dCOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:43 GMT
+      - Mon, 18 Dec 2023 16:47:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1957,7 +1957,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d5b9172-03ee-4a8e-a64c-584904189e7e
+      - 48bf1efb-65ad-40c6-aa75-12d5fe1a2482
     status: 200 OK
     code: 200
     duration: ""
@@ -1968,19 +1968,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1526ee78-8859-444d-880e-312871f1f4c3&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1200"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:43 GMT
+      - Mon, 18 Dec 2023 16:47:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1990,7 +1990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95dc5cb6-8134-4df0-8051-6b19019f3c4a
+      - 843049a2-f152-48fd-8571-529859c05bce
     status: 200 OK
     code: 200
     duration: ""
@@ -2001,10 +2001,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fa9783ea-685f-4ba0-a7bb-a97fe0311e0c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12244,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -2013,7 +2046,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:44 GMT
+      - Mon, 18 Dec 2023 16:47:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2023,7 +2056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d40641c9-058f-4b4a-be5e-c055daf198f3
+      - ff32eb5e-f25d-4818-a27c-05695c138ccf
     status: 200 OK
     code: 200
     duration: ""
@@ -2034,19 +2067,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:44 GMT
+      - Mon, 18 Dec 2023 16:47:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2056,7 +2089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 612df742-4d40-4367-90dc-595925971720
+      - d1550014-b2d7-43a8-ac25-c7f41d29bee4
     status: 200 OK
     code: 200
     duration: ""
@@ -2067,7 +2100,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -2079,7 +2112,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:44 GMT
+      - Mon, 18 Dec 2023 16:47:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2089,7 +2122,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab9b4af1-d939-4b95-9106-617ee9a8a97a
+      - 8b6bfc5e-424f-41f2-af71-f0459ef7571f
     status: 200 OK
     code: 200
     duration: ""
@@ -2100,19 +2133,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRnRnbURpaHVVbFdqV0ttRDhWUzJnSUxrZkxrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TlRBeE5UQmFGdzB6TXpFeU1UVXhOVEF4TlRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNHTmNqR08rSHBJRUxmSFNiQ05STjF3dkJnSDFuU0hkcHo1aWx4cmhYOG0rcWM2WnZUc2JGTHZ1TkcKYlZDamdNU1NpSFdBNUNSV0F5ZVZIdytkQmhKS1dhU0srTnp3M2d6emhnQlVOSmRhRWFaenVKeUhDR0x2c1l3dgpnVEZ1S2Fsem5qenJWTkhxRkt5N3pDZE9BV3VYbHJuMjVrRjk1eCtHcWNoQ01BYW1MZU5vOUh4Skx0Z0Q1Wkg2CklJdU13VGhnbUtMR2gxNTg1R0dTYUZMTGFaQ0F2RURsRjN6eTRETlBFWjBjQWN1eXlNbElaRCtsNm5uZ0NXSkkKK1RYWGg5cnRLdjcyYTAvbUtjdmZqL2V4ODRjTkZyZ3JmMnFkdnhzaTQvM2JDbldlR1FXS2c2bXhlYkZtMTNObgpBeFVFMVFmcHd1eTJXMG94aEVWSFRnbFZjQjdQQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkwd1pERXdZV1ZpTnkxa1lqVm1MVFJtT1RFdE9XVTNaQzFrWWpNeFkyVmoKTldZMk9XSXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TUdReApNR0ZsWWpjdFpHSTFaaTAwWmpreExUbGxOMlF0WkdJek1XTmxZelZtTmpsaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvMW5od1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCaGRFRnQKaERSNXZ0SWVoMzNIMkJ0QXIwZXRiRlNEeFNsQURKcElyQXBqZXN0NUFEeXN0R0RHUit6cFRDZGpPaXQ4aHhmWgo1UzdBNzBMMEtQVzZHWVQyenlKQlF4M3NTbGpPUTl4VTFGR0FGMXdHRkNhK0p6QXhGdFBOWDNWZ1NYanZwMEVxCkxRRWNYc3IycU4xZjNHZzF0MHRiL2h5VnpRdmxJVituMUJONStmbnlJOFh6dUY4Q0xEdEY2RmxWZkV1NmQxZDAKanR5QmRKY0txZzVIcmFGOXRmVW1nbXo4UU5mbEwxbWFJNEhUbVFFVmpuMVJZd1NwUXprV0lVUlFxcXZkTEdiUwpFTktSOXJPTXpMaG5sclB3dnVVVktsYXlBRDRLanF3MWh5OCtRZ3dPYXRqTjJEa1lxK1J1cXF5algyVWcxdDVxCjVGZHloZTNQVlZUamNQTS8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUEJHVEVZbUkyeWpTQy85OVl3WEFtNzZYTURzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EWXlNRm9YRFRNek1USXhOVEUyTkRZeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXUxbTFlUWRXei8zZzZKSER0L3kxNW9DbXBtM3FlWkVvb1lNZXZnMnB3WFVhcDFrT3ZnY2wKUkVHWWpuRDJQZkg5ZCs2RlYyU0dFam1FR1labUE1ZnBON3FzSC9ubkdsOE95YTFYS0dsV3lFSGd3cUJ2a2hVdwowak9mSjI1SVpDdEp0dXhaRFJWYzJPcDFzTlhpWVJuckxwWTg2K2JyMGpHN3dCOTRyUlU2a01CQ3hWSXhNMXJ1CmxETEN2SFQxNTlFK0tEUDZESWlhV29nN0xyREdIYmh1ZXpGdDR0aWdlY25FZW14WS9mTkhienNRb3BhaXJ4MEUKNnV6c0N0azA1Q0dHOXRMWFRQN2dlMVdOOStCcCtPeGl1RVpOMjJlYkduakVQbU5xQWMwanl2QS9JSlhIV0ZkegpuR0ZldngrZU9xcWFFbEU1Q3Rna0x3YmFQRDV0VktEUE5RSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB4TlRJMlpXVTNPQzA0T0RVNUxUUTBOR1F0T0Rnd1pTMHoKTVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkweE5USTJaV1UzT0MwNE9EVTVMVFEwTkdRdE9EZ3daUzB6TVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZWNFU0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIT1F3bk9Oc3YwelhkZzlzczJIbTVnYmtMZG9sRXR4ZlhuNk10OGVPUWpOUkU5YzRhZzZZS3A4KzFJSgo0U3FpSFB6Uld5WFJtcHhrcmNPT0dLbEF6VGs2MkhLam8zUkZHM2tMZEtjK2NycWw4akxabityVGl0NjdNMDdxCkE3d0dVdkxmMnJwV2NpRm5OSTl1dWFnb2RTUVdNRVFubUdFOU9IZTl5MnVXREpRbGRwLzlZRmRYZktZUXRwcjQKSUJjdkdYQndXbUJSLzgyOUVVeFlQRU9udlAwRjQ4emFhdzRwQjhUZ1RtUGJTMkFsN0dPK2NOTTVXZy9aZkVqVAorVEl1WndreWRjN1ZxUCtpVWwydkdDY3hPYUFGd0xFL3hRTjh3b1hDY3dyaXFMMmVvdmExS3p2Z051aEZtUDA0CkFmbGlZQ3VSUDNqM0l4TnNCM0xSd2tiK2dCOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:44 GMT
+      - Mon, 18 Dec 2023 16:47:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2122,7 +2155,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b306b98-0583-4ea6-8e8a-f3d946ec17f9
+      - c98c119f-d7fd-4cc6-91e6-751eb8f503ac
     status: 200 OK
     code: 200
     duration: ""
@@ -2133,19 +2166,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1526ee78-8859-444d-880e-312871f1f4c3&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1200"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:44 GMT
+      - Mon, 18 Dec 2023 16:47:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2155,7 +2188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f162d66-3be3-4c46-abb6-bbd02318d2cc
+      - 907db06f-3e94-45d9-83b7-29f929d0719c
     status: 200 OK
     code: 200
     duration: ""
@@ -2166,10 +2199,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:47:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ea3e0ae-0174-478a-ae05-be28d12a8b29
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"bar","direction":"inbound","ip":"4.5.6.7/32","port":12244,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -2178,7 +2244,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:45 GMT
+      - Mon, 18 Dec 2023 16:47:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2188,7 +2254,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31c72e9d-a9fd-4efb-9f32-8fb50d290de9
+      - a2e332b2-fb4d-491c-8876-bfabd1ce40b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2199,19 +2265,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:45 GMT
+      - Mon, 18 Dec 2023 16:47:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2221,7 +2287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25528a1a-6c11-4a8a-ba8b-2f7fd73c6744
+      - 0400c20f-e7e0-4f01-97b8-1adb099309ec
     status: 200 OK
     code: 200
     duration: ""
@@ -2232,19 +2298,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:45 GMT
+      - Mon, 18 Dec 2023 16:47:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2254,7 +2320,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce81857c-0163-40e9-9045-7466a6ad8c4c
+      - 59afe4ea-bb98-49c1-aa5b-fabffea400f3
     status: 200 OK
     code: 200
     duration: ""
@@ -2267,10 +2333,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
     method: PUT
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":20932,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12244,"protocol":"tcp"}]}'
     headers:
       Content-Length:
       - "229"
@@ -2279,7 +2345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:46 GMT
+      - Mon, 18 Dec 2023 16:47:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2289,7 +2355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50e91a37-d59d-4010-b955-ef0ff813fdeb
+      - 07d67354-e622-4748-9cb8-4d506ba03410
     status: 200 OK
     code: 200
     duration: ""
@@ -2300,19 +2366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:03:46 GMT
+      - Mon, 18 Dec 2023 16:47:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2322,7 +2388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf456109-01e3-4737-b143-e222a04cb55c
+      - e6862a7a-a199-43d4-b4f0-18e344d8d9fb
     status: 200 OK
     code: 200
     duration: ""
@@ -2333,19 +2399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:16 GMT
+      - Mon, 18 Dec 2023 16:48:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2355,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3af2e14-c42b-4de1-afb2-46eaac62f34a
+      - b97e638d-e5a2-438d-a9fa-3cdeb9ce50e2
     status: 200 OK
     code: 200
     duration: ""
@@ -2366,10 +2432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12244,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -2378,7 +2444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:17 GMT
+      - Mon, 18 Dec 2023 16:48:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2388,7 +2454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea0ec456-1b49-4d59-bd2f-54235410ed32
+      - 23bd5531-9a4b-4e3e-95bb-a7d855058354
     status: 200 OK
     code: 200
     duration: ""
@@ -2399,19 +2465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:17 GMT
+      - Mon, 18 Dec 2023 16:48:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2421,7 +2487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d894b0fc-62e0-4fd8-b8b6-560376e14b27
+      - 4bfc2e97-1181-43d5-b9fa-59b87199b2b4
     status: 200 OK
     code: 200
     duration: ""
@@ -2432,7 +2498,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -2444,7 +2510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:18 GMT
+      - Mon, 18 Dec 2023 16:48:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2454,7 +2520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c994b1e-105e-4ec2-83bf-6f79c174c55a
+      - a95ca265-d1d2-4ba8-b5b4-dc6db0414a3e
     status: 200 OK
     code: 200
     duration: ""
@@ -2465,19 +2531,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRnRnbURpaHVVbFdqV0ttRDhWUzJnSUxrZkxrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TlRBeE5UQmFGdzB6TXpFeU1UVXhOVEF4TlRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNHTmNqR08rSHBJRUxmSFNiQ05STjF3dkJnSDFuU0hkcHo1aWx4cmhYOG0rcWM2WnZUc2JGTHZ1TkcKYlZDamdNU1NpSFdBNUNSV0F5ZVZIdytkQmhKS1dhU0srTnp3M2d6emhnQlVOSmRhRWFaenVKeUhDR0x2c1l3dgpnVEZ1S2Fsem5qenJWTkhxRkt5N3pDZE9BV3VYbHJuMjVrRjk1eCtHcWNoQ01BYW1MZU5vOUh4Skx0Z0Q1Wkg2CklJdU13VGhnbUtMR2gxNTg1R0dTYUZMTGFaQ0F2RURsRjN6eTRETlBFWjBjQWN1eXlNbElaRCtsNm5uZ0NXSkkKK1RYWGg5cnRLdjcyYTAvbUtjdmZqL2V4ODRjTkZyZ3JmMnFkdnhzaTQvM2JDbldlR1FXS2c2bXhlYkZtMTNObgpBeFVFMVFmcHd1eTJXMG94aEVWSFRnbFZjQjdQQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkwd1pERXdZV1ZpTnkxa1lqVm1MVFJtT1RFdE9XVTNaQzFrWWpNeFkyVmoKTldZMk9XSXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TUdReApNR0ZsWWpjdFpHSTFaaTAwWmpreExUbGxOMlF0WkdJek1XTmxZelZtTmpsaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvMW5od1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCaGRFRnQKaERSNXZ0SWVoMzNIMkJ0QXIwZXRiRlNEeFNsQURKcElyQXBqZXN0NUFEeXN0R0RHUit6cFRDZGpPaXQ4aHhmWgo1UzdBNzBMMEtQVzZHWVQyenlKQlF4M3NTbGpPUTl4VTFGR0FGMXdHRkNhK0p6QXhGdFBOWDNWZ1NYanZwMEVxCkxRRWNYc3IycU4xZjNHZzF0MHRiL2h5VnpRdmxJVituMUJONStmbnlJOFh6dUY4Q0xEdEY2RmxWZkV1NmQxZDAKanR5QmRKY0txZzVIcmFGOXRmVW1nbXo4UU5mbEwxbWFJNEhUbVFFVmpuMVJZd1NwUXprV0lVUlFxcXZkTEdiUwpFTktSOXJPTXpMaG5sclB3dnVVVktsYXlBRDRLanF3MWh5OCtRZ3dPYXRqTjJEa1lxK1J1cXF5algyVWcxdDVxCjVGZHloZTNQVlZUamNQTS8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUEJHVEVZbUkyeWpTQy85OVl3WEFtNzZYTURzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EWXlNRm9YRFRNek1USXhOVEUyTkRZeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXUxbTFlUWRXei8zZzZKSER0L3kxNW9DbXBtM3FlWkVvb1lNZXZnMnB3WFVhcDFrT3ZnY2wKUkVHWWpuRDJQZkg5ZCs2RlYyU0dFam1FR1labUE1ZnBON3FzSC9ubkdsOE95YTFYS0dsV3lFSGd3cUJ2a2hVdwowak9mSjI1SVpDdEp0dXhaRFJWYzJPcDFzTlhpWVJuckxwWTg2K2JyMGpHN3dCOTRyUlU2a01CQ3hWSXhNMXJ1CmxETEN2SFQxNTlFK0tEUDZESWlhV29nN0xyREdIYmh1ZXpGdDR0aWdlY25FZW14WS9mTkhienNRb3BhaXJ4MEUKNnV6c0N0azA1Q0dHOXRMWFRQN2dlMVdOOStCcCtPeGl1RVpOMjJlYkduakVQbU5xQWMwanl2QS9JSlhIV0ZkegpuR0ZldngrZU9xcWFFbEU1Q3Rna0x3YmFQRDV0VktEUE5RSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB4TlRJMlpXVTNPQzA0T0RVNUxUUTBOR1F0T0Rnd1pTMHoKTVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkweE5USTJaV1UzT0MwNE9EVTVMVFEwTkdRdE9EZ3daUzB6TVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZWNFU0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIT1F3bk9Oc3YwelhkZzlzczJIbTVnYmtMZG9sRXR4ZlhuNk10OGVPUWpOUkU5YzRhZzZZS3A4KzFJSgo0U3FpSFB6Uld5WFJtcHhrcmNPT0dLbEF6VGs2MkhLam8zUkZHM2tMZEtjK2NycWw4akxabityVGl0NjdNMDdxCkE3d0dVdkxmMnJwV2NpRm5OSTl1dWFnb2RTUVdNRVFubUdFOU9IZTl5MnVXREpRbGRwLzlZRmRYZktZUXRwcjQKSUJjdkdYQndXbUJSLzgyOUVVeFlQRU9udlAwRjQ4emFhdzRwQjhUZ1RtUGJTMkFsN0dPK2NOTTVXZy9aZkVqVAorVEl1WndreWRjN1ZxUCtpVWwydkdDY3hPYUFGd0xFL3hRTjh3b1hDY3dyaXFMMmVvdmExS3p2Z051aEZtUDA0CkFmbGlZQ3VSUDNqM0l4TnNCM0xSd2tiK2dCOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:18 GMT
+      - Mon, 18 Dec 2023 16:48:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2487,7 +2553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bf4cfe0-219f-409d-ad57-468e42ba730f
+      - 684e4d9e-ea34-47b6-9acf-696598fe9220
     status: 200 OK
     code: 200
     duration: ""
@@ -2498,19 +2564,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1526ee78-8859-444d-880e-312871f1f4c3&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1200"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:18 GMT
+      - Mon, 18 Dec 2023 16:48:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2520,7 +2586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9284c27-36cc-4896-82fd-f00e49cbe4a4
+      - ee32d1cf-e879-4cf0-9af9-e2008d327536
     status: 200 OK
     code: 200
     duration: ""
@@ -2531,19 +2597,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "245"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:18 GMT
+      - Mon, 18 Dec 2023 16:48:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2553,7 +2619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e73b2829-ea4d-4207-b33b-ca409233947d
+      - a5405dd5-09e6-4590-8d20-a56af16e75a8
     status: 200 OK
     code: 200
     duration: ""
@@ -2564,76 +2630,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1200"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 15:04:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33b19f7b-7f85-4089-8251-7b53cf8f6dd5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1200"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 15:04:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eed4d757-c6c4-42fa-aef3-0fd66166ca22
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
-    method: GET
-  response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":20932,"protocol":"tcp"}],"total_count":2}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12244,"protocol":"tcp"}],"total_count":2}'
     headers:
       Content-Length:
       - "245"
@@ -2642,7 +2642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:18 GMT
+      - Mon, 18 Dec 2023 16:48:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2652,7 +2652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7ab5d09-5a89-4a3e-8b76-abb4aae07756
+      - 1087c070-a0cf-41c3-a706-78e3e9db5184
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,7 +2663,106 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:48:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 71118120-ccc3-4cbe-b661-7eefb13c53fd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:48:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9351e5f-21bc-4690-bc5a-8832eadddf7c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
+    method: GET
+  response:
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12244,"protocol":"tcp"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "245"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:48:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4a101e12-4fc0-4b0a-9a13-0f6b59af0623
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -2675,7 +2774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:19 GMT
+      - Mon, 18 Dec 2023 16:48:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2685,7 +2784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bb542cb-801b-48d4-b431-54e422ac5284
+      - f57a7d48-a773-4aa1-91a7-e162285e84ba
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,19 +2795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRnRnbURpaHVVbFdqV0ttRDhWUzJnSUxrZkxrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TlRBeE5UQmFGdzB6TXpFeU1UVXhOVEF4TlRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNHTmNqR08rSHBJRUxmSFNiQ05STjF3dkJnSDFuU0hkcHo1aWx4cmhYOG0rcWM2WnZUc2JGTHZ1TkcKYlZDamdNU1NpSFdBNUNSV0F5ZVZIdytkQmhKS1dhU0srTnp3M2d6emhnQlVOSmRhRWFaenVKeUhDR0x2c1l3dgpnVEZ1S2Fsem5qenJWTkhxRkt5N3pDZE9BV3VYbHJuMjVrRjk1eCtHcWNoQ01BYW1MZU5vOUh4Skx0Z0Q1Wkg2CklJdU13VGhnbUtMR2gxNTg1R0dTYUZMTGFaQ0F2RURsRjN6eTRETlBFWjBjQWN1eXlNbElaRCtsNm5uZ0NXSkkKK1RYWGg5cnRLdjcyYTAvbUtjdmZqL2V4ODRjTkZyZ3JmMnFkdnhzaTQvM2JDbldlR1FXS2c2bXhlYkZtMTNObgpBeFVFMVFmcHd1eTJXMG94aEVWSFRnbFZjQjdQQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkwd1pERXdZV1ZpTnkxa1lqVm1MVFJtT1RFdE9XVTNaQzFrWWpNeFkyVmoKTldZMk9XSXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TUdReApNR0ZsWWpjdFpHSTFaaTAwWmpreExUbGxOMlF0WkdJek1XTmxZelZtTmpsaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvMW5od1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCaGRFRnQKaERSNXZ0SWVoMzNIMkJ0QXIwZXRiRlNEeFNsQURKcElyQXBqZXN0NUFEeXN0R0RHUit6cFRDZGpPaXQ4aHhmWgo1UzdBNzBMMEtQVzZHWVQyenlKQlF4M3NTbGpPUTl4VTFGR0FGMXdHRkNhK0p6QXhGdFBOWDNWZ1NYanZwMEVxCkxRRWNYc3IycU4xZjNHZzF0MHRiL2h5VnpRdmxJVituMUJONStmbnlJOFh6dUY4Q0xEdEY2RmxWZkV1NmQxZDAKanR5QmRKY0txZzVIcmFGOXRmVW1nbXo4UU5mbEwxbWFJNEhUbVFFVmpuMVJZd1NwUXprV0lVUlFxcXZkTEdiUwpFTktSOXJPTXpMaG5sclB3dnVVVktsYXlBRDRLanF3MWh5OCtRZ3dPYXRqTjJEa1lxK1J1cXF5algyVWcxdDVxCjVGZHloZTNQVlZUamNQTS8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUEJHVEVZbUkyeWpTQy85OVl3WEFtNzZYTURzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EWXlNRm9YRFRNek1USXhOVEUyTkRZeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXUxbTFlUWRXei8zZzZKSER0L3kxNW9DbXBtM3FlWkVvb1lNZXZnMnB3WFVhcDFrT3ZnY2wKUkVHWWpuRDJQZkg5ZCs2RlYyU0dFam1FR1labUE1ZnBON3FzSC9ubkdsOE95YTFYS0dsV3lFSGd3cUJ2a2hVdwowak9mSjI1SVpDdEp0dXhaRFJWYzJPcDFzTlhpWVJuckxwWTg2K2JyMGpHN3dCOTRyUlU2a01CQ3hWSXhNMXJ1CmxETEN2SFQxNTlFK0tEUDZESWlhV29nN0xyREdIYmh1ZXpGdDR0aWdlY25FZW14WS9mTkhienNRb3BhaXJ4MEUKNnV6c0N0azA1Q0dHOXRMWFRQN2dlMVdOOStCcCtPeGl1RVpOMjJlYkduakVQbU5xQWMwanl2QS9JSlhIV0ZkegpuR0ZldngrZU9xcWFFbEU1Q3Rna0x3YmFQRDV0VktEUE5RSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB4TlRJMlpXVTNPQzA0T0RVNUxUUTBOR1F0T0Rnd1pTMHoKTVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkweE5USTJaV1UzT0MwNE9EVTVMVFEwTkdRdE9EZ3daUzB6TVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZWNFU0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIT1F3bk9Oc3YwelhkZzlzczJIbTVnYmtMZG9sRXR4ZlhuNk10OGVPUWpOUkU5YzRhZzZZS3A4KzFJSgo0U3FpSFB6Uld5WFJtcHhrcmNPT0dLbEF6VGs2MkhLam8zUkZHM2tMZEtjK2NycWw4akxabityVGl0NjdNMDdxCkE3d0dVdkxmMnJwV2NpRm5OSTl1dWFnb2RTUVdNRVFubUdFOU9IZTl5MnVXREpRbGRwLzlZRmRYZktZUXRwcjQKSUJjdkdYQndXbUJSLzgyOUVVeFlQRU9udlAwRjQ4emFhdzRwQjhUZ1RtUGJTMkFsN0dPK2NOTTVXZy9aZkVqVAorVEl1WndreWRjN1ZxUCtpVWwydkdDY3hPYUFGd0xFL3hRTjh3b1hDY3dyaXFMMmVvdmExS3p2Z051aEZtUDA0CkFmbGlZQ3VSUDNqM0l4TnNCM0xSd2tiK2dCOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:19 GMT
+      - Mon, 18 Dec 2023 16:48:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2718,7 +2817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbe0d82d-c104-42df-926d-eea0ee124c49
+      - ac2cdc12-d968-4b65-a17a-398c410576ba
     status: 200 OK
     code: 200
     duration: ""
@@ -2729,19 +2828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1526ee78-8859-444d-880e-312871f1f4c3&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1200"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:19 GMT
+      - Mon, 18 Dec 2023 16:48:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2751,7 +2850,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c2b8829-09ad-4f34-9e95-6079bac2e5d9
+      - fe00ef15-76cd-4ec6-8e57-b0d03047bab7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:48:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d8553859-2c46-4c42-87a2-412f6dfcad2f
     status: 200 OK
     code: 200
     duration: ""
@@ -2764,10 +2896,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/acls
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/acls
     method: DELETE
   response:
-    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":20932,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":20932,"protocol":"tcp"}]}'
+    body: '{"rules":[{"action":"allow","description":"foo","direction":"inbound","ip":"1.2.3.4/32","port":12244,"protocol":"tcp"},{"action":"allow","description":"baz","direction":"inbound","ip":"9.0.0.0/16","port":12244,"protocol":"tcp"}]}'
     headers:
       Content-Length:
       - "229"
@@ -2776,7 +2908,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:19 GMT
+      - Mon, 18 Dec 2023 16:48:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2786,7 +2918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62ab647b-a98a-4e6a-ac8f-baa6bd198b4f
+      - 8b9b73a7-bb6c-49bf-9284-586acc7896b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2797,19 +2929,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1206"
+      - "1210"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:19 GMT
+      - Mon, 18 Dec 2023 16:48:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2819,7 +2951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7bd00b1-1f0c-49da-b91a-9adaeae21244
+      - 29ac7961-4e89-4437-a536-5fa8e7cc1aef
     status: 200 OK
     code: 200
     duration: ""
@@ -2830,19 +2962,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:51 GMT
+      - Mon, 18 Dec 2023 16:49:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2852,7 +2984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80c351c2-41f6-4878-b7b4-7583c1884a23
+      - bae8df99-8dde-4c86-8042-d9dce448df0f
     status: 200 OK
     code: 200
     duration: ""
@@ -2863,19 +2995,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:52 GMT
+      - Mon, 18 Dec 2023 16:49:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2885,7 +3017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58595863-d2a7-4532-82b6-0b00e8891287
+      - efeefebe-af78-4cb5-8473-7324d52629fd
     status: 200 OK
     code: 200
     duration: ""
@@ -2896,7 +3028,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/users?order_by=name_asc&page=1
     method: GET
   response:
     body: '{"total_count":0,"users":[]}'
@@ -2908,7 +3040,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:54 GMT
+      - Mon, 18 Dec 2023 16:49:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2918,7 +3050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02f702c5-abbd-471f-8e5b-8403cd8879ba
+      - adcce8b8-32ed-43d4-b9e9-500255ca1866
     status: 200 OK
     code: 200
     duration: ""
@@ -2929,19 +3061,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVRnRnbURpaHVVbFdqV0ttRDhWUzJnSUxrZkxrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TlRBeE5UQmFGdzB6TXpFeU1UVXhOVEF4TlRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNHTmNqR08rSHBJRUxmSFNiQ05STjF3dkJnSDFuU0hkcHo1aWx4cmhYOG0rcWM2WnZUc2JGTHZ1TkcKYlZDamdNU1NpSFdBNUNSV0F5ZVZIdytkQmhKS1dhU0srTnp3M2d6emhnQlVOSmRhRWFaenVKeUhDR0x2c1l3dgpnVEZ1S2Fsem5qenJWTkhxRkt5N3pDZE9BV3VYbHJuMjVrRjk1eCtHcWNoQ01BYW1MZU5vOUh4Skx0Z0Q1Wkg2CklJdU13VGhnbUtMR2gxNTg1R0dTYUZMTGFaQ0F2RURsRjN6eTRETlBFWjBjQWN1eXlNbElaRCtsNm5uZ0NXSkkKK1RYWGg5cnRLdjcyYTAvbUtjdmZqL2V4ODRjTkZyZ3JmMnFkdnhzaTQvM2JDbldlR1FXS2c2bXhlYkZtMTNObgpBeFVFMVFmcHd1eTJXMG94aEVWSFRnbFZjQjdQQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkwd1pERXdZV1ZpTnkxa1lqVm1MVFJtT1RFdE9XVTNaQzFrWWpNeFkyVmoKTldZMk9XSXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TUdReApNR0ZsWWpjdFpHSTFaaTAwWmpreExUbGxOMlF0WkdJek1XTmxZelZtTmpsaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdUVUwvMW5od1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCaGRFRnQKaERSNXZ0SWVoMzNIMkJ0QXIwZXRiRlNEeFNsQURKcElyQXBqZXN0NUFEeXN0R0RHUit6cFRDZGpPaXQ4aHhmWgo1UzdBNzBMMEtQVzZHWVQyenlKQlF4M3NTbGpPUTl4VTFGR0FGMXdHRkNhK0p6QXhGdFBOWDNWZ1NYanZwMEVxCkxRRWNYc3IycU4xZjNHZzF0MHRiL2h5VnpRdmxJVituMUJONStmbnlJOFh6dUY4Q0xEdEY2RmxWZkV1NmQxZDAKanR5QmRKY0txZzVIcmFGOXRmVW1nbXo4UU5mbEwxbWFJNEhUbVFFVmpuMVJZd1NwUXprV0lVUlFxcXZkTEdiUwpFTktSOXJPTXpMaG5sclB3dnVVVktsYXlBRDRLanF3MWh5OCtRZ3dPYXRqTjJEa1lxK1J1cXF5algyVWcxdDVxCjVGZHloZTNQVlZUamNQTS8KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUEJHVEVZbUkyeWpTQy85OVl3WEFtNzZYTURzd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFMk5EWXlNRm9YRFRNek1USXhOVEUyTkRZeU1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXUxbTFlUWRXei8zZzZKSER0L3kxNW9DbXBtM3FlWkVvb1lNZXZnMnB3WFVhcDFrT3ZnY2wKUkVHWWpuRDJQZkg5ZCs2RlYyU0dFam1FR1labUE1ZnBON3FzSC9ubkdsOE95YTFYS0dsV3lFSGd3cUJ2a2hVdwowak9mSjI1SVpDdEp0dXhaRFJWYzJPcDFzTlhpWVJuckxwWTg2K2JyMGpHN3dCOTRyUlU2a01CQ3hWSXhNMXJ1CmxETEN2SFQxNTlFK0tEUDZESWlhV29nN0xyREdIYmh1ZXpGdDR0aWdlY25FZW14WS9mTkhienNRb3BhaXJ4MEUKNnV6c0N0azA1Q0dHOXRMWFRQN2dlMVdOOStCcCtPeGl1RVpOMjJlYkduakVQbU5xQWMwanl2QS9JSlhIV0ZkegpuR0ZldngrZU9xcWFFbEU1Q3Rna0x3YmFQRDV0VktEUE5RSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB4TlRJMlpXVTNPQzA0T0RVNUxUUTBOR1F0T0Rnd1pTMHoKTVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkweE5USTJaV1UzT0MwNE9EVTVMVFEwTkdRdE9EZ3daUzB6TVRJNE56Rm1NV1kwWXpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZWNFU0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIT1F3bk9Oc3YwelhkZzlzczJIbTVnYmtMZG9sRXR4ZlhuNk10OGVPUWpOUkU5YzRhZzZZS3A4KzFJSgo0U3FpSFB6Uld5WFJtcHhrcmNPT0dLbEF6VGs2MkhLam8zUkZHM2tMZEtjK2NycWw4akxabityVGl0NjdNMDdxCkE3d0dVdkxmMnJwV2NpRm5OSTl1dWFnb2RTUVdNRVFubUdFOU9IZTl5MnVXREpRbGRwLzlZRmRYZktZUXRwcjQKSUJjdkdYQndXbUJSLzgyOUVVeFlQRU9udlAwRjQ4emFhdzRwQjhUZ1RtUGJTMkFsN0dPK2NOTTVXZy9aZkVqVAorVEl1WndreWRjN1ZxUCtpVWwydkdDY3hPYUFGd0xFL3hRTjh3b1hDY3dyaXFMMmVvdmExS3p2Z051aEZtUDA0CkFmbGlZQ3VSUDNqM0l4TnNCM0xSd2tiK2dCOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1995"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:55 GMT
+      - Mon, 18 Dec 2023 16:49:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2951,7 +3083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18e3050d-3b9e-4656-a2e2-af9eeb944016
+      - 5802c2dc-8933-4c3e-85d2-4ca86821996b
     status: 200 OK
     code: 200
     duration: ""
@@ -2962,19 +3094,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1526ee78-8859-444d-880e-312871f1f4c3&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1200"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:55 GMT
+      - Mon, 18 Dec 2023 16:49:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2984,7 +3116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9373d478-2834-45f6-96bd-14cb9f9acb7c
+      - 81062b2e-99dd-4123-b0d2-f72fbaf1d9fd
     status: 200 OK
     code: 200
     duration: ""
@@ -2995,19 +3127,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1204"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 16:49:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4158153-b41d-4646-86e2-554cd804d97f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:56 GMT
+      - Mon, 18 Dec 2023 16:49:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3017,7 +3182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d84f7395-727f-4af5-a0ef-03c3ccce99b3
+      - f2a269d2-13ee-4bfd-8f70-fc06ba42ca41
     status: 200 OK
     code: 200
     duration: ""
@@ -3028,19 +3193,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:57:54.926869Z","retention":7},"created_at":"2023-12-18T14:57:54.926869Z","endpoint":{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932},"endpoints":[{"id":"74d5d906-bbbd-4d49-9f6d-145cecbb11a6","ip":"51.158.56.32","load_balancer":{},"name":null,"port":20932}],"engine":"PostgreSQL-15","id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T16:43:38.854806Z","retention":7},"created_at":"2023-12-18T16:43:38.854806Z","endpoint":{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244},"endpoints":[{"id":"941a186b-3d45-4eb0-9846-6dc0fb27061b","ip":"51.159.207.148","load_balancer":{},"name":null,"port":12244}],"engine":"PostgreSQL-15","id":"1526ee78-8859-444d-880e-312871f1f4c3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"rdb-acl-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1203"
+      - "1207"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:04:56 GMT
+      - Mon, 18 Dec 2023 16:49:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3050,7 +3215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fce6baee-9456-4717-9878-68bd76b0a04c
+      - b6170148-255b-4bec-b9f7-6a81b086b543
     status: 200 OK
     code: 200
     duration: ""
@@ -3061,10 +3226,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1526ee78-8859-444d-880e-312871f1f4c3","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3073,7 +3238,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:05:27 GMT
+      - Mon, 18 Dec 2023 16:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3083,7 +3248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2985e525-83b1-46c7-805e-f5b668e01679
+      - ebec41fe-5aba-4314-b009-9fd929129706
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3094,10 +3259,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0d10aeb7-db5f-4f91-9e7d-db31cec5f69b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1526ee78-8859-444d-880e-312871f1f4c3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0d10aeb7-db5f-4f91-9e7d-db31cec5f69b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1526ee78-8859-444d-880e-312871f1f4c3","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3106,7 +3271,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 15:05:28 GMT
+      - Mon, 18 Dec 2023 16:49:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3116,7 +3281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ae007b4-07be-4778-aea6-ccc9d71c0420
+      - d2010949-f431-4037-97e4-6f70eb260e5d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-backup-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-database-backup-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:02 GMT
+      - Mon, 18 Dec 2023 14:50:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22be7049-a2b5-4240-8a59-149c593e677e
+      - ee34240c-4381-40b0-805a-d13f48412c01
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:02:16 GMT
+      - Mon, 18 Dec 2023 14:50:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fed68cfb-efc8-404e-a069-de25b17ddc59
+      - d4b8939c-a858-49ef-8621-d288e2918896
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:02:16 GMT
+      - Mon, 18 Dec 2023 14:50:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5925b5e5-910b-41f3-99e2-84f07d766d96
+      - 6c7ae1ab-8980-4e23-b5b2-371970fb1d31
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:02:46 GMT
+      - Mon, 18 Dec 2023 14:51:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 041eb740-87a0-4efe-9f10-07d632a9cbfb
+      - 8de3b7da-08eb-473e-ab7a-90fce2b464ac
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:03:17 GMT
+      - Mon, 18 Dec 2023 14:51:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 354fccf5-4c79-4156-bf23-5a8ae1d0a9d7
+      - 1b66ff06-0aee-4ec8-ad07-b8c9541ef9ab
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:03:47 GMT
+      - Mon, 18 Dec 2023 14:52:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45d0d643-336d-4afc-b7bf-05f13a567895
+      - 8583e130-be83-44ff-b86e-1ddf7b4282ee
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:04:18 GMT
+      - Mon, 18 Dec 2023 14:52:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2683dcd-7397-4f77-b531-bdd7de0591d9
+      - 5cd47251-06da-4b73-bcd1-1226f6df8832
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:04:48 GMT
+      - Mon, 18 Dec 2023 14:53:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0feb718c-f753-483b-b84f-03f9e2ba6fb4
+      - f77c5666-4b37-4655-b5a9-098691a33675
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "920"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:05:18 GMT
+      - Mon, 18 Dec 2023 14:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,73 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79288e0e-dc81-40c8-be29-9a6928e04352
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1184"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:05:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42fc1ca9-24c0-4e5e-9590-24653b2bc6f3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1229"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:06:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 255b06d3-9a2d-4db1-9bfc-9489f59bc45e
+      - 7bc34c93-71c1-40da-a577-aab017e49eaf
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:25 GMT
+      - Mon, 18 Dec 2023 14:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0d33ae5-f768-47e5-b637-6f261779b791
+      - 50507ca9-3c20-4946-84cc-2a884d392ea8
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:26 GMT
+      - Mon, 18 Dec 2023 14:53:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd8c1482-1304-43f3-a4d2-fd8a6afacb92
+      - a900b619-af5f-4dfe-97aa-11a3e4b6e3bd
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYThpazBkYjJWRm1nQi9DL3RBRHQvb3RGSy9vd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBOVm9YRFRNek1USXhOVEV6TURVME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXEyOWczZk5KdmF3c29rNVNWckpHN0xpNnljcEhuVGdXZ3ZTZDJXaEtTOXNBV0lIbm14WXQKUXBOcWNQcHdSSUcrT0dEaTZnbDB4UnRXbXAxVkRPNHFuNndWaFFTemRiWjJuNGc2SlJ4WU9GWVdqaDlqUXpNWgpEQkd6c3pWZmc1eEw0U0E5d3NCNXY1N0RMUnZtY0xsaWhSUlIzbWRxU2VHUnlNRHBKWVNVdHZzQnY3MDdWSmxvCmczWUpFQ0NEZXJ5NDdueDVVOFZTRktxaUNmVU8venJkaVd3cDNrRWJuaGRFOXArMURKOTlGQ3pxYmlWRkpZYjYKQ2JQeUp0Q1RETXgwMjBGVmdaNVhxNFh4Q3NoWHpYb0hVSFp6RFN1UUVPUnQrUlFOUmtyN3k4MVRzeCs2Y3o4cwp0QncwSlNiRitGdHVkbUhQSkkrMVgvTXdlVW5CZ3dYTjd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFtWkRKall6Vm1ZUzFtWkRFekxUUXlOV1F0WVRJeFpDMDMKTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbVpESmpZelZtWVMxbVpERXpMVFF5TldRdFlUSXhaQzAzTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBcVJTTWFsVmIxVDZmOXREUWlNSWJGODR5b1BSejZlVGlVK1hLcFpob0w0SWMza3o3bEYxZUpnckgwTQpzOU5FVi9rWW93OHAvRjBoM0FHSk5NMUJWdlh3UmZnM3RudGVSQk5HQ3prdjdiVGI0aTdXR3BxWU5OU00yZ0VYCk1QUm1vYnRKMm02VEt0d0Q5WUhwYlFDR0gyNU82dS9KaGJDVVdqcmVMcmVrdDhnYmFQVkVSTG1XSldPMzhNeU4KK3IyUmZDdCtTbitiRVJVZFl0NkZVa2FDY0xlTXFDajdDWXZ5NkloVU9IeUdGWWxMdHFVc2JVd1hGWEl0T3RNRAorWUpVcnpYQXV0WGFrQjc1dnJwTHBqYjl5UlpsZmFGLzA3KzExY3c4bjRyOXFXQ2t3cW9UdVdYUXoxa1hxcnpQCmVkVlN4WWVqRUJ3cEdLQm5HVjRIMk55TkxEMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:26 GMT
+      - Mon, 18 Dec 2023 14:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac1e8231-7905-49c4-9d60-a7988da115b3
+      - 34512b85-81d9-44fe-a3c3-5c375a5ea4c7
     status: 200 OK
     code: 200
     duration: ""
@@ -772,7 +706,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fd2cc5fa-fd13-425d-a21d-7345a97ee95b&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVVVZRVW1BM09BNllKaXJ0NE9pVXh6ZmxTWi9Zd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRVek1qQmFGdzB6TXpFeU1UVXhORFV6TWpCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUN0SGhjc0Z5cmpsKzRaYVdnWmFJMTc0c0xCdzBJdjVxNElueWpPa2d2SzUzQUFvVWJqUFpzNnRKVkEKbEMvZHY0QjRrU2kxTXoyRy9xZ3o4am1RZUE2SjJqMUhweHRVODFNVGxrekVQTUtHRGF6N09UeWw1WjJwd0FWMQpqRjBVVEMvRHJWUzZuNDFURnlpNG1GUDZ2akw2dlZwbFhTRVZHZndPbnMzUE44dCtTS01RQTB4Ui9tak5Na1FoCnVObWpYWTNYZjhSTWttN1lPUGZuMFhnZm1uMFN4NExMRkF3UGZVbHNjRktoYU5vcGNEWGdGRkVTQ3lmT1V6QUsKaGhYZ0FTcmZ0WUNUWlRSTnZOUWtKQnZYVVNNaUJSYVRGVk83ajdSd3F5b3JPLzBScm5tdGVySU1zZHpXRmo1RApNV2RDZmZ5dFhSQm5OM3IxSFZ5cmNBUlFMeDZqQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkxaU5UWXlNV1ZoTWkwMU4yVmxMVFF4TVdZdFlqSmtaUzAxTkdKbU9UQTMKTWpNNE9UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0WWpVMgpNakZsWVRJdE5UZGxaUzAwTVRGbUxXSXlaR1V0TlRSaVpqa3dOekl6T0RrekxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdRekQ5SFJod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTFA3TVgKK2M3VWdrSHQyUkVaa29laDdTTFBPWUtkWkJKbWxyRWFxK0pUVDdrdFdTWGg0RE9NdWQyOEhJbk1NSndZSmJ1WApBRzFRRk42S3cwcFovQS9jc3RGVStKSlFqL1gwVHNyTXZkdEVJL2J5TklZOHo0Y1FpRDBxRWJ3WCs1amczY3R2CnBtWDVqRXZISmY4R0VDckNWZVNXUTNucGswVTF2MHhZaVpzaDRaUVQwdmNjQTYweGpKK0Y3emkraHV3dVhhcFEKT0xWVFk1RmVJUmh3WCt2aDA0RFVSK3ZoM1NyYnlNRU5tUmV2N0V1a2dXWllNNksyY0ZQZVdWRmVxU2kvVTRwawpmN0Uwb1VvQ29kRG9NVjZSVUZXSXlZamN4cGhiWVpRZ1d3SUZFRFpTMWdXaHNvMUJqOTFlNGcvaVBsL3RJQWN2CjcvMFA3NFZ3cjczdVBjRjkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:53:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a500359-ba83-44c0-a154-47bccd7885bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=b5621ea2-57ee-411f-b2de-54bf90723893&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -784,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:26 GMT
+      - Mon, 18 Dec 2023 14:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 290d0a96-f5ef-43ce-98de-d16b07702e28
+      - e1726f3a-405d-4e7c-b3ff-106f24712dc6
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:26 GMT
+      - Mon, 18 Dec 2023 14:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e4bfbe9-f64c-467c-848d-fa834415d57a
+      - fd5080b0-3d77-4a96-a5fa-12c4e71af481
     status: 200 OK
     code: 200
     duration: ""
@@ -840,7 +807,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
@@ -852,7 +819,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:32 GMT
+      - Mon, 18 Dec 2023 14:53:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6281d204-f13b-4e06-91bb-cd767ff10f7a
+      - 09d7af60-4597-44d6-8c5c-f8cc356462d7
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +840,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:34 GMT
+      - Mon, 18 Dec 2023 14:53:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97a4afc6-bebc-4eb1-b6fe-052b006ba26f
+      - 757555cd-bff4-4ff7-a119-c0fc39a80b53
     status: 200 OK
     code: 200
     duration: ""
@@ -906,43 +873,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:06:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 269db255-dfe7-484e-bfc4-7e24a920fedb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -951,7 +885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:35 GMT
+      - Mon, 18 Dec 2023 14:53:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5267e780-35fa-4c25-8eda-8be5276bdc90
+      - 5a9c1bd0-75c2-4f0c-ab3e-c67c17a69af2
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
-      - "1229"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:35 GMT
+      - Mon, 18 Dec 2023 14:53:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea5f2337-bd56-4140-b839-44dd35806a44
+      - 304e73ee-244e-4589-bdab-33b438abda14
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYThpazBkYjJWRm1nQi9DL3RBRHQvb3RGSy9vd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBOVm9YRFRNek1USXhOVEV6TURVME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXEyOWczZk5KdmF3c29rNVNWckpHN0xpNnljcEhuVGdXZ3ZTZDJXaEtTOXNBV0lIbm14WXQKUXBOcWNQcHdSSUcrT0dEaTZnbDB4UnRXbXAxVkRPNHFuNndWaFFTemRiWjJuNGc2SlJ4WU9GWVdqaDlqUXpNWgpEQkd6c3pWZmc1eEw0U0E5d3NCNXY1N0RMUnZtY0xsaWhSUlIzbWRxU2VHUnlNRHBKWVNVdHZzQnY3MDdWSmxvCmczWUpFQ0NEZXJ5NDdueDVVOFZTRktxaUNmVU8venJkaVd3cDNrRWJuaGRFOXArMURKOTlGQ3pxYmlWRkpZYjYKQ2JQeUp0Q1RETXgwMjBGVmdaNVhxNFh4Q3NoWHpYb0hVSFp6RFN1UUVPUnQrUlFOUmtyN3k4MVRzeCs2Y3o4cwp0QncwSlNiRitGdHVkbUhQSkkrMVgvTXdlVW5CZ3dYTjd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFtWkRKall6Vm1ZUzFtWkRFekxUUXlOV1F0WVRJeFpDMDMKTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbVpESmpZelZtWVMxbVpERXpMVFF5TldRdFlUSXhaQzAzTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBcVJTTWFsVmIxVDZmOXREUWlNSWJGODR5b1BSejZlVGlVK1hLcFpob0w0SWMza3o3bEYxZUpnckgwTQpzOU5FVi9rWW93OHAvRjBoM0FHSk5NMUJWdlh3UmZnM3RudGVSQk5HQ3prdjdiVGI0aTdXR3BxWU5OU00yZ0VYCk1QUm1vYnRKMm02VEt0d0Q5WUhwYlFDR0gyNU82dS9KaGJDVVdqcmVMcmVrdDhnYmFQVkVSTG1XSldPMzhNeU4KK3IyUmZDdCtTbitiRVJVZFl0NkZVa2FDY0xlTXFDajdDWXZ5NkloVU9IeUdGWWxMdHFVc2JVd1hGWEl0T3RNRAorWUpVcnpYQXV0WGFrQjc1dnJwTHBqYjl5UlpsZmFGLzA3KzExY3c4bjRyOXFXQ2t3cW9UdVdYUXoxa1hxcnpQCmVkVlN4WWVqRUJ3cEdLQm5HVjRIMk55TkxEMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2011"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:35 GMT
+      - Mon, 18 Dec 2023 14:53:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cff16058-041c-4c33-b0ab-1c3aead2dd9f
+      - d1066e34-e119-4072-9d83-67bd4212c23d
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,7 +972,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fd2cc5fa-fd13-425d-a21d-7345a97ee95b&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/users?order_by=name_asc&page=1
+    method: GET
+  response:
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d64fc4bb-6e36-4e3a-9b45-a1cff4cc3490
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVVVZRVW1BM09BNllKaXJ0NE9pVXh6ZmxTWi9Zd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRVek1qQmFGdzB6TXpFeU1UVXhORFV6TWpCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUN0SGhjc0Z5cmpsKzRaYVdnWmFJMTc0c0xCdzBJdjVxNElueWpPa2d2SzUzQUFvVWJqUFpzNnRKVkEKbEMvZHY0QjRrU2kxTXoyRy9xZ3o4am1RZUE2SjJqMUhweHRVODFNVGxrekVQTUtHRGF6N09UeWw1WjJwd0FWMQpqRjBVVEMvRHJWUzZuNDFURnlpNG1GUDZ2akw2dlZwbFhTRVZHZndPbnMzUE44dCtTS01RQTB4Ui9tak5Na1FoCnVObWpYWTNYZjhSTWttN1lPUGZuMFhnZm1uMFN4NExMRkF3UGZVbHNjRktoYU5vcGNEWGdGRkVTQ3lmT1V6QUsKaGhYZ0FTcmZ0WUNUWlRSTnZOUWtKQnZYVVNNaUJSYVRGVk83ajdSd3F5b3JPLzBScm5tdGVySU1zZHpXRmo1RApNV2RDZmZ5dFhSQm5OM3IxSFZ5cmNBUlFMeDZqQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkxaU5UWXlNV1ZoTWkwMU4yVmxMVFF4TVdZdFlqSmtaUzAxTkdKbU9UQTMKTWpNNE9UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0WWpVMgpNakZsWVRJdE5UZGxaUzAwTVRGbUxXSXlaR1V0TlRSaVpqa3dOekl6T0RrekxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdRekQ5SFJod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTFA3TVgKK2M3VWdrSHQyUkVaa29laDdTTFBPWUtkWkJKbWxyRWFxK0pUVDdrdFdTWGg0RE9NdWQyOEhJbk1NSndZSmJ1WApBRzFRRk42S3cwcFovQS9jc3RGVStKSlFqL1gwVHNyTXZkdEVJL2J5TklZOHo0Y1FpRDBxRWJ3WCs1amczY3R2CnBtWDVqRXZISmY4R0VDckNWZVNXUTNucGswVTF2MHhZaVpzaDRaUVQwdmNjQTYweGpKK0Y3emkraHV3dVhhcFEKT0xWVFk1RmVJUmh3WCt2aDA0RFVSK3ZoM1NyYnlNRU5tUmV2N0V1a2dXWllNNksyY0ZQZVdWRmVxU2kvVTRwawpmN0Uwb1VvQ29kRG9NVjZSVUZXSXlZamN4cGhiWVpRZ1d3SUZFRFpTMWdXaHNvMUJqOTFlNGcvaVBsL3RJQWN2CjcvMFA3NFZ3cjczdVBjRjkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:53:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5e97c97-4966-463b-9a51-1ecd4ed495ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=b5621ea2-57ee-411f-b2de-54bf90723893&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1050,7 +1050,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:35 GMT
+      - Mon, 18 Dec 2023 14:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af3b0c46-ed3e-4aa2-a3c8-98bde6a0b0fd
+      - 1ed1f8cd-dbd2-48e9-a44a-cb245e84714f
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,10 +1071,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1083,7 +1083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:36 GMT
+      - Mon, 18 Dec 2023 14:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9a863e0-2d5c-4a3e-8113-ac868f0f6945
+      - 41648126-ce95-4ec3-9e7c-1b5b668fc403
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:36 GMT
+      - Mon, 18 Dec 2023 14:53:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc31f33b-db5c-4d31-876e-6585cac9a79e
+      - bb08c645-80d4-403e-8850-7f9a479e6d8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYThpazBkYjJWRm1nQi9DL3RBRHQvb3RGSy9vd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBOVm9YRFRNek1USXhOVEV6TURVME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXEyOWczZk5KdmF3c29rNVNWckpHN0xpNnljcEhuVGdXZ3ZTZDJXaEtTOXNBV0lIbm14WXQKUXBOcWNQcHdSSUcrT0dEaTZnbDB4UnRXbXAxVkRPNHFuNndWaFFTemRiWjJuNGc2SlJ4WU9GWVdqaDlqUXpNWgpEQkd6c3pWZmc1eEw0U0E5d3NCNXY1N0RMUnZtY0xsaWhSUlIzbWRxU2VHUnlNRHBKWVNVdHZzQnY3MDdWSmxvCmczWUpFQ0NEZXJ5NDdueDVVOFZTRktxaUNmVU8venJkaVd3cDNrRWJuaGRFOXArMURKOTlGQ3pxYmlWRkpZYjYKQ2JQeUp0Q1RETXgwMjBGVmdaNVhxNFh4Q3NoWHpYb0hVSFp6RFN1UUVPUnQrUlFOUmtyN3k4MVRzeCs2Y3o4cwp0QncwSlNiRitGdHVkbUhQSkkrMVgvTXdlVW5CZ3dYTjd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFtWkRKall6Vm1ZUzFtWkRFekxUUXlOV1F0WVRJeFpDMDMKTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbVpESmpZelZtWVMxbVpERXpMVFF5TldRdFlUSXhaQzAzTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBcVJTTWFsVmIxVDZmOXREUWlNSWJGODR5b1BSejZlVGlVK1hLcFpob0w0SWMza3o3bEYxZUpnckgwTQpzOU5FVi9rWW93OHAvRjBoM0FHSk5NMUJWdlh3UmZnM3RudGVSQk5HQ3prdjdiVGI0aTdXR3BxWU5OU00yZ0VYCk1QUm1vYnRKMm02VEt0d0Q5WUhwYlFDR0gyNU82dS9KaGJDVVdqcmVMcmVrdDhnYmFQVkVSTG1XSldPMzhNeU4KK3IyUmZDdCtTbitiRVJVZFl0NkZVa2FDY0xlTXFDajdDWXZ5NkloVU9IeUdGWWxMdHFVc2JVd1hGWEl0T3RNRAorWUpVcnpYQXV0WGFrQjc1dnJwTHBqYjl5UlpsZmFGLzA3KzExY3c4bjRyOXFXQ2t3cW9UdVdYUXoxa1hxcnpQCmVkVlN4WWVqRUJ3cEdLQm5HVjRIMk55TkxEMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:36 GMT
+      - Mon, 18 Dec 2023 14:53:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 067b285a-1894-481e-9972-08fb3de739c8
+      - ba7ae740-cbdb-45c9-a761-aa750d1ba64d
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,7 +1170,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fd2cc5fa-fd13-425d-a21d-7345a97ee95b&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVVVZRVW1BM09BNllKaXJ0NE9pVXh6ZmxTWi9Zd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRVek1qQmFGdzB6TXpFeU1UVXhORFV6TWpCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUN0SGhjc0Z5cmpsKzRaYVdnWmFJMTc0c0xCdzBJdjVxNElueWpPa2d2SzUzQUFvVWJqUFpzNnRKVkEKbEMvZHY0QjRrU2kxTXoyRy9xZ3o4am1RZUE2SjJqMUhweHRVODFNVGxrekVQTUtHRGF6N09UeWw1WjJwd0FWMQpqRjBVVEMvRHJWUzZuNDFURnlpNG1GUDZ2akw2dlZwbFhTRVZHZndPbnMzUE44dCtTS01RQTB4Ui9tak5Na1FoCnVObWpYWTNYZjhSTWttN1lPUGZuMFhnZm1uMFN4NExMRkF3UGZVbHNjRktoYU5vcGNEWGdGRkVTQ3lmT1V6QUsKaGhYZ0FTcmZ0WUNUWlRSTnZOUWtKQnZYVVNNaUJSYVRGVk83ajdSd3F5b3JPLzBScm5tdGVySU1zZHpXRmo1RApNV2RDZmZ5dFhSQm5OM3IxSFZ5cmNBUlFMeDZqQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkxaU5UWXlNV1ZoTWkwMU4yVmxMVFF4TVdZdFlqSmtaUzAxTkdKbU9UQTMKTWpNNE9UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0WWpVMgpNakZsWVRJdE5UZGxaUzAwTVRGbUxXSXlaR1V0TlRSaVpqa3dOekl6T0RrekxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdRekQ5SFJod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTFA3TVgKK2M3VWdrSHQyUkVaa29laDdTTFBPWUtkWkJKbWxyRWFxK0pUVDdrdFdTWGg0RE9NdWQyOEhJbk1NSndZSmJ1WApBRzFRRk42S3cwcFovQS9jc3RGVStKSlFqL1gwVHNyTXZkdEVJL2J5TklZOHo0Y1FpRDBxRWJ3WCs1amczY3R2CnBtWDVqRXZISmY4R0VDckNWZVNXUTNucGswVTF2MHhZaVpzaDRaUVQwdmNjQTYweGpKK0Y3emkraHV3dVhhcFEKT0xWVFk1RmVJUmh3WCt2aDA0RFVSK3ZoM1NyYnlNRU5tUmV2N0V1a2dXWllNNksyY0ZQZVdWRmVxU2kvVTRwawpmN0Uwb1VvQ29kRG9NVjZSVUZXSXlZamN4cGhiWVpRZ1d3SUZFRFpTMWdXaHNvMUJqOTFlNGcvaVBsL3RJQWN2CjcvMFA3NFZ3cjczdVBjRjkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:53:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b323925c-5b0a-48ad-aaf5-385f5c8c3374
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=b5621ea2-57ee-411f-b2de-54bf90723893&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1182,7 +1215,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:36 GMT
+      - Mon, 18 Dec 2023 14:53:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e56328d9-d6b2-43cc-9328-2ab77a31271a
+      - 028459a7-3d20-4f56-b15b-6f3088432357
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,10 +1236,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1215,7 +1248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:36 GMT
+      - Mon, 18 Dec 2023 14:53:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,12 +1258,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05edb6c5-8121-4367-9615-c5ae5ebf8e71
+      - 70110411-980f-43a7-93dc-04f90a7ec70e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","database_name":"foo","name":"test_backup"}'
+    body: '{"instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","database_name":"foo","name":"test_backup"}'
     form: {}
     headers:
       Content-Type:
@@ -1241,7 +1274,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-12-18T14:53:45.209806Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
       - "398"
@@ -1250,7 +1283,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:37 GMT
+      - Mon, 18 Dec 2023 14:53:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6057bc6c-a825-40ce-8141-116406e2a343
+      - 47d2a444-9401-41ce-831e-fc6aa415a7f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,10 +1304,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-12-18T14:53:45.209806Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
       - "398"
@@ -1283,7 +1316,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:38 GMT
+      - Mon, 18 Dec 2023 14:53:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e137e32-91e6-4cca-a7a5-46045727e327
+      - 884f1ee3-bdc2-4ae0-8f5a-5cf303fa3ca3
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,10 +1337,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
+    body: '{"created_at":"2023-12-18T14:53:45.209806Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T14:53:47.597150Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1316,7 +1349,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:08 GMT
+      - Mon, 18 Dec 2023 14:54:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fb2a828-f0cb-47cf-8db3-a6e2167fb2b3
+      - d7805c54-cb16-44bf-bf21-48c3e20220e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,10 +1370,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
+    body: '{"created_at":"2023-12-18T14:53:45.209806Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T14:53:47.597150Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1349,7 +1382,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:08 GMT
+      - Mon, 18 Dec 2023 14:54:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 900913b6-45d3-43a8-87c8-3408e604fff0
+      - 3aa57367-73d1-427b-9389-124bab093fd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,10 +1403,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
+    body: '{"created_at":"2023-12-18T14:53:45.209806Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T14:53:47.597150Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1382,7 +1415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:08 GMT
+      - Mon, 18 Dec 2023 14:54:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75df126a-3e44-4725-a220-3240d4b4d47d
+      - f5dd7878-4692-48e2-b342-712eeae55644
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,19 +1436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:08 GMT
+      - Mon, 18 Dec 2023 14:54:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd9936f9-dee0-42a7-83a3-72992961506d
+      - 02a91840-557c-45c3-a02e-ef0faf513715
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYThpazBkYjJWRm1nQi9DL3RBRHQvb3RGSy9vd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBOVm9YRFRNek1USXhOVEV6TURVME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXEyOWczZk5KdmF3c29rNVNWckpHN0xpNnljcEhuVGdXZ3ZTZDJXaEtTOXNBV0lIbm14WXQKUXBOcWNQcHdSSUcrT0dEaTZnbDB4UnRXbXAxVkRPNHFuNndWaFFTemRiWjJuNGc2SlJ4WU9GWVdqaDlqUXpNWgpEQkd6c3pWZmc1eEw0U0E5d3NCNXY1N0RMUnZtY0xsaWhSUlIzbWRxU2VHUnlNRHBKWVNVdHZzQnY3MDdWSmxvCmczWUpFQ0NEZXJ5NDdueDVVOFZTRktxaUNmVU8venJkaVd3cDNrRWJuaGRFOXArMURKOTlGQ3pxYmlWRkpZYjYKQ2JQeUp0Q1RETXgwMjBGVmdaNVhxNFh4Q3NoWHpYb0hVSFp6RFN1UUVPUnQrUlFOUmtyN3k4MVRzeCs2Y3o4cwp0QncwSlNiRitGdHVkbUhQSkkrMVgvTXdlVW5CZ3dYTjd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFtWkRKall6Vm1ZUzFtWkRFekxUUXlOV1F0WVRJeFpDMDMKTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbVpESmpZelZtWVMxbVpERXpMVFF5TldRdFlUSXhaQzAzTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBcVJTTWFsVmIxVDZmOXREUWlNSWJGODR5b1BSejZlVGlVK1hLcFpob0w0SWMza3o3bEYxZUpnckgwTQpzOU5FVi9rWW93OHAvRjBoM0FHSk5NMUJWdlh3UmZnM3RudGVSQk5HQ3prdjdiVGI0aTdXR3BxWU5OU00yZ0VYCk1QUm1vYnRKMm02VEt0d0Q5WUhwYlFDR0gyNU82dS9KaGJDVVdqcmVMcmVrdDhnYmFQVkVSTG1XSldPMzhNeU4KK3IyUmZDdCtTbitiRVJVZFl0NkZVa2FDY0xlTXFDajdDWXZ5NkloVU9IeUdGWWxMdHFVc2JVd1hGWEl0T3RNRAorWUpVcnpYQXV0WGFrQjc1dnJwTHBqYjl5UlpsZmFGLzA3KzExY3c4bjRyOXFXQ2t3cW9UdVdYUXoxa1hxcnpQCmVkVlN4WWVqRUJ3cEdLQm5HVjRIMk55TkxEMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:08 GMT
+      - Mon, 18 Dec 2023 14:54:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4747d8f-08ec-49bb-b3c4-8403a1485dcc
+      - b0fa19a0-31bc-4613-8f86-f1b87414b346
     status: 200 OK
     code: 200
     duration: ""
@@ -1469,7 +1502,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fd2cc5fa-fd13-425d-a21d-7345a97ee95b&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVVVZRVW1BM09BNllKaXJ0NE9pVXh6ZmxTWi9Zd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRVek1qQmFGdzB6TXpFeU1UVXhORFV6TWpCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUN0SGhjc0Z5cmpsKzRaYVdnWmFJMTc0c0xCdzBJdjVxNElueWpPa2d2SzUzQUFvVWJqUFpzNnRKVkEKbEMvZHY0QjRrU2kxTXoyRy9xZ3o4am1RZUE2SjJqMUhweHRVODFNVGxrekVQTUtHRGF6N09UeWw1WjJwd0FWMQpqRjBVVEMvRHJWUzZuNDFURnlpNG1GUDZ2akw2dlZwbFhTRVZHZndPbnMzUE44dCtTS01RQTB4Ui9tak5Na1FoCnVObWpYWTNYZjhSTWttN1lPUGZuMFhnZm1uMFN4NExMRkF3UGZVbHNjRktoYU5vcGNEWGdGRkVTQ3lmT1V6QUsKaGhYZ0FTcmZ0WUNUWlRSTnZOUWtKQnZYVVNNaUJSYVRGVk83ajdSd3F5b3JPLzBScm5tdGVySU1zZHpXRmo1RApNV2RDZmZ5dFhSQm5OM3IxSFZ5cmNBUlFMeDZqQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkxaU5UWXlNV1ZoTWkwMU4yVmxMVFF4TVdZdFlqSmtaUzAxTkdKbU9UQTMKTWpNNE9UTXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0WWpVMgpNakZsWVRJdE5UZGxaUzAwTVRGbUxXSXlaR1V0TlRSaVpqa3dOekl6T0RrekxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdRekQ5SFJod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBTFA3TVgKK2M3VWdrSHQyUkVaa29laDdTTFBPWUtkWkJKbWxyRWFxK0pUVDdrdFdTWGg0RE9NdWQyOEhJbk1NSndZSmJ1WApBRzFRRk42S3cwcFovQS9jc3RGVStKSlFqL1gwVHNyTXZkdEVJL2J5TklZOHo0Y1FpRDBxRWJ3WCs1amczY3R2CnBtWDVqRXZISmY4R0VDckNWZVNXUTNucGswVTF2MHhZaVpzaDRaUVQwdmNjQTYweGpKK0Y3emkraHV3dVhhcFEKT0xWVFk1RmVJUmh3WCt2aDA0RFVSK3ZoM1NyYnlNRU5tUmV2N0V1a2dXWllNNksyY0ZQZVdWRmVxU2kvVTRwawpmN0Uwb1VvQ29kRG9NVjZSVUZXSXlZamN4cGhiWVpRZ1d3SUZFRFpTMWdXaHNvMUJqOTFlNGcvaVBsL3RJQWN2CjcvMFA3NFZ3cjczdVBjRjkKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:54:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 26544ab4-813d-45a5-bebd-51d810ab5eb1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=b5621ea2-57ee-411f-b2de-54bf90723893&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1481,7 +1547,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:09 GMT
+      - Mon, 18 Dec 2023 14:54:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4a0080e-2458-4c92-bd6d-8e8acbff03b3
+      - e00e3e40-1102-4bdb-9def-552e8fc518ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,10 +1568,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1514,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:09 GMT
+      - Mon, 18 Dec 2023 14:54:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d39b6d29-0fcd-474c-a272-75c6a8805880
+      - 48395246-b9b1-4396-b713-d661045d3943
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,10 +1601,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
+    body: '{"created_at":"2023-12-18T14:53:45.209806Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T14:53:47.597150Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1547,7 +1613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:09 GMT
+      - Mon, 18 Dec 2023 14:54:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20d51491-0dd8-4c92-a527-fbf8178b644f
+      - ed856769-d5c4-4b89-87b1-ded27b6187e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,10 +1634,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
+    body: '{"created_at":"2023-12-18T14:53:45.209806Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T14:53:47.597150Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1580,7 +1646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:09 GMT
+      - Mon, 18 Dec 2023 14:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5d014ee-b00c-4fa6-b6b2-52149073b345
+      - f7fd8df8-982d-4759-83e2-836070ab8d11
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,10 +1667,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: DELETE
   response:
-    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"deleting","updated_at":"2023-12-18T13:06:39.149909Z"}'
+    body: '{"created_at":"2023-12-18T14:53:45.209806Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","instance_id":"b5621ea2-57ee-411f-b2de-54bf90723893","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"deleting","updated_at":"2023-12-18T14:53:47.597150Z"}'
     headers:
       Content-Length:
       - "423"
@@ -1613,7 +1679,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:10 GMT
+      - Mon, 18 Dec 2023 14:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4cbbaa4-86d9-4cc0-9688-80867b1c9f65
+      - cfd3ffcf-f55b-4e50-853d-82180646c3de
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,10 +1700,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"f5837fe9-f189-4049-83e5-e915409d48d0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1646,7 +1712,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:10 GMT
+      - Mon, 18 Dec 2023 14:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc9f5047-9178-42ac-bc83-73fe8a16da4b
+      - ebfe10c3-6f19-4a9e-91d9-c02ba3554482
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1667,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:10 GMT
+      - Mon, 18 Dec 2023 14:54:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 711ad187-9d7b-4254-a145-99d97d2b5215
+      - e976e9d8-736f-4aa7-859e-4871a9ee3fdd
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,7 +1766,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893/databases/foo
     method: DELETE
   response:
     body: ""
@@ -1710,7 +1776,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:10 GMT
+      - Mon, 18 Dec 2023 14:54:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43c02fba-86b3-4800-a584-1a426261b045
+      - 54221b25-f618-461c-9597-6111ad8d489e
     status: 204 No Content
     code: 204
     duration: ""
@@ -1731,19 +1797,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:10 GMT
+      - Mon, 18 Dec 2023 14:54:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3974fe6e-2aff-4b9e-aa0f-0ecad13bf96a
+      - 3e7a973e-0850-4c3a-88a6-b0a8990079d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,19 +1830,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1229"
+      - "1225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:11 GMT
+      - Mon, 18 Dec 2023 14:54:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e03d35e-11e9-49fb-9b90-881d283de44c
+      - 08094b20-ef7c-4618-b84a-47267ac6d251
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,19 +1863,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1228"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:11 GMT
+      - Mon, 18 Dec 2023 14:54:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2669937f-3792-4e51-90a1-69e8bbe8d0bf
+      - 603ca5b3-0f7a-45e8-b4f4-3ade77920be8
     status: 200 OK
     code: 200
     duration: ""
@@ -1830,19 +1896,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:50:31.231899Z","retention":7},"created_at":"2023-12-18T14:50:31.231899Z","endpoint":{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021},"endpoints":[{"id":"2f95493e-2a4f-4018-aaa9-dc01a40bb90b","ip":"51.158.56.32","load_balancer":{},"name":null,"port":18021}],"engine":"PostgreSQL-15","id":"b5621ea2-57ee-411f-b2de-54bf90723893","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1228"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:11 GMT
+      - Mon, 18 Dec 2023 14:54:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65fbc2dc-3440-48c9-8882-ef21bb733660
+      - 90155327-fff7-4e1a-ba7d-36f74d99b914
     status: 200 OK
     code: 200
     duration: ""
@@ -1863,10 +1929,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"b5621ea2-57ee-411f-b2de-54bf90723893","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1875,7 +1941,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:41 GMT
+      - Mon, 18 Dec 2023 14:54:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +1951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d024860-e6e4-40e0-acf8-28d2554d7945
+      - d8cd4ed7-7501-4fb6-9fbf-b211ba5e8c6c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1896,10 +1962,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b5621ea2-57ee-411f-b2de-54bf90723893
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"b5621ea2-57ee-411f-b2de-54bf90723893","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1908,7 +1974,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:41 GMT
+      - Mon, 18 Dec 2023 14:54:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +1984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35dbf137-7eee-4ea3-8d5c-1fe5e2d46af5
+      - 0d19cee7-8dd7-437f-a110-19e6aeb5fb93
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1929,10 +1995,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/59802cbd-57c4-45f9-a239-763d7ca0b6a1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"f5837fe9-f189-4049-83e5-e915409d48d0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"59802cbd-57c4-45f9-a239-763d7ca0b6a1","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1941,7 +2007,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:41 GMT
+      - Mon, 18 Dec 2023 14:54:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1951,7 +2017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 158f4fbb-2b63-425d-b6f5-fad64ce1c70a
+      - 9cc27c1f-8b5b-4271-927c-bcd8f9bda576
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-backup-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-database-backup-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:01 GMT
+      - Mon, 18 Dec 2023 12:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0dd0235-cb93-4531-ae48-dd6afed9c97f
+      - 22be7049-a2b5-4240-8a59-149c593e677e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabaseBackup_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"TestAccScalewayRdbDatabaseBackup_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:02 GMT
+      - Mon, 18 Dec 2023 13:02:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc2ccc33-2dd5-430d-8343-766fd896e5a2
+      - fed68cfb-efc8-404e-a069-de25b17ddc59
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:03 GMT
+      - Mon, 18 Dec 2023 13:02:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4738dce3-fe0b-4114-a2d8-0521846cb52d
+      - 5925b5e5-910b-41f3-99e2-84f07d766d96
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:33 GMT
+      - Mon, 18 Dec 2023 13:02:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86fc15fd-52ff-44f1-9520-e9c75d4683de
+      - 041eb740-87a0-4efe-9f10-07d632a9cbfb
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:03 GMT
+      - Mon, 18 Dec 2023 13:03:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f32b1b4-fd6b-41c2-8362-ef09d581d737
+      - 354fccf5-4c79-4156-bf23-5a8ae1d0a9d7
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:33 GMT
+      - Mon, 18 Dec 2023 13:03:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05d4fb5f-a0c8-4060-8cf6-afb45bca9cf1
+      - 45d0d643-336d-4afc-b7bf-05f13a567895
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:04 GMT
+      - Mon, 18 Dec 2023 13:04:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18a530ed-3848-4909-a6ef-5aeb7077e4af
+      - b2683dcd-7397-4f77-b531-bdd7de0591d9
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:04:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cbc119e-9ac6-4e68-9a84-c9d4d480d0a0
+      - 0feb718c-f753-483b-b84f-03f9e2ba6fb4
     status: 200 OK
     code: 200
     duration: ""
@@ -572,10 +572,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "920"
@@ -584,7 +584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:04 GMT
+      - Mon, 18 Dec 2023 13:05:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c24b0f6-c285-4bd2-a7fb-ee541b516c4f
+      - 79288e0e-dc81-40c8-be29-9a6928e04352
     status: 200 OK
     code: 200
     duration: ""
@@ -605,10 +605,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1184"
@@ -617,7 +617,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:05:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2cca55b-9816-4049-bfcc-09a8cbcc0549
+      - 42fc1ca9-24c0-4e5e-9590-24653b2bc6f3
     status: 200 OK
     code: 200
     duration: ""
@@ -638,10 +638,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -650,7 +650,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:04 GMT
+      - Mon, 18 Dec 2023 13:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7198315f-c4be-405a-93de-77d9211306c6
+      - 255b06d3-9a2d-4db1-9bfc-9489f59bc45e
     status: 200 OK
     code: 200
     duration: ""
@@ -673,10 +673,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -685,7 +685,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:06 GMT
+      - Mon, 18 Dec 2023 13:06:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6120f1b9-f5e5-4213-8e55-404ae7202dcd
+      - a0d33ae5-f768-47e5-b637-6f261779b791
     status: 200 OK
     code: 200
     duration: ""
@@ -706,10 +706,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -718,7 +718,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:06 GMT
+      - Mon, 18 Dec 2023 13:06:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac23ed02-42c8-4f8d-a18c-b7239495ab08
+      - fd8c1482-1304-43f3-a4d2-fd8a6afacb92
     status: 200 OK
     code: 200
     duration: ""
@@ -739,43 +739,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e7b69ef8-5b7d-4cba-8e7d-3bc9552595e1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVQ1ZTR3lSYWlKcjZlQ1c5L1J1RDNVOWVyQkVNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1Ua3pOVm9YRFRNek1USXhOVEV6TVRrek5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXllV2ZVa0MwR2MvWFJBUjZYOFhFejlUb21Ud0dRTG4vaUZCd2VoUTNjeHdYS0psTEE3WS8KanF4VjUwdm9aWnlvRDFKamJ4b05Hc3JMakRwc2txcGErN2MySFZNMWtKVWZMa2ZYQTZ2aVlxNmJVWVllQklmTgpDUExibUEvNDhLMzJGT2pxZkN3VmhjTEF6SUIybVQ3aVlucmduUm14ekgxb0tFYVIvVEYyaFE4NXNGb05WV2FaCjJPYVhLWEpsbFF5OSs0Q0RNUDNzREJqUVR0eFJXQVA2SVMwaGpJY2JxOXlHY1FSRjhkTzcvNTdRQ3k0Y0ovQnAKQkdIeWhLeGtpS3d1dFJpRHlaWUsyWWRUVjE0d295TFRQK1RVRG9tZjJBbVNNNHBjSnppVDV0elJkYWdUMFVCWQpjQ0MyZVU0Z1JEc3llVTlKOWtjZjlWcG1yYUNUR0J0MEd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAxWXpCaU5UbGhNUzB6WXpJM0xUUm1OalV0T1RFMk5DMWkKTVROa1kyTTRPR1JsTnpBdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwMVl6QmlOVGxoTVMwell6STNMVFJtTmpVdE9URTJOQzFpTVROa1kyTTRPR1JsTnpBdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGd1cUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFNU3U0S1FBby9yN3U0bTF1YmNCbytQampwMGFKWFFDT2NkWGdCMzRIZERodmREemFsODdkQkphMDF4dgpGaG92M0RyN3E2dUdhb2xxZ3piVDJ0SVpTM2s3aHA1Q3U5VmxkS0x5WUpvZ1FYRmxaU0ZSUTdtcCt0SEZ1UjhhCkJ6WG05ajBlQkF6eDBsdmM1RG9kNHdMa0E0TisrbS9iVzhSeEFxeFYvczZIUkdleXQwS1VqSE82TDRicERhVzAKNnNPb0Urc0w3VDJiNi9tM2M4Lzd3QkxvS3cyc3JzZGIxUDRETEE3Z2R3T1hpRHdTRzN1cGc3Nit5S1lhOU0zVwpoeklCUmJzQUNtVnByc1ZEdHFxZWthTGxscXBURFA5Z0ZQQzUvN3UrVHE1TVI3T1duTGJwdzJ1bDFmaXVtMHltCmhsT3hVbXR4OTZSVlRNMDFoWkJhZnNqWUVUZz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYThpazBkYjJWRm1nQi9DL3RBRHQvb3RGSy9vd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBOVm9YRFRNek1USXhOVEV6TURVME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXEyOWczZk5KdmF3c29rNVNWckpHN0xpNnljcEhuVGdXZ3ZTZDJXaEtTOXNBV0lIbm14WXQKUXBOcWNQcHdSSUcrT0dEaTZnbDB4UnRXbXAxVkRPNHFuNndWaFFTemRiWjJuNGc2SlJ4WU9GWVdqaDlqUXpNWgpEQkd6c3pWZmc1eEw0U0E5d3NCNXY1N0RMUnZtY0xsaWhSUlIzbWRxU2VHUnlNRHBKWVNVdHZzQnY3MDdWSmxvCmczWUpFQ0NEZXJ5NDdueDVVOFZTRktxaUNmVU8venJkaVd3cDNrRWJuaGRFOXArMURKOTlGQ3pxYmlWRkpZYjYKQ2JQeUp0Q1RETXgwMjBGVmdaNVhxNFh4Q3NoWHpYb0hVSFp6RFN1UUVPUnQrUlFOUmtyN3k4MVRzeCs2Y3o4cwp0QncwSlNiRitGdHVkbUhQSkkrMVgvTXdlVW5CZ3dYTjd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFtWkRKall6Vm1ZUzFtWkRFekxUUXlOV1F0WVRJeFpDMDMKTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbVpESmpZelZtWVMxbVpERXpMVFF5TldRdFlUSXhaQzAzTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBcVJTTWFsVmIxVDZmOXREUWlNSWJGODR5b1BSejZlVGlVK1hLcFpob0w0SWMza3o3bEYxZUpnckgwTQpzOU5FVi9rWW93OHAvRjBoM0FHSk5NMUJWdlh3UmZnM3RudGVSQk5HQ3prdjdiVGI0aTdXR3BxWU5OU00yZ0VYCk1QUm1vYnRKMm02VEt0d0Q5WUhwYlFDR0gyNU82dS9KaGJDVVdqcmVMcmVrdDhnYmFQVkVSTG1XSldPMzhNeU4KK3IyUmZDdCtTbitiRVJVZFl0NkZVa2FDY0xlTXFDajdDWXZ5NkloVU9IeUdGWWxMdHFVc2JVd1hGWEl0T3RNRAorWUpVcnpYQXV0WGFrQjc1dnJwTHBqYjl5UlpsZmFGLzA3KzExY3c4bjRyOXFXQ2t3cW9UdVdYUXoxa1hxcnpQCmVkVlN4WWVqRUJ3cEdLQm5HVjRIMk55TkxEMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2011"
@@ -784,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:06:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba90b566-80f6-462f-a676-a51a65ce50c3
+      - ac1e8231-7905-49c4-9d60-a7988da115b3
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fd2cc5fa-fd13-425d-a21d-7345a97ee95b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1229"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:06:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +794,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf5659fc-3511-4ca2-a1ef-b3f5e253c481
+      - 290d0a96-f5ef-43ce-98de-d16b07702e28
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1229"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:26 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5e4bfbe9-f64c-467c-848d-fa834415d57a
     status: 200 OK
     code: 200
     duration: ""
@@ -840,7 +840,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
@@ -852,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:06:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5d8dbd3-1cee-4e82-ad2a-818fe3d19f9f
+      - 6281d204-f13b-4e06-91bb-cd767ff10f7a
     status: 200 OK
     code: 200
     duration: ""
@@ -873,10 +873,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -885,7 +885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:06:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77355d33-1d8e-469b-8537-0f7b1119253d
+      - 97a4afc6-bebc-4eb1-b6fe-052b006ba26f
     status: 200 OK
     code: 200
     duration: ""
@@ -906,7 +906,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -918,7 +918,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:06:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ec6235a-bd8d-47c5-80ca-edd3c9b2c6ab
+      - 269db255-dfe7-484e-bfc4-7e24a920fedb
     status: 200 OK
     code: 200
     duration: ""
@@ -939,7 +939,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -951,7 +951,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:06:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d707c50-14e8-4777-be5e-a25b9e66e9da
+      - 5267e780-35fa-4c25-8eda-8be5276bdc90
     status: 200 OK
     code: 200
     duration: ""
@@ -972,10 +972,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -984,7 +984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:06:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f02f254d-ac45-4d5d-9074-6240868a386f
+      - ea5f2337-bd56-4140-b839-44dd35806a44
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,43 +1005,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 61d19cd6-e8bb-4622-a734-a4b19f77d8c0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVQ1ZTR3lSYWlKcjZlQ1c5L1J1RDNVOWVyQkVNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1Ua3pOVm9YRFRNek1USXhOVEV6TVRrek5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXllV2ZVa0MwR2MvWFJBUjZYOFhFejlUb21Ud0dRTG4vaUZCd2VoUTNjeHdYS0psTEE3WS8KanF4VjUwdm9aWnlvRDFKamJ4b05Hc3JMakRwc2txcGErN2MySFZNMWtKVWZMa2ZYQTZ2aVlxNmJVWVllQklmTgpDUExibUEvNDhLMzJGT2pxZkN3VmhjTEF6SUIybVQ3aVlucmduUm14ekgxb0tFYVIvVEYyaFE4NXNGb05WV2FaCjJPYVhLWEpsbFF5OSs0Q0RNUDNzREJqUVR0eFJXQVA2SVMwaGpJY2JxOXlHY1FSRjhkTzcvNTdRQ3k0Y0ovQnAKQkdIeWhLeGtpS3d1dFJpRHlaWUsyWWRUVjE0d295TFRQK1RVRG9tZjJBbVNNNHBjSnppVDV0elJkYWdUMFVCWQpjQ0MyZVU0Z1JEc3llVTlKOWtjZjlWcG1yYUNUR0J0MEd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAxWXpCaU5UbGhNUzB6WXpJM0xUUm1OalV0T1RFMk5DMWkKTVROa1kyTTRPR1JsTnpBdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwMVl6QmlOVGxoTVMwell6STNMVFJtTmpVdE9URTJOQzFpTVROa1kyTTRPR1JsTnpBdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGd1cUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFNU3U0S1FBby9yN3U0bTF1YmNCbytQampwMGFKWFFDT2NkWGdCMzRIZERodmREemFsODdkQkphMDF4dgpGaG92M0RyN3E2dUdhb2xxZ3piVDJ0SVpTM2s3aHA1Q3U5VmxkS0x5WUpvZ1FYRmxaU0ZSUTdtcCt0SEZ1UjhhCkJ6WG05ajBlQkF6eDBsdmM1RG9kNHdMa0E0TisrbS9iVzhSeEFxeFYvczZIUkdleXQwS1VqSE82TDRicERhVzAKNnNPb0Urc0w3VDJiNi9tM2M4Lzd3QkxvS3cyc3JzZGIxUDRETEE3Z2R3T1hpRHdTRzN1cGc3Nit5S1lhOU0zVwpoeklCUmJzQUNtVnByc1ZEdHFxZWthTGxscXBURFA5Z0ZQQzUvN3UrVHE1TVI3T1duTGJwdzJ1bDFmaXVtMHltCmhsT3hVbXR4OTZSVlRNMDFoWkJhZnNqWUVUZz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYThpazBkYjJWRm1nQi9DL3RBRHQvb3RGSy9vd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBOVm9YRFRNek1USXhOVEV6TURVME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXEyOWczZk5KdmF3c29rNVNWckpHN0xpNnljcEhuVGdXZ3ZTZDJXaEtTOXNBV0lIbm14WXQKUXBOcWNQcHdSSUcrT0dEaTZnbDB4UnRXbXAxVkRPNHFuNndWaFFTemRiWjJuNGc2SlJ4WU9GWVdqaDlqUXpNWgpEQkd6c3pWZmc1eEw0U0E5d3NCNXY1N0RMUnZtY0xsaWhSUlIzbWRxU2VHUnlNRHBKWVNVdHZzQnY3MDdWSmxvCmczWUpFQ0NEZXJ5NDdueDVVOFZTRktxaUNmVU8venJkaVd3cDNrRWJuaGRFOXArMURKOTlGQ3pxYmlWRkpZYjYKQ2JQeUp0Q1RETXgwMjBGVmdaNVhxNFh4Q3NoWHpYb0hVSFp6RFN1UUVPUnQrUlFOUmtyN3k4MVRzeCs2Y3o4cwp0QncwSlNiRitGdHVkbUhQSkkrMVgvTXdlVW5CZ3dYTjd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFtWkRKall6Vm1ZUzFtWkRFekxUUXlOV1F0WVRJeFpDMDMKTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbVpESmpZelZtWVMxbVpERXpMVFF5TldRdFlUSXhaQzAzTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBcVJTTWFsVmIxVDZmOXREUWlNSWJGODR5b1BSejZlVGlVK1hLcFpob0w0SWMza3o3bEYxZUpnckgwTQpzOU5FVi9rWW93OHAvRjBoM0FHSk5NMUJWdlh3UmZnM3RudGVSQk5HQ3prdjdiVGI0aTdXR3BxWU5OU00yZ0VYCk1QUm1vYnRKMm02VEt0d0Q5WUhwYlFDR0gyNU82dS9KaGJDVVdqcmVMcmVrdDhnYmFQVkVSTG1XSldPMzhNeU4KK3IyUmZDdCtTbitiRVJVZFl0NkZVa2FDY0xlTXFDajdDWXZ5NkloVU9IeUdGWWxMdHFVc2JVd1hGWEl0T3RNRAorWUpVcnpYQXV0WGFrQjc1dnJwTHBqYjl5UlpsZmFGLzA3KzExY3c4bjRyOXFXQ2t3cW9UdVdYUXoxa1hxcnpQCmVkVlN4WWVqRUJ3cEdLQm5HVjRIMk55TkxEMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2011"
@@ -1050,7 +1017,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:06:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e0a5cc6-81a9-409d-9efc-bf05dd529397
+      - cff16058-041c-4c33-b0ab-1c3aead2dd9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,7 +1038,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fd2cc5fa-fd13-425d-a21d-7345a97ee95b&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af3b0c46-ed3e-4aa2-a3c8-98bde6a0b0fd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -1083,7 +1083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:06:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d91c6f6-7c01-4208-9576-f41271298316
+      - f9a863e0-2d5c-4a3e-8113-ac868f0f6945
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,10 +1104,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -1116,7 +1116,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:06:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5329e661-1467-4fc2-a676-7e8f2631169d
+      - bc31f33b-db5c-4d31-876e-6585cac9a79e
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,43 +1137,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f7beb4e7-c06e-4ea3-a03f-d10cd85c2cd9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVQ1ZTR3lSYWlKcjZlQ1c5L1J1RDNVOWVyQkVNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1Ua3pOVm9YRFRNek1USXhOVEV6TVRrek5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXllV2ZVa0MwR2MvWFJBUjZYOFhFejlUb21Ud0dRTG4vaUZCd2VoUTNjeHdYS0psTEE3WS8KanF4VjUwdm9aWnlvRDFKamJ4b05Hc3JMakRwc2txcGErN2MySFZNMWtKVWZMa2ZYQTZ2aVlxNmJVWVllQklmTgpDUExibUEvNDhLMzJGT2pxZkN3VmhjTEF6SUIybVQ3aVlucmduUm14ekgxb0tFYVIvVEYyaFE4NXNGb05WV2FaCjJPYVhLWEpsbFF5OSs0Q0RNUDNzREJqUVR0eFJXQVA2SVMwaGpJY2JxOXlHY1FSRjhkTzcvNTdRQ3k0Y0ovQnAKQkdIeWhLeGtpS3d1dFJpRHlaWUsyWWRUVjE0d295TFRQK1RVRG9tZjJBbVNNNHBjSnppVDV0elJkYWdUMFVCWQpjQ0MyZVU0Z1JEc3llVTlKOWtjZjlWcG1yYUNUR0J0MEd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAxWXpCaU5UbGhNUzB6WXpJM0xUUm1OalV0T1RFMk5DMWkKTVROa1kyTTRPR1JsTnpBdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwMVl6QmlOVGxoTVMwell6STNMVFJtTmpVdE9URTJOQzFpTVROa1kyTTRPR1JsTnpBdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGd1cUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFNU3U0S1FBby9yN3U0bTF1YmNCbytQampwMGFKWFFDT2NkWGdCMzRIZERodmREemFsODdkQkphMDF4dgpGaG92M0RyN3E2dUdhb2xxZ3piVDJ0SVpTM2s3aHA1Q3U5VmxkS0x5WUpvZ1FYRmxaU0ZSUTdtcCt0SEZ1UjhhCkJ6WG05ajBlQkF6eDBsdmM1RG9kNHdMa0E0TisrbS9iVzhSeEFxeFYvczZIUkdleXQwS1VqSE82TDRicERhVzAKNnNPb0Urc0w3VDJiNi9tM2M4Lzd3QkxvS3cyc3JzZGIxUDRETEE3Z2R3T1hpRHdTRzN1cGc3Nit5S1lhOU0zVwpoeklCUmJzQUNtVnByc1ZEdHFxZWthTGxscXBURFA5Z0ZQQzUvN3UrVHE1TVI3T1duTGJwdzJ1bDFmaXVtMHltCmhsT3hVbXR4OTZSVlRNMDFoWkJhZnNqWUVUZz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYThpazBkYjJWRm1nQi9DL3RBRHQvb3RGSy9vd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBOVm9YRFRNek1USXhOVEV6TURVME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXEyOWczZk5KdmF3c29rNVNWckpHN0xpNnljcEhuVGdXZ3ZTZDJXaEtTOXNBV0lIbm14WXQKUXBOcWNQcHdSSUcrT0dEaTZnbDB4UnRXbXAxVkRPNHFuNndWaFFTemRiWjJuNGc2SlJ4WU9GWVdqaDlqUXpNWgpEQkd6c3pWZmc1eEw0U0E5d3NCNXY1N0RMUnZtY0xsaWhSUlIzbWRxU2VHUnlNRHBKWVNVdHZzQnY3MDdWSmxvCmczWUpFQ0NEZXJ5NDdueDVVOFZTRktxaUNmVU8venJkaVd3cDNrRWJuaGRFOXArMURKOTlGQ3pxYmlWRkpZYjYKQ2JQeUp0Q1RETXgwMjBGVmdaNVhxNFh4Q3NoWHpYb0hVSFp6RFN1UUVPUnQrUlFOUmtyN3k4MVRzeCs2Y3o4cwp0QncwSlNiRitGdHVkbUhQSkkrMVgvTXdlVW5CZ3dYTjd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFtWkRKall6Vm1ZUzFtWkRFekxUUXlOV1F0WVRJeFpDMDMKTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbVpESmpZelZtWVMxbVpERXpMVFF5TldRdFlUSXhaQzAzTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBcVJTTWFsVmIxVDZmOXREUWlNSWJGODR5b1BSejZlVGlVK1hLcFpob0w0SWMza3o3bEYxZUpnckgwTQpzOU5FVi9rWW93OHAvRjBoM0FHSk5NMUJWdlh3UmZnM3RudGVSQk5HQ3prdjdiVGI0aTdXR3BxWU5OU00yZ0VYCk1QUm1vYnRKMm02VEt0d0Q5WUhwYlFDR0gyNU82dS9KaGJDVVdqcmVMcmVrdDhnYmFQVkVSTG1XSldPMzhNeU4KK3IyUmZDdCtTbitiRVJVZFl0NkZVa2FDY0xlTXFDajdDWXZ5NkloVU9IeUdGWWxMdHFVc2JVd1hGWEl0T3RNRAorWUpVcnpYQXV0WGFrQjc1dnJwTHBqYjl5UlpsZmFGLzA3KzExY3c4bjRyOXFXQ2t3cW9UdVdYUXoxa1hxcnpQCmVkVlN4WWVqRUJ3cEdLQm5HVjRIMk55TkxEMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2011"
@@ -1182,7 +1149,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:06:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd7b4f71-b8d5-4775-848b-b931428c9ed4
+      - 067b285a-1894-481e-9972-08fb3de739c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,7 +1170,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fd2cc5fa-fd13-425d-a21d-7345a97ee95b&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e56328d9-d6b2-43cc-9328-2ab77a31271a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -1215,7 +1215,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:06:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,12 +1225,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83c36a62-b82f-4e34-b56a-60249b2e86da
+      - 05edb6c5-8121-4367-9615-c5ae5ebf8e71
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","database_name":"foo","name":"test_backup"}'
+    body: '{"instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","database_name":"foo","name":"test_backup"}'
     form: {}
     headers:
       Content-Type:
@@ -1241,7 +1241,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:20:10.054323Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
       - "398"
@@ -1250,7 +1250,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:10 GMT
+      - Mon, 18 Dec 2023 13:06:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfebaa06-03e9-4060-a689-302d40d22a93
+      - 6057bc6c-a825-40ce-8141-116406e2a343
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,10 +1271,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:10.054323Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
+    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":null,"status":"creating","updated_at":null}'
     headers:
       Content-Length:
       - "398"
@@ -1283,7 +1283,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:10 GMT
+      - Mon, 18 Dec 2023 13:06:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 498c9a6d-4338-4697-b88d-82e5a40a6e82
+      - 4e137e32-91e6-4cca-a7a5-46045727e327
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,10 +1304,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:10.054323Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:20:11.587328Z"}'
+    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1316,7 +1316,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:07:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e18a5c3e-e20f-46b3-be0a-0f5b3a15bd83
+      - 7fb2a828-f0cb-47cf-8db3-a6e2167fb2b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,10 +1337,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:10.054323Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:20:11.587328Z"}'
+    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1349,7 +1349,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:07:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fe42ea3-635d-4591-a940-62bec50d2d1a
+      - 900913b6-45d3-43a8-87c8-3408e604fff0
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,10 +1370,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:10.054323Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:20:11.587328Z"}'
+    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1382,7 +1382,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:07:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63aea145-de14-49b7-9b8d-0d3d574b259c
+      - 75df126a-3e44-4725-a220-3240d4b4d47d
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,10 +1403,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -1415,7 +1415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:07:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1425,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 268bc770-09a2-4992-8eb0-4651c9d1f31c
+      - fd9936f9-dee0-42a7-83a3-72992961506d
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,43 +1436,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be196bf5-a4b5-4e91-b7a5-ffeb4bc2d01b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVQ1ZTR3lSYWlKcjZlQ1c5L1J1RDNVOWVyQkVNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1Ua3pOVm9YRFRNek1USXhOVEV6TVRrek5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXllV2ZVa0MwR2MvWFJBUjZYOFhFejlUb21Ud0dRTG4vaUZCd2VoUTNjeHdYS0psTEE3WS8KanF4VjUwdm9aWnlvRDFKamJ4b05Hc3JMakRwc2txcGErN2MySFZNMWtKVWZMa2ZYQTZ2aVlxNmJVWVllQklmTgpDUExibUEvNDhLMzJGT2pxZkN3VmhjTEF6SUIybVQ3aVlucmduUm14ekgxb0tFYVIvVEYyaFE4NXNGb05WV2FaCjJPYVhLWEpsbFF5OSs0Q0RNUDNzREJqUVR0eFJXQVA2SVMwaGpJY2JxOXlHY1FSRjhkTzcvNTdRQ3k0Y0ovQnAKQkdIeWhLeGtpS3d1dFJpRHlaWUsyWWRUVjE0d295TFRQK1RVRG9tZjJBbVNNNHBjSnppVDV0elJkYWdUMFVCWQpjQ0MyZVU0Z1JEc3llVTlKOWtjZjlWcG1yYUNUR0J0MEd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAxWXpCaU5UbGhNUzB6WXpJM0xUUm1OalV0T1RFMk5DMWkKTVROa1kyTTRPR1JsTnpBdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwMVl6QmlOVGxoTVMwell6STNMVFJtTmpVdE9URTJOQzFpTVROa1kyTTRPR1JsTnpBdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGd1cUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFNU3U0S1FBby9yN3U0bTF1YmNCbytQampwMGFKWFFDT2NkWGdCMzRIZERodmREemFsODdkQkphMDF4dgpGaG92M0RyN3E2dUdhb2xxZ3piVDJ0SVpTM2s3aHA1Q3U5VmxkS0x5WUpvZ1FYRmxaU0ZSUTdtcCt0SEZ1UjhhCkJ6WG05ajBlQkF6eDBsdmM1RG9kNHdMa0E0TisrbS9iVzhSeEFxeFYvczZIUkdleXQwS1VqSE82TDRicERhVzAKNnNPb0Urc0w3VDJiNi9tM2M4Lzd3QkxvS3cyc3JzZGIxUDRETEE3Z2R3T1hpRHdTRzN1cGc3Nit5S1lhOU0zVwpoeklCUmJzQUNtVnByc1ZEdHFxZWthTGxscXBURFA5Z0ZQQzUvN3UrVHE1TVI3T1duTGJwdzJ1bDFmaXVtMHltCmhsT3hVbXR4OTZSVlRNMDFoWkJhZnNqWUVUZz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYThpazBkYjJWRm1nQi9DL3RBRHQvb3RGSy9vd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBOVm9YRFRNek1USXhOVEV6TURVME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXEyOWczZk5KdmF3c29rNVNWckpHN0xpNnljcEhuVGdXZ3ZTZDJXaEtTOXNBV0lIbm14WXQKUXBOcWNQcHdSSUcrT0dEaTZnbDB4UnRXbXAxVkRPNHFuNndWaFFTemRiWjJuNGc2SlJ4WU9GWVdqaDlqUXpNWgpEQkd6c3pWZmc1eEw0U0E5d3NCNXY1N0RMUnZtY0xsaWhSUlIzbWRxU2VHUnlNRHBKWVNVdHZzQnY3MDdWSmxvCmczWUpFQ0NEZXJ5NDdueDVVOFZTRktxaUNmVU8venJkaVd3cDNrRWJuaGRFOXArMURKOTlGQ3pxYmlWRkpZYjYKQ2JQeUp0Q1RETXgwMjBGVmdaNVhxNFh4Q3NoWHpYb0hVSFp6RFN1UUVPUnQrUlFOUmtyN3k4MVRzeCs2Y3o4cwp0QncwSlNiRitGdHVkbUhQSkkrMVgvTXdlVW5CZ3dYTjd3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFtWkRKall6Vm1ZUzFtWkRFekxUUXlOV1F0WVRJeFpDMDMKTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbVpESmpZelZtWVMxbVpERXpMVFF5TldRdFlUSXhaQzAzTXpRMVlUazNaV1U1TldJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc2oxK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBcVJTTWFsVmIxVDZmOXREUWlNSWJGODR5b1BSejZlVGlVK1hLcFpob0w0SWMza3o3bEYxZUpnckgwTQpzOU5FVi9rWW93OHAvRjBoM0FHSk5NMUJWdlh3UmZnM3RudGVSQk5HQ3prdjdiVGI0aTdXR3BxWU5OU00yZ0VYCk1QUm1vYnRKMm02VEt0d0Q5WUhwYlFDR0gyNU82dS9KaGJDVVdqcmVMcmVrdDhnYmFQVkVSTG1XSldPMzhNeU4KK3IyUmZDdCtTbitiRVJVZFl0NkZVa2FDY0xlTXFDajdDWXZ5NkloVU9IeUdGWWxMdHFVc2JVd1hGWEl0T3RNRAorWUpVcnpYQXV0WGFrQjc1dnJwTHBqYjl5UlpsZmFGLzA3KzExY3c4bjRyOXFXQ2t3cW9UdVdYUXoxa1hxcnpQCmVkVlN4WWVqRUJ3cEdLQm5HVjRIMk55TkxEMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
       - "2011"
@@ -1481,7 +1448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:07:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1491,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1bee7e4-d6db-4940-bdb0-0dd7ba9322fc
+      - e4747d8f-08ec-49bb-b3c4-8403a1485dcc
     status: 200 OK
     code: 200
     duration: ""
@@ -1502,7 +1469,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fd2cc5fa-fd13-425d-a21d-7345a97ee95b&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:07:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f4a0080e-2458-4c92-bd6d-8e8acbff03b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -1514,7 +1514,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:41 GMT
+      - Mon, 18 Dec 2023 13:07:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1524,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2642171-fa5f-4a1e-9518-7de55d4a7f5b
+      - d39b6d29-0fcd-474c-a272-75c6a8805880
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,10 +1535,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:10.054323Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:20:11.587328Z"}'
+    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1547,7 +1547,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:07:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91d48c1c-1a27-45f6-9a02-907651136b5c
+      - 20d51491-0dd8-4c92-a527-fbf8178b644f
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,10 +1568,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:20:10.054323Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:20:11.587328Z"}'
+    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"ready","updated_at":"2023-12-18T13:06:39.149909Z"}'
     headers:
       Content-Length:
       - "420"
@@ -1580,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:07:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 816f49c2-d7ea-4e17-a491-7725b574324f
+      - a5d014ee-b00c-4fa6-b6b2-52149073b345
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,10 +1601,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: DELETE
   response:
-    body: '{"created_at":"2023-12-18T13:20:10.054323Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","instance_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"deleting","updated_at":"2023-12-18T13:20:11.587328Z"}'
+    body: '{"created_at":"2023-12-18T13:06:37.630844Z","database_name":"foo","download_url":null,"download_url_expires_at":null,"expires_at":null,"id":"f5837fe9-f189-4049-83e5-e915409d48d0","instance_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","instance_name":"TestAccScalewayRdbDatabaseBackup_Basic","name":"test_backup","region":"fr-par","same_region":false,"size":1229,"status":"deleting","updated_at":"2023-12-18T13:06:39.149909Z"}'
     headers:
       Content-Length:
       - "423"
@@ -1613,7 +1613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:07:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efe98fd6-6180-4eb8-9e86-b9ed5f794d79
+      - d4cbbaa4-86d9-4cc0-9688-80867b1c9f65
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,10 +1634,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"f5837fe9-f189-4049-83e5-e915409d48d0","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1646,7 +1646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:07:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ef0af7c-31f0-45d7-92bb-64ebae41d396
+      - bc9f5047-9178-42ac-bc83-73fe8a16da4b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1667,10 +1667,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -1679,7 +1679,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:42 GMT
+      - Mon, 18 Dec 2023 13:07:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d5337d6-323b-4367-801a-f3c2b2d8a440
+      - 711ad187-9d7b-4254-a145-99d97d2b5215
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,7 +1700,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b/databases/foo
     method: DELETE
   response:
     body: ""
@@ -1710,7 +1710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:43 GMT
+      - Mon, 18 Dec 2023 13:07:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3fad7ca-10ea-4bcf-b3f8-dc27f4274c19
+      - 43c02fba-86b3-4800-a584-1a426261b045
     status: 204 No Content
     code: 204
     duration: ""
@@ -1731,10 +1731,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -1743,7 +1743,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:44 GMT
+      - Mon, 18 Dec 2023 13:07:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16721884-149b-4290-a82d-23ebeb45e91c
+      - 3974fe6e-2aff-4b9e-aa0f-0ecad13bf96a
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,10 +1764,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1229"
@@ -1776,7 +1776,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:44 GMT
+      - Mon, 18 Dec 2023 13:07:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ff53da2-9d83-4068-b4f4-3a9d89c9bc7c
+      - 4e03d35e-11e9-49fb-9b90-881d283de44c
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,10 +1797,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1232"
@@ -1809,7 +1809,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:44 GMT
+      - Mon, 18 Dec 2023 13:07:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7fe1b29-1e86-40cd-b12e-27447a6c2127
+      - 2669937f-3792-4e51-90a1-69e8bbe8d0bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1830,10 +1830,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.609612Z","retention":7},"created_at":"2023-12-18T13:16:02.609612Z","endpoint":{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523},"endpoints":[{"id":"caf91fac-53c8-487a-8d44-07b7dd0b86e1","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25523}],"engine":"PostgreSQL-15","id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:02:16.390946Z","retention":7},"created_at":"2023-12-18T13:02:16.390946Z","endpoint":{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922},"endpoints":[{"id":"5c64a79b-c6e6-41fc-9236-e12c7209561d","ip":"51.159.207.148","load_balancer":{},"name":null,"port":16922}],"engine":"PostgreSQL-15","id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabaseBackup_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1232"
@@ -1842,7 +1842,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:44 GMT
+      - Mon, 18 Dec 2023 13:07:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 896ee787-abed-4529-ad00-7a94f0484c2e
+      - 65fbc2dc-3440-48c9-8882-ef21bb733660
     status: 200 OK
     code: 200
     duration: ""
@@ -1863,10 +1863,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1875,7 +1875,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:07:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +1885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 139cdaeb-6f0f-42cd-8868-fe090bd617e9
+      - 5d024860-e6e4-40e0-acf8-28d2554d7945
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1896,10 +1896,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c0b59a1-3c27-4f65-9164-b13dcc88de70
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fd2cc5fa-fd13-425d-a21d-7345a97ee95b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5c0b59a1-3c27-4f65-9164-b13dcc88de70","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"fd2cc5fa-fd13-425d-a21d-7345a97ee95b","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1908,7 +1908,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:07:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1918,7 +1918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06ad8db7-7752-45b2-99dc-716ad3442ef2
+      - 35dbf137-7eee-4ea3-8d5c-1fe5e2d46af5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1929,10 +1929,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/30c064e9-6b2f-45d9-8f14-eac91ecf5551
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/backups/f5837fe9-f189-4049-83e5-e915409d48d0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"30c064e9-6b2f-45d9-8f14-eac91ecf5551","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"database_backup","resource_id":"f5837fe9-f189-4049-83e5-e915409d48d0","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -1941,7 +1941,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:21:15 GMT
+      - Mon, 18 Dec 2023 13:07:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1951,7 +1951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea89ff8c-8891-4aee-b218-8c91c7f50321
+      - 158f4fbb-2b63-425d-b6f5-fad64ce1c70a
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-database-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:01 GMT
+      - Mon, 18 Dec 2023 12:57:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00e40e44-514c-423c-bc00-393ac0a7d9cd
+      - 37ec5c9f-aa64-442e-a1c3-1abf62059e7d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbDatabase_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"TestAccScalewayRdbDatabase_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:02 GMT
+      - Mon, 18 Dec 2023 13:01:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22a7d5e9-1295-4158-825e-f4eb262d3ead
+      - fad12f9f-1ada-4ba2-88cf-f953e46c0934
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:03 GMT
+      - Mon, 18 Dec 2023 13:01:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74b35772-9aee-4100-a422-347475f6569c
+      - dcbeb1a4-ab0b-48a4-94bf-ce0bfec3b756
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:33 GMT
+      - Mon, 18 Dec 2023 13:02:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a6f1507-0b43-4007-9d22-224251a8ce7e
+      - 429de44a-b7b1-49b5-9c64-16b29550ce34
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:03 GMT
+      - Mon, 18 Dec 2023 13:02:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e928b7c7-4fa7-48c8-9e27-184c473d263f
+      - b9873573-19e7-433c-8aae-d95d89dceac8
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:33 GMT
+      - Mon, 18 Dec 2023 13:03:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6b1eea4-8e1f-48a5-8104-200c6651637a
+      - dbd46748-c622-49d7-a02f-c959c324dcef
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:04 GMT
+      - Mon, 18 Dec 2023 13:03:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35432080-812f-4acc-9cd9-f638ed00276f
+      - 0c20a0f2-9ff3-4689-8a9b-95b15d6af5de
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:04:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c587a0d-42f6-4a57-b755-fffa41a6652a
+      - ef6177b6-3113-43dd-9e21-49452fa8856d
     status: 200 OK
     code: 200
     duration: ""
@@ -572,10 +572,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "960"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:04:48 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 892b3cf5-6f48-4330-8df5-53ca550f0ee0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "960"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 17cb39b2-ca0f-43f4-9688-fa61f861277f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1224"
@@ -584,7 +650,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:04 GMT
+      - Mon, 18 Dec 2023 13:05:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8c5ba00-6ceb-43af-aad0-56f27cd40d43
+      - 021f7fcc-5f78-4119-8c35-bff960189e44
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:06:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91f5e9cf-5129-4c2c-91e2-1b907eaaa3d3
+      - 6a6db34e-e5d3-40b1-b943-5ab8b4909f57
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:06:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab6b6556-a794-4afd-a16c-a6d66ed23d33
+      - c70d2cf8-0e62-4d91-9426-77175234dd5f
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:34 GMT
+      - Mon, 18 Dec 2023 13:06:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 211e7dfc-f856-47e3-91ba-2511b1b96065
+      - c123b5d4-6d66-4059-97bd-7d307c27e693
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUHd5bERzUHBUTkVneVNpMUV0aVpQczNJbEQ4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBPVm9YRFRNek1USXhOVEV6TURVME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXkyOFlieXk5cWNFdkk1N0N3L0JOaFZNdFBHbjVqSjNsKzlIVS95eW9BV2Z2amg5SUEvMlgKOGc2dDRrUkx1MUxoK0R1M01YUUprSlFlTmxQN0FRM3hnbXVOU2tpaERYdzBDZTN3LzUxWGl1YnQ4YlVEZFZGUApKZ3Avc0pDS3NwWGxrWjZCZlhpTDhGdnN1K1F5K24wa3NObmFFSGtBWEpvYTJnMFJYbGhVK2E4SlhSVlEzNHdCCncvZUhDT1VlYktEZzR4RDJ5L3hoUzcrbUovZXZkUmk2QXZRaHRhV1QzZXFKbmsrUEtscUdnZmRuS1E1akswVSsKUzVnL1ZyT3JXV0hnTWZuSCt1c2ZRVU9rZTdhQjVQSjVoMWc2bW0rVWhJUnVQOUJkTER6Y0RSVnJ2a2s3WG8yawpiVWhBZ0NNM0dWSFF2WTd4TlVqbkI0ejJuVFRCcEJ2M0VRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAwWkRnNFlXRTNOaTB6T1RkbUxUUmhZall0WVdaa015MWwKTW1VM09XRTVZbUprWldNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwMFpEZzRZV0UzTmkwek9UZG1MVFJoWWpZdFlXWmtNeTFsTW1VM09XRTVZbUprWldNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIQmZLc3BrakhKY3hiNkcwLzhYRkxqRzBETVdMR2xteDlZeHF1dGlxYkpUR3lLeDR4b0pXeUtrQTY4VwpPNXZubHBlNXdMd3ZWK2p0MHN0dHc1TkhrWmM1cUt6L1pzbU9RekowRmdSUy9NVVM2NGJUNzdZSEFlOHNLZSs3CkhpYXYxTHh1Zng0aEwzUEpZb3pQMFlrZzFDeng2Tzk2S3dFNEQ1KzNHOHdBUWE3bXFBS1MwNElPeituZ1QwckEKSlM4S21PcWJ0R010clBIZVNXc1R6NlJOVzJEbFoxVmdqYWFkZmM5ZnpLam91eDkzenNTUWYzR2xUcTlOSmdGUwpOMlA4K1lRR2J3RlB3Sy9tQU92UmlBUVNDWk5meHphbS9RMXpuVFpwa25DMThMNGtrTkRHY1MrYzJEZkNLa1B0ClZucmpoa01lU1E0VmJCMG4vazNremJ0bHVMOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:06:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66b2fc42-ad04-45d4-aa04-1d1ace8ca364
+      - 489fc814-1333-4183-a659-9c9eacb050cc
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4d88aa76-397f-4ab6-afd3-e2e79a9bbdec&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVYzdXWXE2MVVZZS93Y0lEZ3MzOTFORmRtalk0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RTVNVEZhRncwek16RXlNVFV4TXpFNU1URmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzZBVC90ZGdUTVIxK3RmUzZCcGVPTmJEcExGT00xdnNvdkVCMWZkS2JxU0RiWEVxWDMKblgvTG5aWHJVa1hnaXlJU0NoVk5aOUNuelBhNktjaE9lNCsvYnBneG1ueGVNNnJlVEZuVnd2VmJUQ3FVZzVwRQptUDhWMzB5bEpNblFKc3BZbE9qcndreWE4ZXJOamVtRTVQOVYwbnBjbG5YaWpsdkZmWXUwbnE2TjhtbkxERmpSCnY5MWtIV09JL3BQdEdGVzZicjZzWU1tcGhVcnppb1ZjS3JPZnF3Ym5va1B5NFpOUE5OTWZrNnlyQUVxUk5nTE0KWkpXaG81SzBhWGViN3Y0TEd6MGhRQW9sSUR1Tm8xeEkyNUxhQjdER3dFNlVMNVBDcVpoRWMyTjY4NGkwRXcwZApqRVU0RWREcEpmMWt5M25nVGxQWFp1eUFqQ3oydGtBcTdSQjFBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwek1UWXpaV1JoWmkwek16TTRMVFJtWW1NdE9HTTQKT0MwMk16QXhaV1UwTkRsa1lURXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNekUyTTJWa1lXWXRNek16T0MwMFptSmpMVGhqT0RndE5qTXdNV1ZsTkRRNVpHRXhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS3p1aHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUJVMWdGaEwzNVVLTDJIckJHZkZQaE03Z0RXTVh3NEI3VEd1YU5acDlqbXNFNmVXV09tYzBWawoyUkRHdUJYUXZGbW9WMmkxYWw3UjJSeis4dFc1TGFpbzhnbEtZWTdEcm9ZdzVkRkpjVjczSzVnMzlmM3gyRk43CkhFK2MrYXZxakd1TTZBMCszenA0NFd5YWNUMTRjT01PRVNsR1A4N1lWZUZMa2U4K00vNXFoL29ZalNjY091RkkKaUZUSTFtNVYvT2E1cG5zOVY2bGxZZEFLSWdoK0xud2dDd3pnQ0RUQk9GSlVNRTN4SUR2Y2ZtdGJoUXF4T051WApKbHp4VCtoR0JQMzdTbVFEbFdDS0ZMd2RPMklFNkd5aEo0ZWJRQ1hGeWUvU3REZWt0OURkV0E5cXd2ZEdZMXJwCkgzckZ2a082OGo3MlRKS3g5SnZTN1h3TUx4YldZeFpkCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2015"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:06:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32180f72-3048-42ef-a2a5-666fecb5d082
+      - 5ad8d036-a272-4239-93a7-708a021bc7c4
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:35 GMT
+      - Mon, 18 Dec 2023 13:06:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67f864a6-6cd0-40b9-809d-96071b45a31e
+      - 8c716525-c2d7-4b11-b214-7def1be7763c
     status: 200 OK
     code: 200
     duration: ""
@@ -807,7 +873,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
@@ -819,7 +885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:06 GMT
+      - Mon, 18 Dec 2023 13:06:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3af778c5-8b22-4275-a1bc-0263146dfa5d
+      - 25a0632f-184b-4b50-9978-a578c18b653f
     status: 200 OK
     code: 200
     duration: ""
@@ -840,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:06:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeb5ffde-6fc5-49b9-ac7e-0cabb997d83a
+      - 511b92d1-dc70-4a65-9bc6-2c5617f4182d
     status: 200 OK
     code: 200
     duration: ""
@@ -873,40 +939,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d30b0fff-f688-406a-9679-ace9931cd801
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -918,7 +951,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:06:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8015c726-98b4-4efa-9944-427429fdf295
+      - 6a279575-be53-434b-bff4-507365860f58
     status: 200 OK
     code: 200
     duration: ""
@@ -939,106 +972,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1271"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a6cc7f6-fb9f-4f7f-9acc-c73bae6b1362
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/users?order_by=name_asc&page=1
-    method: GET
-  response:
-    body: '{"total_count":0,"users":[]}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 120923e0-a32c-4594-aff9-21c97281b491
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVYzdXWXE2MVVZZS93Y0lEZ3MzOTFORmRtalk0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RTVNVEZhRncwek16RXlNVFV4TXpFNU1URmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzZBVC90ZGdUTVIxK3RmUzZCcGVPTmJEcExGT00xdnNvdkVCMWZkS2JxU0RiWEVxWDMKblgvTG5aWHJVa1hnaXlJU0NoVk5aOUNuelBhNktjaE9lNCsvYnBneG1ueGVNNnJlVEZuVnd2VmJUQ3FVZzVwRQptUDhWMzB5bEpNblFKc3BZbE9qcndreWE4ZXJOamVtRTVQOVYwbnBjbG5YaWpsdkZmWXUwbnE2TjhtbkxERmpSCnY5MWtIV09JL3BQdEdGVzZicjZzWU1tcGhVcnppb1ZjS3JPZnF3Ym5va1B5NFpOUE5OTWZrNnlyQUVxUk5nTE0KWkpXaG81SzBhWGViN3Y0TEd6MGhRQW9sSUR1Tm8xeEkyNUxhQjdER3dFNlVMNVBDcVpoRWMyTjY4NGkwRXcwZApqRVU0RWREcEpmMWt5M25nVGxQWFp1eUFqQ3oydGtBcTdSQjFBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwek1UWXpaV1JoWmkwek16TTRMVFJtWW1NdE9HTTQKT0MwMk16QXhaV1UwTkRsa1lURXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNekUyTTJWa1lXWXRNek16T0MwMFptSmpMVGhqT0RndE5qTXdNV1ZsTkRRNVpHRXhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS3p1aHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUJVMWdGaEwzNVVLTDJIckJHZkZQaE03Z0RXTVh3NEI3VEd1YU5acDlqbXNFNmVXV09tYzBWawoyUkRHdUJYUXZGbW9WMmkxYWw3UjJSeis4dFc1TGFpbzhnbEtZWTdEcm9ZdzVkRkpjVjczSzVnMzlmM3gyRk43CkhFK2MrYXZxakd1TTZBMCszenA0NFd5YWNUMTRjT01PRVNsR1A4N1lWZUZMa2U4K00vNXFoL29ZalNjY091RkkKaUZUSTFtNVYvT2E1cG5zOVY2bGxZZEFLSWdoK0xud2dDd3pnQ0RUQk9GSlVNRTN4SUR2Y2ZtdGJoUXF4T051WApKbHp4VCtoR0JQMzdTbVFEbFdDS0ZMd2RPMklFNkd5aEo0ZWJRQ1hGeWUvU3REZWt0OURkV0E5cXd2ZEdZMXJwCkgzckZ2a082OGo3MlRKS3g5SnZTN1h3TUx4YldZeFpkCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2015"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6fdfa766-62b6-48d5-8493-15748b78d72f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -1050,7 +984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:07 GMT
+      - Mon, 18 Dec 2023 13:06:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29cdbbe1-ce02-4e06-88f7-94e6bbf55664
+      - 2b420f30-4358-4f58-aedc-a1ea7593c8fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:06:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c158282-d979-4c6e-b304-44dd0af79bb4
+      - 59f064c0-80cb-4b25-95bc-e78914694825
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,7 +1038,139 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUHd5bERzUHBUTkVneVNpMUV0aVpQczNJbEQ4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBPVm9YRFRNek1USXhOVEV6TURVME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXkyOFlieXk5cWNFdkk1N0N3L0JOaFZNdFBHbjVqSjNsKzlIVS95eW9BV2Z2amg5SUEvMlgKOGc2dDRrUkx1MUxoK0R1M01YUUprSlFlTmxQN0FRM3hnbXVOU2tpaERYdzBDZTN3LzUxWGl1YnQ4YlVEZFZGUApKZ3Avc0pDS3NwWGxrWjZCZlhpTDhGdnN1K1F5K24wa3NObmFFSGtBWEpvYTJnMFJYbGhVK2E4SlhSVlEzNHdCCncvZUhDT1VlYktEZzR4RDJ5L3hoUzcrbUovZXZkUmk2QXZRaHRhV1QzZXFKbmsrUEtscUdnZmRuS1E1akswVSsKUzVnL1ZyT3JXV0hnTWZuSCt1c2ZRVU9rZTdhQjVQSjVoMWc2bW0rVWhJUnVQOUJkTER6Y0RSVnJ2a2s3WG8yawpiVWhBZ0NNM0dWSFF2WTd4TlVqbkI0ejJuVFRCcEJ2M0VRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAwWkRnNFlXRTNOaTB6T1RkbUxUUmhZall0WVdaa015MWwKTW1VM09XRTVZbUprWldNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwMFpEZzRZV0UzTmkwek9UZG1MVFJoWWpZdFlXWmtNeTFsTW1VM09XRTVZbUprWldNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIQmZLc3BrakhKY3hiNkcwLzhYRkxqRzBETVdMR2xteDlZeHF1dGlxYkpUR3lLeDR4b0pXeUtrQTY4VwpPNXZubHBlNXdMd3ZWK2p0MHN0dHc1TkhrWmM1cUt6L1pzbU9RekowRmdSUy9NVVM2NGJUNzdZSEFlOHNLZSs3CkhpYXYxTHh1Zng0aEwzUEpZb3pQMFlrZzFDeng2Tzk2S3dFNEQ1KzNHOHdBUWE3bXFBS1MwNElPeituZ1QwckEKSlM4S21PcWJ0R010clBIZVNXc1R6NlJOVzJEbFoxVmdqYWFkZmM5ZnpLam91eDkzenNTUWYzR2xUcTlOSmdGUwpOMlA4K1lRR2J3RlB3Sy9tQU92UmlBUVNDWk5meHphbS9RMXpuVFpwa25DMThMNGtrTkRHY1MrYzJEZkNLa1B0ClZucmpoa01lU1E0VmJCMG4vazNremJ0bHVMOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8564333f-d95d-4434-a902-c3cf8fdc9cc0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4d88aa76-397f-4ab6-afd3-e2e79a9bbdec&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5650887e-6d3b-4d62-87bd-0c3c82480f0b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "102"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 10fb7e0e-c9ab-4773-86ef-cb142b576941
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1267"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6815e5d1-485a-491c-a26a-a8d83bbe2cd9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases/foo
     method: DELETE
   response:
     body: ""
@@ -1114,7 +1180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:08 GMT
+      - Mon, 18 Dec 2023 13:06:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 696bd8da-5a8c-4caa-b1db-e3ef255785f1
+      - 3e275cb4-ec38-495f-a5b1-1af326347871
     status: 204 No Content
     code: 204
     duration: ""
@@ -1135,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:06:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0958128b-3d8d-4d73-bf75-41b964a574cd
+      - af40fe34-70ac-48fd-854e-2627ba756664
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:06:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04fd93ee-ca12-48bf-a72f-360d4e92ffca
+      - 24e25bcd-3bd1-4815-af57-d579b3c2f794
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1274"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:06:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 859f4b30-46fa-400b-8110-93d138c28089
+      - 862bce2c-ba07-4f55-b38a-2cf99364f21e
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:16:02.685299Z","retention":7},"created_at":"2023-12-18T13:16:02.685299Z","endpoint":{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645},"endpoints":[{"id":"f7bd583b-c9e7-4fbe-8c37-8b00e31e5689","ip":"195.154.197.252","load_balancer":{},"name":null,"port":21645}],"engine":"PostgreSQL-15","id":"3163edaf-3338-4fbc-8c88-6301ee449da1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1274"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:09 GMT
+      - Mon, 18 Dec 2023 13:06:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54da6262-0eee-4769-b480-c3fbb17aaf46
+      - 6d617a9e-0cff-4f17-9b9a-8c463bf3ded7
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,10 +1333,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"3163edaf-3338-4fbc-8c88-6301ee449da1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1279,7 +1345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:39 GMT
+      - Mon, 18 Dec 2023 13:06:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18254d74-8fb6-43ec-8bce-8b46c3443346
+      - f3feb9c2-abc8-44e8-a8f6-5699493d6372
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1300,10 +1366,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3163edaf-3338-4fbc-8c88-6301ee449da1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"3163edaf-3338-4fbc-8c88-6301ee449da1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1312,7 +1378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:20:39 GMT
+      - Mon, 18 Dec 2023 13:06:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54e1699e-7858-4e6c-9887-abdb085931e3
+      - ac9cb16b-7bde-4577-b341-ee7ee6a0c4c9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-database-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:02 GMT
+      - Mon, 18 Dec 2023 14:09:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37ec5c9f-aa64-442e-a1c3-1abf62059e7d
+      - e8dee85c-e23b-436a-a9c2-8a268a6f7a45
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:47 GMT
+      - Mon, 18 Dec 2023 14:09:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fad12f9f-1ada-4ba2-88cf-f953e46c0934
+      - a1ede7e0-fe34-48b5-98fc-2fcbf600b7ba
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:47 GMT
+      - Mon, 18 Dec 2023 14:09:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcbeb1a4-ab0b-48a4-94bf-ce0bfec3b756
+      - 0ab94db9-cea4-4a72-8fa6-ffcec29e3600
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:02:17 GMT
+      - Mon, 18 Dec 2023 14:10:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 429de44a-b7b1-49b5-9c64-16b29550ce34
+      - fd87f236-4b1d-4f35-b579-ca20e9311aaf
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:02:47 GMT
+      - Mon, 18 Dec 2023 14:10:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9873573-19e7-433c-8aae-d95d89dceac8
+      - c72445e5-9362-4fc2-abf1-73be89f64d58
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:03:18 GMT
+      - Mon, 18 Dec 2023 14:11:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbd46748-c622-49d7-a02f-c959c324dcef
+      - c199ea1e-b188-48fc-a168-3a247586913e
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:03:48 GMT
+      - Mon, 18 Dec 2023 14:11:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c20a0f2-9ff3-4689-8a9b-95b15d6af5de
+      - 78169e62-6e77-4f33-afef-bf2a540d1966
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "960"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:04:18 GMT
+      - Mon, 18 Dec 2023 14:12:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef6177b6-3113-43dd-9e21-49452fa8856d
+      - 95e45126-8db3-40ba-8eeb-79d30e019587
     status: 200 OK
     code: 200
     duration: ""
@@ -572,76 +572,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "960"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:04:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 892b3cf5-6f48-4330-8df5-53ca550f0ee0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "960"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:05:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17cb39b2-ca0f-43f4-9688-fa61f861277f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1224"
@@ -650,7 +584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:05:49 GMT
+      - Mon, 18 Dec 2023 14:13:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 021f7fcc-5f78-4119-8c35-bff960189e44
+      - 0568a64c-94f8-4e7c-ae96-f34812c99d40
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:19 GMT
+      - Mon, 18 Dec 2023 14:13:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a6db34e-e5d3-40b1-b943-5ab8b4909f57
+      - 07b46fe4-030f-4fed-8e59-24543a6c12c8
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:20 GMT
+      - Mon, 18 Dec 2023 14:13:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c70d2cf8-0e62-4d91-9426-77175234dd5f
+      - d83db605-3966-47f2-838e-1e0545ed5947
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:20 GMT
+      - Mon, 18 Dec 2023 14:13:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c123b5d4-6d66-4059-97bd-7d307c27e693
+      - c59310b7-48e3-4264-9bad-3cb09c565802
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUHd5bERzUHBUTkVneVNpMUV0aVpQczNJbEQ4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBPVm9YRFRNek1USXhOVEV6TURVME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXkyOFlieXk5cWNFdkk1N0N3L0JOaFZNdFBHbjVqSjNsKzlIVS95eW9BV2Z2amg5SUEvMlgKOGc2dDRrUkx1MUxoK0R1M01YUUprSlFlTmxQN0FRM3hnbXVOU2tpaERYdzBDZTN3LzUxWGl1YnQ4YlVEZFZGUApKZ3Avc0pDS3NwWGxrWjZCZlhpTDhGdnN1K1F5K24wa3NObmFFSGtBWEpvYTJnMFJYbGhVK2E4SlhSVlEzNHdCCncvZUhDT1VlYktEZzR4RDJ5L3hoUzcrbUovZXZkUmk2QXZRaHRhV1QzZXFKbmsrUEtscUdnZmRuS1E1akswVSsKUzVnL1ZyT3JXV0hnTWZuSCt1c2ZRVU9rZTdhQjVQSjVoMWc2bW0rVWhJUnVQOUJkTER6Y0RSVnJ2a2s3WG8yawpiVWhBZ0NNM0dWSFF2WTd4TlVqbkI0ejJuVFRCcEJ2M0VRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAwWkRnNFlXRTNOaTB6T1RkbUxUUmhZall0WVdaa015MWwKTW1VM09XRTVZbUprWldNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwMFpEZzRZV0UzTmkwek9UZG1MVFJoWWpZdFlXWmtNeTFsTW1VM09XRTVZbUprWldNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIQmZLc3BrakhKY3hiNkcwLzhYRkxqRzBETVdMR2xteDlZeHF1dGlxYkpUR3lLeDR4b0pXeUtrQTY4VwpPNXZubHBlNXdMd3ZWK2p0MHN0dHc1TkhrWmM1cUt6L1pzbU9RekowRmdSUy9NVVM2NGJUNzdZSEFlOHNLZSs3CkhpYXYxTHh1Zng0aEwzUEpZb3pQMFlrZzFDeng2Tzk2S3dFNEQ1KzNHOHdBUWE3bXFBS1MwNElPeituZ1QwckEKSlM4S21PcWJ0R010clBIZVNXc1R6NlJOVzJEbFoxVmdqYWFkZmM5ZnpLam91eDkzenNTUWYzR2xUcTlOSmdGUwpOMlA4K1lRR2J3RlB3Sy9tQU92UmlBUVNDWk5meHphbS9RMXpuVFpwa25DMThMNGtrTkRHY1MrYzJEZkNLa1B0ClZucmpoa01lU1E0VmJCMG4vazNremJ0bHVMOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:20 GMT
+      - Mon, 18 Dec 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 489fc814-1333-4183-a659-9c9eacb050cc
+      - 6b12ae26-5a3b-42c3-91ed-41bb6c856ce0
     status: 200 OK
     code: 200
     duration: ""
@@ -805,7 +739,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4d88aa76-397f-4ab6-afd3-e2e79a9bbdec&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVUTZnSk1YV0hDdmc1a1BjeFlQdzhTQ1ZEbmdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRFeU5EbGFGdzB6TXpFeU1UVXhOREV5TkRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURVcTZ5SjFCc3dwWklhUjM0Tm8rT2NqMW1zVUxlaWd5VlozKzRsc3Y5Z2IxUk95YWk0Q1FSZEEvOHoKRHpBcGI0dVd2L2pFVDdacXQ1dTRmWEVpOGllMlZKa1dCVHRYSXVTTkc2dEVlSHU5U2RQUDRBNENlYWpLSEp0eQo1WjdneGczYjRHcHY0d1VMOTFZWllnczI2WGVqUnBkTXpYQ2cyNFI0MXpnUlkydDFxaUNaRHdYZjNaNXN5czZ6CnYwdmNWRlErejJnQzJTdHNkUEpNenlxWkNoNmFXQ1pHNDVwbktFalNXSHNIcStIQ3VuUlNCYXdtSFR0aEZxV1UKdUozMWh0WkZCQ1djRVVNNnRab1d3RElQWUxDdGU3dmhaZ2c0dkUzTkM3ZyszTGNwbW9neUN1MGxZb0hXVUNOWApERjdtRjlINWl6WHZ2SjhZZmIzc2R6SFhRRDFuQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkweU1XTXlNMk5pT1MwMU5EVXdMVFE0T0RFdE9XUXpOeTB4T0RNME5URTMKTm1RMFkySXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TWpGagpNak5qWWprdE5UUTFNQzAwT0RneExUbGtNemN0TVRnek5EVXhOelprTkdOaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJLRWVod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBdjVvTkMKdTRWOURPQ3pLcWFSWnowd0QxYlpuT3BJU0ZyOFJWQ1JUTDUyVW9KcXpsMU9qcldndjZNTGtOdU05b3cxTXgzNApkNlBSN3YwNEorYnpWNFVSM0JBOWdqOW5ZaGVZUDFPWlhpcG1BbDlFVVRUdlhySnhFZWhZc2tIUlFwOUpKYU5ZCmQ1cXNNa1ExanYwZGZEUUdENWJXTFo0a2V0MGptYUZibGF1ckNSc09tZkZVckpmdHlhMXU3VFo4aFBjalFGWVIKSjk5dGNtUElHamtrbVFkcUY3SzhuYm5DazlIUVNjSlRPY1g2Z0lFVUI0MDArOFNuOEpGTm96VGt3a3BsekMxMwpacUJlRG5TRXFGays5My9Xc2hTdWhUZldwVmdPYi9tZHBYUUhzU1NIQkNabzFWQTlpVHBWbGZMcGEvNi9yN1ZnCm52Z1JUV0FCNkRQcFgyQzcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:13:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6cdfcafc-bddb-4cfb-acfd-7805d2a9e0b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=21c23cb9-5450-4881-9d37-18345176d4cb&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -817,7 +784,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:20 GMT
+      - Mon, 18 Dec 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ad8d036-a272-4239-93a7-708a021bc7c4
+      - e1d56223-df6f-4ce4-9c97-26d2393fcd07
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:20 GMT
+      - Mon, 18 Dec 2023 14:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c716525-c2d7-4b11-b214-7def1be7763c
+      - 1d482b00-2086-4487-b211-817c6a079464
     status: 200 OK
     code: 200
     duration: ""
@@ -873,7 +840,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
@@ -885,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:21 GMT
+      - Mon, 18 Dec 2023 14:13:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25a0632f-184b-4b50-9978-a578c18b653f
+      - 556ef765-da59-4402-883c-661c09f390c2
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:21 GMT
+      - Mon, 18 Dec 2023 14:13:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 511b92d1-dc70-4a65-9bc6-2c5617f4182d
+      - 791a40a0-3232-46c6-858d-28c9f57ebb43
     status: 200 OK
     code: 200
     duration: ""
@@ -939,40 +906,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "102"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:06:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6a279575-be53-434b-bff4-507365860f58
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -984,7 +918,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:21 GMT
+      - Mon, 18 Dec 2023 14:13:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b420f30-4358-4f58-aedc-a1ea7593c8fc
+      - c2a6aaa8-315c-4e23-a693-58731d97f332
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
-      - "1267"
+      - "102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:22 GMT
+      - Mon, 18 Dec 2023 14:13:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59f064c0-80cb-4b25-95bc-e78914694825
+      - ca0ac158-7c45-4bfb-9934-ca69911511c4
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVUHd5bERzUHBUTkVneVNpMUV0aVpQczNJbEQ4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EVTBPVm9YRFRNek1USXhOVEV6TURVME9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXkyOFlieXk5cWNFdkk1N0N3L0JOaFZNdFBHbjVqSjNsKzlIVS95eW9BV2Z2amg5SUEvMlgKOGc2dDRrUkx1MUxoK0R1M01YUUprSlFlTmxQN0FRM3hnbXVOU2tpaERYdzBDZTN3LzUxWGl1YnQ4YlVEZFZGUApKZ3Avc0pDS3NwWGxrWjZCZlhpTDhGdnN1K1F5K24wa3NObmFFSGtBWEpvYTJnMFJYbGhVK2E4SlhSVlEzNHdCCncvZUhDT1VlYktEZzR4RDJ5L3hoUzcrbUovZXZkUmk2QXZRaHRhV1QzZXFKbmsrUEtscUdnZmRuS1E1akswVSsKUzVnL1ZyT3JXV0hnTWZuSCt1c2ZRVU9rZTdhQjVQSjVoMWc2bW0rVWhJUnVQOUJkTER6Y0RSVnJ2a2s3WG8yawpiVWhBZ0NNM0dWSFF2WTd4TlVqbkI0ejJuVFRCcEJ2M0VRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTAwWkRnNFlXRTNOaTB6T1RkbUxUUmhZall0WVdaa015MWwKTW1VM09XRTVZbUprWldNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwMFpEZzRZV0UzTmkwek9UZG1MVFJoWWpZdFlXWmtNeTFsTW1VM09XRTVZbUprWldNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFIQmZLc3BrakhKY3hiNkcwLzhYRkxqRzBETVdMR2xteDlZeHF1dGlxYkpUR3lLeDR4b0pXeUtrQTY4VwpPNXZubHBlNXdMd3ZWK2p0MHN0dHc1TkhrWmM1cUt6L1pzbU9RekowRmdSUy9NVVM2NGJUNzdZSEFlOHNLZSs3CkhpYXYxTHh1Zng0aEwzUEpZb3pQMFlrZzFDeng2Tzk2S3dFNEQ1KzNHOHdBUWE3bXFBS1MwNElPeituZ1QwckEKSlM4S21PcWJ0R010clBIZVNXc1R6NlJOVzJEbFoxVmdqYWFkZmM5ZnpLam91eDkzenNTUWYzR2xUcTlOSmdGUwpOMlA4K1lRR2J3RlB3Sy9tQU92UmlBUVNDWk5meHphbS9RMXpuVFpwa25DMThMNGtrTkRHY1MrYzJEZkNLa1B0ClZucmpoa01lU1E0VmJCMG4vazNremJ0bHVMOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2011"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:22 GMT
+      - Mon, 18 Dec 2023 14:13:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8564333f-d95d-4434-a902-c3cf8fdc9cc0
+      - 40e2a8b9-2892-4939-83c9-54ed2c6fd82b
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,7 +1005,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4d88aa76-397f-4ab6-afd3-e2e79a9bbdec&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/users?order_by=name_asc&page=1
+    method: GET
+  response:
+    body: '{"total_count":0,"users":[]}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:13:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9277d23b-1b21-41d7-a50c-4c1682042783
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVUTZnSk1YV0hDdmc1a1BjeFlQdzhTQ1ZEbmdNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzQxTmk0ek1qQWVGdzB5Ck16RXlNVGd4TkRFeU5EbGFGdzB6TXpFeU1UVXhOREV5TkRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU5UWXVNekl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURVcTZ5SjFCc3dwWklhUjM0Tm8rT2NqMW1zVUxlaWd5VlozKzRsc3Y5Z2IxUk95YWk0Q1FSZEEvOHoKRHpBcGI0dVd2L2pFVDdacXQ1dTRmWEVpOGllMlZKa1dCVHRYSXVTTkc2dEVlSHU5U2RQUDRBNENlYWpLSEp0eQo1WjdneGczYjRHcHY0d1VMOTFZWllnczI2WGVqUnBkTXpYQ2cyNFI0MXpnUlkydDFxaUNaRHdYZjNaNXN5czZ6CnYwdmNWRlErejJnQzJTdHNkUEpNenlxWkNoNmFXQ1pHNDVwbktFalNXSHNIcStIQ3VuUlNCYXdtSFR0aEZxV1UKdUozMWh0WkZCQ1djRVVNNnRab1d3RElQWUxDdGU3dmhaZ2c0dkUzTkM3ZyszTGNwbW9neUN1MGxZb0hXVUNOWApERjdtRjlINWl6WHZ2SjhZZmIzc2R6SFhRRDFuQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpVMkxqTXlnanh5ZHkweU1XTXlNMk5pT1MwMU5EVXdMVFE0T0RFdE9XUXpOeTB4T0RNME5URTMKTm1RMFkySXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzQxTmk0ek1vSThjbmN0TWpGagpNak5qWWprdE5UUTFNQzAwT0RneExUbGtNemN0TVRnek5EVXhOelprTkdOaUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJLRWVod1F6bmpnZ2h3UXpuamdnTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBdjVvTkMKdTRWOURPQ3pLcWFSWnowd0QxYlpuT3BJU0ZyOFJWQ1JUTDUyVW9KcXpsMU9qcldndjZNTGtOdU05b3cxTXgzNApkNlBSN3YwNEorYnpWNFVSM0JBOWdqOW5ZaGVZUDFPWlhpcG1BbDlFVVRUdlhySnhFZWhZc2tIUlFwOUpKYU5ZCmQ1cXNNa1ExanYwZGZEUUdENWJXTFo0a2V0MGptYUZibGF1ckNSc09tZkZVckpmdHlhMXU3VFo4aFBjalFGWVIKSjk5dGNtUElHamtrbVFkcUY3SzhuYm5DazlIUVNjSlRPY1g2Z0lFVUI0MDArOFNuOEpGTm96VGt3a3BsekMxMwpacUJlRG5TRXFGays5My9Xc2hTdWhUZldwVmdPYi9tZHBYUUhzU1NIQkNabzFWQTlpVHBWbGZMcGEvNi9yN1ZnCm52Z1JUV0FCNkRQcFgyQzcKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:13:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7cad486d-bd0b-44eb-8e82-c722008e4691
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=21c23cb9-5450-4881-9d37-18345176d4cb&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1083,7 +1083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:22 GMT
+      - Mon, 18 Dec 2023 14:13:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5650887e-6d3b-4d62-87bd-0c3c82480f0b
+      - 7869d7b9-c64d-40c6-81ae-d1606e692bdb
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,7 +1104,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -1116,7 +1116,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:22 GMT
+      - Mon, 18 Dec 2023 14:13:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10fb7e0e-c9ab-4773-86ef-cb142b576941
+      - a338f4f8-758a-4705-b695-d8b51715518d
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:22 GMT
+      - Mon, 18 Dec 2023 14:13:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6815e5d1-485a-491c-a26a-a8d83bbe2cd9
+      - 3388d152-e3b4-4a1b-9393-6763fcf1aa81
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,7 +1170,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb/databases/foo
     method: DELETE
   response:
     body: ""
@@ -1180,7 +1180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:23 GMT
+      - Mon, 18 Dec 2023 14:13:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e275cb4-ec38-495f-a5b1-1af326347871
+      - a507cf0e-90ce-486d-9732-f79397746dd3
     status: 204 No Content
     code: 204
     duration: ""
@@ -1201,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:23 GMT
+      - Mon, 18 Dec 2023 14:13:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af40fe34-70ac-48fd-854e-2627ba756664
+      - e84aa47e-f961-4400-a94e-65f72ab82631
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1267"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:23 GMT
+      - Mon, 18 Dec 2023 14:13:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24e25bcd-3bd1-4815-af57-d579b3c2f794
+      - 768c5067-abfa-491b-9161-139719bf144d
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:24 GMT
+      - Mon, 18 Dec 2023 14:13:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 862bce2c-ba07-4f55-b38a-2cf99364f21e
+      - 4455aad0-5d40-4fe2-a79a-9e40bf4823d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:01:47.007469Z","retention":7},"created_at":"2023-12-18T13:01:47.007469Z","endpoint":{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779},"endpoints":[{"id":"9f686ce1-67b7-4dfb-bcc8-1f3c5fb2f85c","ip":"51.159.207.148","load_balancer":{},"name":null,"port":9779}],"engine":"PostgreSQL-15","id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:09:54.740682Z","retention":7},"created_at":"2023-12-18T14:09:54.740682Z","endpoint":{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250},"endpoints":[{"id":"cf8425bc-4ae9-4fe2-bb64-e19e776f0acb","ip":"51.158.56.32","load_balancer":{},"name":null,"port":1250}],"engine":"PostgreSQL-15","id":"21c23cb9-5450-4881-9d37-18345176d4cb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbDatabase_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:24 GMT
+      - Mon, 18 Dec 2023 14:13:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d617a9e-0cff-4f17-9b9a-8c463bf3ded7
+      - cb985ede-ca24-49d8-adf3-bc4ef9984bb5
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,10 +1333,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"21c23cb9-5450-4881-9d37-18345176d4cb","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1345,7 +1345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:54 GMT
+      - Mon, 18 Dec 2023 14:14:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3feb9c2-abc8-44e8-a8f6-5699493d6372
+      - ff7eb91e-f6e1-40db-8bf5-2dd43d9da213
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1366,10 +1366,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4d88aa76-397f-4ab6-afd3-e2e79a9bbdec
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/21c23cb9-5450-4881-9d37-18345176d4cb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"4d88aa76-397f-4ab6-afd3-e2e79a9bbdec","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"21c23cb9-5450-4881-9d37-18345176d4cb","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1378,7 +1378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:06:54 GMT
+      - Mon, 18 Dec 2023 14:14:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac9cb16b-7bde-4577-b341-ee7ee6a0c4c9
+      - ae5fb194-94ac-49f3-b6d9-527bab67f098
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-database-manual-delete.cassette.yaml
+++ b/scaleway/testdata/rdb-database-manual-delete.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:01 GMT
+      - Mon, 18 Dec 2023 12:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36c91dc7-fbea-49fe-91b1-7fd1b284da01
+      - 7aae3b8c-5c01-4c4c-8086-a0988d370541
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"bug","engine":"PostgreSQL-15","user_name":"admin","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-m","is_ha_cluster":false,"disable_backup":true,"tags":["bug"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"bug","engine":"PostgreSQL-15","user_name":"admin","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-m","is_ha_cluster":false,"disable_backup":true,"tags":["bug"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "865"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:02 GMT
+      - Mon, 18 Dec 2023 13:01:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75b60ca6-c571-41f6-8737-f418a6f017f3
+      - df900913-c45f-4b1e-b848-0fe3adc3aab8
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "865"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:03 GMT
+      - Mon, 18 Dec 2023 13:01:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d06ecde3-c0d6-4bf2-af81-df813a1be234
+      - 97f02adb-556c-432f-806c-9f6a9b2ad0f2
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "865"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:33 GMT
+      - Mon, 18 Dec 2023 13:02:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32d2175e-53a5-45bf-b598-ab16d6eb3ae0
+      - 339dfcfa-3f11-4617-9e2d-f4b8a9bd084d
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "865"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:03 GMT
+      - Mon, 18 Dec 2023 13:02:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79597a01-249d-4efe-959e-0504fefc3023
+      - e443098d-f005-48a3-ba51-24f8c78eafd3
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "865"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:33 GMT
+      - Mon, 18 Dec 2023 13:03:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5db8ff58-5dce-4100-a425-e748dc1464d7
+      - 435b0ec9-d188-47e6-8ebf-218ab621a7a3
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "865"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:04 GMT
+      - Mon, 18 Dec 2023 13:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c0d78f6-e8d8-408f-8b79-bf2314dc0234
+      - ed81c495-18b7-42a0-87c8-21df22a2ca00
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "865"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:04:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7218f79c-02e5-40da-a8c0-a36453abb981
+      - 18dde672-47a1-418c-adbc-37b2681d84b8
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1BJRzR3Uy9JZ0s5RDhxalR3dVF3aWVkTzVrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE9ERTNXaGNOTXpNeE1qRTFNVE14T0RFM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1scDJYaXVpQUdUcEgvUGZvL01YTHFhK3FTc1RPckFzSmhvSW9vWENCNmg5RzdjdldyeGFLOXIKMU1oa2V3eEJzKzVRWmpaM1Z6TXdvV01DaHVYU2dnVmxibDVNd2trNWh1aDN2clYxRGhuY3I3WjlUSXFZOWVGbgp3b2VxaG9mZnpPei9jVGhlS2I5ZG9ITkI4NjdnUkQzeU5iTjFVaEx1UkgzYW9teHM2K0c5SldwUHY3bFJWRmNhCmtoWnY5TUZ1cGVRU2NUS3VDTk1zTXFQaDB4RWJIaHRIMS9VKzVDSGYvR0dtT0ZpcTBJbmhMSTc4OUJHRm04UlAKZ3M2N093elkwWVhzS1VvWCtKalhDUjQ5T0toSlYzVlI1UDl1VFJxRyttWk51c3V1WGcvRUdvRzdwNStUVktxawpOemdVZ1FtSDQ3dDRuMTBRWUhvc202akdZQTJXaG9zQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWhNRGd6WmpBM1l5MDJNV0UwTFRSa1lqTXRZV1UwWkMxbU9ETmsKTlRFMlpHTXdOR0l1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV0V3T0RObU1EZGpMVFl4WVRRdE5HUmlNeTFoWlRSa0xXWTRNMlExTVRaa1l6QTBZaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy8yM0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWmZtczYvN29SNExRSlNwQnBKS2pXOE5SUXBUTEhXU3ZSbGUxYndIdlRaT0toZkFjRVI3b1RpVmlDN1ZiVUVjVgpXWmhEUE5rME0yUTYySklVUldvVkNrbWg0TkpUZEFpcGgyZGJrR0RzNk5jNGdreVQ4UHpkUFBrdWwwQ1NmUlE3CnhBNjNVNGovSHRJQ0dJTFlXVEY0cHNiRW91cEd3MG0yUm5CU1lEVmVLZWtFSTF3U2Z3R3Q2VGNVUUhadjlGV2MKaEFSenRvNWZLcFFwR0plRmgxZnBQRWw3SHJkQXVLTUEyM0E2cFVVOFBkMGs4cExsWUFjbUxBN0Y0dGJwSlM5VwpsejJLYVIyNURoYkE0UkJ4c3QvbXNPUFZWRHVNUkkrd1lBbHRMc2ZWZ25rNDdOdVRRcFNHS1FzMnU3MElLckpHCk0reWdkNVQveTg2UjBjSTh0WVNzc3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2007"
+      - "1129"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:04:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34f01988-40a8-4c8a-84cd-166ab44b563b
+      - d84c1e16-4e22-4e8e-afad-27375e767d1a
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"initializing","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1129"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:05:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 781f84bd-553a-45b4-99ae-aa8e0a0e07f7
+      - 701fc437-c710-47d3-8c46-ea40dd2baeba
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8a4d574-7d23-40e0-942b-ce9d166639a7
+      - 1a691a3e-53a8-4bd5-8bdb-709fa2e7b245
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVRGNOTTBOcEY3WGlEQm5zbkpRSWRmWFk1UkJjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1EUTFPRm9YRFRNek1USXhOVEV6TURRMU9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFGSTZnU0NyWHF4aDhDN2dEdFFHTVJab1pMMWp6anNsUlJKN1pxVmZCUC9xMHV0OHN2WUMKeSs5QWdtVU1BRlhyRU1jbnkwY0VjeStYeWxzR01rbHQyWmRCczhCakw3UWZsRXluQm9tL1F6MjBEOUw0U2x5TAp3Q1RHMXRjcm5uRkhFKzVtclg2RFE2aWxzS2RvWlhtTVVYMXZIVVVxc3FlTlJIV014eXAxeGhzMkNYMVZFOERyCndIK1FGWDhOUmtOV1crcnc3NDJZWHlFdVVXTkZYMWpZY1A2VDkxQWlFRnNTdUpwN2lQR05rSzB3ZHBwNWUrQlUKQnRoYXdXdDlmOFA1RGttRWtuN1N4cGtFelV6cVUveVd6amo0eHgvRVViK2toVGg3dmFjbGpyYnZXRGwvVXl6awpjZU9nYUpabzlJWU1ocG5HVlZhSXVjRFdJd2xlUkFTR0V3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTB6WTJSaU1qVTJZeTAxTkdNNExUUmxNVGN0T1RneE9DMWgKWVRobVl6a3lZalprTldRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwelkyUmlNalUyWXkwMU5HTTRMVFJsTVRjdE9UZ3hPQzFoWVRobVl6a3lZalprTldRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc29SNkhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFHTjdWTEcwZnpFUFFuWldzdUFhejlJQTUwM1V0U04wMGRCMDJtRDFYVmhmUllPckFVeUljMEwvU2ZNcApNOHBPbk9zL29xaVk2Vzd0RzQrQStURFpWa3hMZ3RHWUJ0YjYyYmJqMEwxY3FtbmNrTmFhaDBySUdjT1ZQV05oCkZ3Ymo1YlU1UEVLVmhTT0JwV3FteWpJU0dSTEdMbkRLcUlvV3F5WTR5VkF2Q1djdGM0c0RpWC9qTUNuUDNvUEoKTWhNRWt3ODN3UzNtaHVOMnhVSFRjUit4a0pwOWgrejZpU0NQOElLU0k2OHpFdTlScEpISGx5NWNpemt6bFU0aApNbC9Eb3Z4SmRqOGNIZGRlQm5YbzhSRmZrRUJoOGxmM2I1c0xUaHdjTkl4Q01GZGhESTMwZytrMGNhdTV2aWczCmlsVmQvQUErRU9rcGtMUGs3ZDBUNzNEWEZzUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 98aaf3b4-b164-40d5-80d7-6fb797a7d13c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3cdb256c-54c8-4e17-9818-aa8fc92b6d5d&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0b87d238-b6f8-4b37-aa51-57d66060a806
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1174"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 682b8f21-90dc-4c98-82fa-a60bedd59830
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1174"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a7c2778-028c-4c90-bbf1-e7f15d8b25dd
     status: 200 OK
     code: 200
     duration: ""
@@ -673,7 +805,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"bug"}'
@@ -685,7 +817,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6238bcfc-441d-4f03-b823-bc958e6ebcd7
+      - 3e435072-f011-43ca-813e-214dffaf9fcb
     status: 200 OK
     code: 200
     duration: ""
@@ -708,7 +840,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/databases
     method: POST
   response:
     body: '{"managed":true,"name":"bug","owner":"","size":0}'
@@ -720,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4dc1acb-e896-460c-adb5-8b69e903732c
+      - 020ebc91-9e3e-45b0-a5a6-fd6eec8885b1
     status: 200 OK
     code: 200
     duration: ""
@@ -741,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0929e832-71e5-4250-a269-07d1680348b1
+      - c4bcd31b-6b22-4eaa-864c-ce58b2a1f1b2
     status: 200 OK
     code: 200
     duration: ""
@@ -774,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98eee244-0cf2-40a3-b94c-c6d46da717f0
+      - cda4194f-83df-41da-a519-ab666748abd0
     status: 200 OK
     code: 200
     duration: ""
@@ -807,7 +939,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
@@ -819,7 +951,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b7178db-c57e-4a15-9dbd-3861b81559ea
+      - 31d46fe4-b4fa-4ae5-9e3d-2ebe0059dfd9
     status: 200 OK
     code: 200
     duration: ""
@@ -840,10 +972,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/databases?name=bug&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -852,7 +984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:34 GMT
+      - Mon, 18 Dec 2023 13:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c47029b-dbef-42da-8512-3c6563c27323
+      - b93466ce-d5bc-4ea1-ab6a-d0569ac7e591
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:35 GMT
+      - Mon, 18 Dec 2023 13:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc1cc1b8-29b6-48c6-855c-5ddcf55a9156
+      - df81b04a-afa1-4b61-8fae-1d716f57da37
     status: 200 OK
     code: 200
     duration: ""
@@ -908,7 +1040,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/privileges
     method: PUT
   response:
     body: '{"database_name":"bug","permission":"all","user_name":"bug"}'
@@ -920,7 +1052,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:35 GMT
+      - Mon, 18 Dec 2023 13:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -930,7 +1062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21e9ca2b-89d8-4160-ab41-5694fe0d30b2
+      - 813178e0-4a40-46e3-876f-14dd0791ab1c
     status: 200 OK
     code: 200
     duration: ""
@@ -941,19 +1073,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:35 GMT
+      - Mon, 18 Dec 2023 13:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -963,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 215103b0-a5f5-414a-9e02-0d8efb8dd9f2
+      - ceb3c8c6-630f-450e-a661-f81fa1ee3c6b
     status: 200 OK
     code: 200
     duration: ""
@@ -974,19 +1106,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:35 GMT
+      - Mon, 18 Dec 2023 13:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -996,7 +1128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 466ddf4c-e478-4512-adeb-6fd7ac6ebb55
+      - 1f64a94b-e2d2-43ac-9556-8e78df60379c
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,7 +1139,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
@@ -1019,7 +1151,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:36 GMT
+      - Mon, 18 Dec 2023 13:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1029,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89a75335-a67a-492b-b653-abf1090cd5ed
+      - b7e48da0-7537-4696-a8c3-7d09455494f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1040,7 +1172,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
     method: GET
   response:
     body: '{"privileges":[{"database_name":"bug","permission":"all","user_name":"bug"}],"total_count":1}'
@@ -1052,7 +1184,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:36 GMT
+      - Mon, 18 Dec 2023 13:05:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1062,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b1178e0-3a82-41a3-ab85-f89c2679017b
+      - fd9347f5-418f-4710-a8ce-7eceedadd554
     status: 200 OK
     code: 200
     duration: ""
@@ -1073,10 +1205,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/databases?name=bug&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1085,7 +1217,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:36 GMT
+      - Mon, 18 Dec 2023 13:05:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1095,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae93114b-f01f-4e72-9536-c4ba411a26ee
+      - 845f4a5b-7c29-4288-9db4-506e307776fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,19 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:36 GMT
+      - Mon, 18 Dec 2023 13:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62cfcdde-2965-4a62-950d-f993668e4bf1
+      - 4de17619-299c-44e4-9dba-2e6be75bdacd
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1BJRzR3Uy9JZ0s5RDhxalR3dVF3aWVkTzVrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE9ERTNXaGNOTXpNeE1qRTFNVE14T0RFM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1scDJYaXVpQUdUcEgvUGZvL01YTHFhK3FTc1RPckFzSmhvSW9vWENCNmg5RzdjdldyeGFLOXIKMU1oa2V3eEJzKzVRWmpaM1Z6TXdvV01DaHVYU2dnVmxibDVNd2trNWh1aDN2clYxRGhuY3I3WjlUSXFZOWVGbgp3b2VxaG9mZnpPei9jVGhlS2I5ZG9ITkI4NjdnUkQzeU5iTjFVaEx1UkgzYW9teHM2K0c5SldwUHY3bFJWRmNhCmtoWnY5TUZ1cGVRU2NUS3VDTk1zTXFQaDB4RWJIaHRIMS9VKzVDSGYvR0dtT0ZpcTBJbmhMSTc4OUJHRm04UlAKZ3M2N093elkwWVhzS1VvWCtKalhDUjQ5T0toSlYzVlI1UDl1VFJxRyttWk51c3V1WGcvRUdvRzdwNStUVktxawpOemdVZ1FtSDQ3dDRuMTBRWUhvc202akdZQTJXaG9zQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWhNRGd6WmpBM1l5MDJNV0UwTFRSa1lqTXRZV1UwWkMxbU9ETmsKTlRFMlpHTXdOR0l1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV0V3T0RObU1EZGpMVFl4WVRRdE5HUmlNeTFoWlRSa0xXWTRNMlExTVRaa1l6QTBZaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy8yM0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWmZtczYvN29SNExRSlNwQnBKS2pXOE5SUXBUTEhXU3ZSbGUxYndIdlRaT0toZkFjRVI3b1RpVmlDN1ZiVUVjVgpXWmhEUE5rME0yUTYySklVUldvVkNrbWg0TkpUZEFpcGgyZGJrR0RzNk5jNGdreVQ4UHpkUFBrdWwwQ1NmUlE3CnhBNjNVNGovSHRJQ0dJTFlXVEY0cHNiRW91cEd3MG0yUm5CU1lEVmVLZWtFSTF3U2Z3R3Q2VGNVUUhadjlGV2MKaEFSenRvNWZLcFFwR0plRmgxZnBQRWw3SHJkQXVLTUEyM0E2cFVVOFBkMGs4cExsWUFjbUxBN0Y0dGJwSlM5VwpsejJLYVIyNURoYkE0UkJ4c3QvbXNPUFZWRHVNUkkrd1lBbHRMc2ZWZ25rNDdOdVRRcFNHS1FzMnU3MElLckpHCk0reWdkNVQveTg2UjBjSTh0WVNzc3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVRGNOTTBOcEY3WGlEQm5zbkpRSWRmWFk1UkJjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1EUTFPRm9YRFRNek1USXhOVEV6TURRMU9Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXFGSTZnU0NyWHF4aDhDN2dEdFFHTVJab1pMMWp6anNsUlJKN1pxVmZCUC9xMHV0OHN2WUMKeSs5QWdtVU1BRlhyRU1jbnkwY0VjeStYeWxzR01rbHQyWmRCczhCakw3UWZsRXluQm9tL1F6MjBEOUw0U2x5TAp3Q1RHMXRjcm5uRkhFKzVtclg2RFE2aWxzS2RvWlhtTVVYMXZIVVVxc3FlTlJIV014eXAxeGhzMkNYMVZFOERyCndIK1FGWDhOUmtOV1crcnc3NDJZWHlFdVVXTkZYMWpZY1A2VDkxQWlFRnNTdUpwN2lQR05rSzB3ZHBwNWUrQlUKQnRoYXdXdDlmOFA1RGttRWtuN1N4cGtFelV6cVUveVd6amo0eHgvRVViK2toVGg3dmFjbGpyYnZXRGwvVXl6awpjZU9nYUpabzlJWU1ocG5HVlZhSXVjRFdJd2xlUkFTR0V3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTB6WTJSaU1qVTJZeTAxTkdNNExUUmxNVGN0T1RneE9DMWgKWVRobVl6a3lZalprTldRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwelkyUmlNalUyWXkwMU5HTTRMVFJsTVRjdE9UZ3hPQzFoWVRobVl6a3lZalprTldRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc29SNkhCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFHTjdWTEcwZnpFUFFuWldzdUFhejlJQTUwM1V0U04wMGRCMDJtRDFYVmhmUllPckFVeUljMEwvU2ZNcApNOHBPbk9zL29xaVk2Vzd0RzQrQStURFpWa3hMZ3RHWUJ0YjYyYmJqMEwxY3FtbmNrTmFhaDBySUdjT1ZQV05oCkZ3Ymo1YlU1UEVLVmhTT0JwV3FteWpJU0dSTEdMbkRLcUlvV3F5WTR5VkF2Q1djdGM0c0RpWC9qTUNuUDNvUEoKTWhNRWt3ODN3UzNtaHVOMnhVSFRjUit4a0pwOWgrejZpU0NQOElLU0k2OHpFdTlScEpISGx5NWNpemt6bFU0aApNbC9Eb3Z4SmRqOGNIZGRlQm5YbzhSRmZrRUJoOGxmM2I1c0xUaHdjTkl4Q01GZGhESTMwZytrMGNhdTV2aWczCmlsVmQvQUErRU9rcGtMUGs3ZDBUNzNEWEZzUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2007"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:37 GMT
+      - Mon, 18 Dec 2023 13:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aba7d733-c6a1-460d-9182-53fbaf959682
+      - 82e5c2a4-fa75-45c3-81e6-ee02c05ba427
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3cdb256c-54c8-4e17-9818-aa8fc92b6d5d&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1172"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:37 GMT
+      - Mon, 18 Dec 2023 13:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2a6edc1-c50b-41d0-aa2f-a21fa46e4627
+      - aadbcbc8-d5c5-4065-b7d4-03aaa387fb2b
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,10 +1337,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/databases?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1174"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd5c016c-c37f-4bf8-a9bc-47b2ca94a8e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/databases?name=bug&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"bug","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1217,7 +1382,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:37 GMT
+      - Mon, 18 Dec 2023 13:05:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72030f04-951c-41ef-a6c2-a47366b2ecb4
+      - 701d800d-d66f-45eb-88c4-289e1a372a68
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,7 +1403,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
@@ -1250,7 +1415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:37 GMT
+      - Mon, 18 Dec 2023 13:05:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1260,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e38dcdcc-28d9-49e9-b6f2-abaac3e83e9b
+      - 7593f0c7-4314-40a8-b7e2-5b6a9f167b7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,19 +1436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:37 GMT
+      - Mon, 18 Dec 2023 13:05:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1293,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e733c2e-f2e4-44f9-9f2a-0292c69afc22
+      - e713255a-a5f0-49c3-8fa5-b4c5e7b98c76
     status: 200 OK
     code: 200
     duration: ""
@@ -1304,7 +1469,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
@@ -1316,7 +1481,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:37 GMT
+      - Mon, 18 Dec 2023 13:05:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a555c68-ec0b-4dde-aef8-b09b267a6cfb
+      - 94d3cf1f-55c7-4204-9a8d-d3448b52594c
     status: 200 OK
     code: 200
     duration: ""
@@ -1337,7 +1502,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/privileges?database_name=bug&order_by=user_name_asc&user_name=bug
     method: GET
   response:
     body: '{"privileges":[{"database_name":"bug","permission":"all","user_name":"bug"}],"total_count":1}'
@@ -1349,7 +1514,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:37 GMT
+      - Mon, 18 Dec 2023 13:05:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 336f9d62-65ec-4917-a485-e7d0b7c9e7ba
+      - 32ea4883-91ff-4927-b3cf-a995c85565de
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,19 +1535,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:38 GMT
+      - Mon, 18 Dec 2023 13:05:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 698b568a-3c8a-4617-9d2d-06383d67006c
+      - 5a7b0109-7fe6-44ae-8f41-df8a2a65439b
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,40 +1568,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/users?name=bug&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 116f058c-7f5c-4a1f-a88e-19c096180871
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/users?name=bug&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/users?name=bug&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
@@ -1448,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:38 GMT
+      - Mon, 18 Dec 2023 13:05:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1458,7 +1590,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f1c2e66-ab42-459e-b431-1fb67215a635
+      - 7c95c8cb-fa55-4ea7-9a35-4cb8f94b271c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/users?name=bug&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bug"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b1452ca8-409c-4762-9118-2fc848dbe028
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,7 +1636,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/privileges
     method: PUT
   response:
     body: '{"database_name":"bug","permission":"none","user_name":"bug"}'
@@ -1483,7 +1648,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:39 GMT
+      - Mon, 18 Dec 2023 13:05:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f868e7f6-2d65-4364-9b26-a7df43eec8a9
+      - 5cea912b-4f43-43d6-9503-09f0d42c2e0e
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:39 GMT
+      - Mon, 18 Dec 2023 13:05:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93aaf8d9-4a44-4879-b8aa-cb3c6e1ac7a8
+      - 0e5ec2df-869e-4a67-8eb8-8af0ed49eb14
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,19 +1702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:39 GMT
+      - Mon, 18 Dec 2023 13:05:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f44d07a-130a-4868-8eaa-4b0a66166e8e
+      - 175bf110-e52b-4cd7-8a19-2abc2fde9571
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:39 GMT
+      - Mon, 18 Dec 2023 13:05:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4ba1d7a-d9e6-48e8-b5d1-acbe22a4fe8f
+      - 2864579f-cd23-4b9b-ac77-038869ffe7b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,7 +1768,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/users/bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/users/bug
     method: DELETE
   response:
     body: ""
@@ -1613,7 +1778,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:39 GMT
+      - Mon, 18 Dec 2023 13:05:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85f52ab7-92ce-46be-9477-ebfa8013011b
+      - d3b844f7-309e-420d-8e8a-2d4cb4c30d77
     status: 204 No Content
     code: 204
     duration: ""
@@ -1634,7 +1799,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b/databases/bug
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d/databases/bug
     method: DELETE
   response:
     body: ""
@@ -1644,7 +1809,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:39 GMT
+      - Mon, 18 Dec 2023 13:05:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25bb7f0c-0c98-4ab2-b7f2-40d2933a5999
+      - 6e00bd95-e90d-4624-a293-b6e175416108
     status: 204 No Content
     code: 204
     duration: ""
@@ -1665,19 +1830,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:39 GMT
+      - Mon, 18 Dec 2023 13:05:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4495b705-c225-42ae-b191-15b63bb16c50
+      - fcca7690-71ae-4d8a-933d-43afa606ef7e
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,19 +1863,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:40 GMT
+      - Mon, 18 Dec 2023 13:05:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8568ea2f-e5e3-482d-88a9-5ed5902fdad6
+      - b256430b-f52b-4ed6-8dde-82d20d35e5b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,19 +1896,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1175"
+      - "1177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:40 GMT
+      - Mon, 18 Dec 2023 13:05:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1918,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f07f5bb7-3586-42a3-9d6c-0e742b0b9b3e
+      - 0e50bcf6-c212-4ac8-bf38-8863b77571e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,19 +1929,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:16:02.695658Z","endpoint":{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527},"endpoints":[{"id":"0d8956ae-38d8-4294-b2ea-10496073be15","ip":"51.159.74.238","load_balancer":{},"name":null,"port":13527}],"engine":"PostgreSQL-15","id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:42.531086Z","endpoint":{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564},"endpoints":[{"id":"1b7c38d2-0838-4e66-825f-4eeb7e785879","ip":"195.154.68.173","load_balancer":{},"name":null,"port":15564}],"engine":"PostgreSQL-15","id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"bug","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["bug"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1175"
+      - "1177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:40 GMT
+      - Mon, 18 Dec 2023 13:05:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 766c1a37-5287-46ed-bfc8-5dfb02ad49e3
+      - 0fe36779-60bd-49a7-a7cf-63e0df5092c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,10 +1962,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1809,7 +1974,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:11 GMT
+      - Mon, 18 Dec 2023 13:06:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e0c23c0-eaad-4a96-be50-bcacec8dfd2b
+      - b7fe1cad-78e6-4822-b444-2f7f6375734f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1830,10 +1995,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a083f07c-61a4-4db3-ae4d-f83d516dc04b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3cdb256c-54c8-4e17-9818-aa8fc92b6d5d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a083f07c-61a4-4db3-ae4d-f83d516dc04b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"3cdb256c-54c8-4e17-9818-aa8fc92b6d5d","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1842,7 +2007,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:11 GMT
+      - Mon, 18 Dec 2023 13:06:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +2017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ea60e98-d063-4571-9edd-b4038dc2566e
+      - 7f0556da-0bb5-4c98-a9b6-28108001e837
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-backup-schedule.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-backup-schedule.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:54 GMT
+      - Mon, 18 Dec 2023 12:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7a78ef3-30d3-4ccc-9fa4-ef945b2bec40
+      - df3796b2-889b-441b-b9d7-d610f5a58734
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-instance-backup-schedule","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:12:39.476790Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:11:38.299833Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:39 GMT
+      - Mon, 18 Dec 2023 13:11:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7809c0d-a69f-453c-9630-cbae2e1f2503
+      - 0c59bd23-505a-47ef-950f-59cd85126512
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:12:39.476790Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:11:38.299833Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:39 GMT
+      - Mon, 18 Dec 2023 13:11:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3361f8b-5ec8-4f6d-80c7-93394c7aee18
+      - 89d79aae-0bfa-4d36-af3f-cfab1a216327
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:12:39.476790Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:11:38.299833Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:10 GMT
+      - Mon, 18 Dec 2023 13:12:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5246926d-98b6-4521-b4eb-de08a06b9d42
+      - 7e88e3fb-79e4-4047-93fd-b157782206e9
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:12:39.476790Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:11:38.299833Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:40 GMT
+      - Mon, 18 Dec 2023 13:12:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47ad2b06-7861-451f-b9a3-d56305adf554
+      - 413e51d0-b962-4259-82c5-35679ad9ffd7
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:12:39.476790Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:11:38.299833Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:10 GMT
+      - Mon, 18 Dec 2023 13:13:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1820fef0-ca5e-4fb5-bcdf-cc42d2ee7763
+      - db808ecd-bdc8-4a96-b6b8-c5c8363a49a6
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:12:39.476790Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:11:38.299833Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "773"
+      - "964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:40 GMT
+      - Mon, 18 Dec 2023 13:13:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7233fb83-b3be-4ddd-9b2d-b21c422de222
+      - 18c8d1ac-9129-4e9e-92e8-0e62655d0b18
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:12:39.476790Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:11:38.299833Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1037"
+      - "964"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:10 GMT
+      - Mon, 18 Dec 2023 13:14:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 207bc107-151a-4d2a-887d-c86ba32b0fb4
+      - 31b330d5-2d69-48e9-acb8-3f04219b83e9
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:12:39.476790Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805},"endpoints":[{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805}],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:11:38.299833Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1269"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:41 GMT
+      - Mon, 18 Dec 2023 13:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ec420dd-07cc-4d65-a449-46330c159b46
+      - 98f7b0f6-7662-412c-ae14-79c87c6a4801
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: PATCH
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:15:41.255486Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805},"endpoints":[{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805}],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:14:41.433982Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:41 GMT
+      - Mon, 18 Dec 2023 13:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6510922-f2b6-4bb4-b6aa-b6badcdecfd2
+      - d755702b-ca65-4209-bce4-4debc0b4955e
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:15:41.255486Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805},"endpoints":[{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805}],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:14:41.433982Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:41 GMT
+      - Mon, 18 Dec 2023 13:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b342296-20e4-4479-8b62-81fad883462b
+      - 15acfe19-f213-48ff-9c19-f780c61d9e28
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSlB5MXNhd3hVZXRzRWNVZ1dXeDRrSWZSNkV3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1UQTFNQjRYCkRUSXpNVEV5TVRFMk1UVXdNRm9YRFRNek1URXhPREUyTVRVd01Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TVRBMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTFBUEFQenY4QzQ4SDdoU1Yvd2orN1h0eEhBTlduc01taGtySVNLTHVCZytvU2hqWEtFdHAKOGdCWHJhV0dpNXZUUyt2Z2c5V05zeTdSVTh3OUZMa091d0RoYkp1VjM1ZFJzWis0WEwwelZENTl5dTZmWXUwMQpTaXBUemIvSC80dzV0bllaYlozUU9nWjVXVHdVV21IRWlwclNod013MVJDb1BCSVk4WHNDbE9RVlhhNXNCb0twCk11bG9VVEdFYkVyYjBLZEpqcHc2QVRyVDBOYnFMc2RCS2YrdStTaDBDVEFka3RNUkFpVXZTZEc5c1JvZllGSmoKaldBbXFJWFlxbGt2V1ZtZGZkTHo2U1d6UlR3c1VjK0RiaGlRdTJFclF1ZE5NbExpd1QrT0k4bEF2NklVcGF4VgpYZG9aSDBSREdHV05HalUvWlRGSW1RZVRSSyszdmMzRmt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqRXdOWUk4Y25jdE1UZGlNekkyWlRNdFpXUmlaQzAwTVdRMkxUZzBZemt0Tm1FMk5UaG0KTVRrMFpETmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQyRUNod1F6bm9KcE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNqakE5c0lkVEsxZlVvM2pmRmVUOEdoSDJ6d0pwTDZsaTFVS2F1d0Z6amhlS0xqdnFKCnpFMVozdEE3TTBjbG5zSk1KcTlUbHFadkY3clpJK3IzbUZDeEpkRDY4eHAvbGhwMDQzLzNqelBjcDd0VnZ2TzIKZi9tcWk4Yk5VTkpOQUc2bjJ0aVFJWHhIQ3c1QUhvM0ZrekdUR2lEYXUvUDh1Z0VQVHBjTFZtKytCSGI0b29oWQplbThrUS93RFQzdUhZQ2dxS2JGU0gyMVcvdXUzTnhsVmt6eEpvTmZDSkw5eVBRQ29zVUFkOXpDMjZwSmJwVGZ6ClkxQ1ZGT2ZsMnkxbTV6Wm5kVHgxa0oyUWhKS09sNnJRMFd2eHBYUFRFSFE5VGNtc2VyVEsvOStaQit4bFl2VEEKMXRuSkNySzhVZ0JhcVU1NkF1VXVNdXExOEdiV2htZ1U3MTB5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVU2wxcnV1aVNkOHBETDdkMnJsZEVuc1ExcE9Nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzR4TWpndU5UQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU1USTRMalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ4SkxsTGt5bk0yVFQ4SVpqZFdTMHE0L3piQkpNT1QxcDlBU0JWTFJrbGlFL3NTYXJUelN5MFRpRFIKWk54Mzhxb0Rwekt2bWc2SFl4WHozNkRUdjhMS05ldjNEalFTZENQbmJSVythYmUwc2J5MDRod0lMdFhMOWJCMQpmRXRhREtPaGZXTDlqRGRReWt3TnR0Mlh4MVV6eHk2enB0eHJWSm1Nd0QrdFJkWjRReWowWHc0RzRibVBGZzZ1Cm1rdTNCQWJyN2I2d0RPRzQ3R09kU0o2ek5GanpnZ0RoUUVHRVE1UEJZK01INThCWnpnZFhkMzJNaHVWbnZ1eTQKUWpoMnp2TlVEcmwvTitsekV4ZzVhdXpvdjRmd1c3U0VNSnRPN0lvVHc4QzJFQU8rSEtsNlJvV1FiL0IrcHJBTQp1K2RuMmlLR3pvUDZhTUFnOEJpRlEwek1FT0lsQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpFeU9DNDFnanh5ZHkxbVl6SmhOall3TUMwd01HRmxMVFJpWVRJdE9EQTJaaTAzTjJKbVpXWmkKTkdZeU1qTXVjbVJpTG01c0xXRnRjeTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzR4TWpndU5ZSThjbmN0Wm1NeQpZVFkyTURBdE1EQmhaUzAwWW1FeUxUZ3dObVl0TnpkaVptVm1ZalJtTWpJekxuSmtZaTV1YkMxaGJYTXVjMk4zCkxtTnNiM1ZraHdRekQxMGlod1F6bm9BRmh3UXpub0FGTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBZGxVU2MKS2dRcE5UelpiQ0IwS2R0ejZRVlQvYjhGWEI1amhEZUZVc1dpUTdUaHpsQUk5R29GOWxHRUw4a3ArbXlxaG9MMwpla0NYeGZuWVdFb1FzcGZGdVk3UjQvQTA1TTVvVU5wdEROakw0VTdrYllraUF1NlYweVU5c21pbWtZalF2Ly95CkZSWnROQXdlRXlKMTAycXlrSVZaVFY5YnlGZFJSUTlMM2dIblYwUjdCaGMzNmZXbGFLbS9YRTBCSHNYQXBzelEKbDRkR3d5TmxkMmFZR2dJUE8yd2xlMHV6M1k3K3dvR01LUWpQMWlIclpSdkVPdG0yY1NxMHRFYU11aDY0T0NsNwpkSlhyRndSSXgrNGRwL1B5L0s2ODFTWCtqdGVxdzZBTmtMa2FKVG5VMDVXc3RnOW9QVlJIZFN6K1dqamhra3dXCitMcGo1ZDJUVmt4NHVseTgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:41 GMT
+      - Mon, 18 Dec 2023 13:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 056b394e-8b6b-457a-b00a-caa5beed1fbf
+      - 937ab4ce-9b1b-4315-93c0-c831cb67facb
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fc2a6600-00ae-4ba2-806f-77bfefb4f223&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:15:41.255486Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805},"endpoints":[{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805}],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1247"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:41 GMT
+      - Mon, 18 Dec 2023 13:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2419b65-5615-4875-8f06-e72b4bb796b3
+      - 8d64adf3-668c-4666-99fa-4966c43b3300
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:15:41.255486Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805},"endpoints":[{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805}],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:14:41.433982Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:42 GMT
+      - Mon, 18 Dec 2023 13:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6b9f026-f33e-48c3-b30e-ecbed09d04f5
+      - 4da3ea0f-159d-4660-a659-e0a2213565df
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVSlB5MXNhd3hVZXRzRWNVZ1dXeDRrSWZSNkV3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1UQTFNQjRYCkRUSXpNVEV5TVRFMk1UVXdNRm9YRFRNek1URXhPREUyTVRVd01Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TVRBMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTFBUEFQenY4QzQ4SDdoU1Yvd2orN1h0eEhBTlduc01taGtySVNLTHVCZytvU2hqWEtFdHAKOGdCWHJhV0dpNXZUUyt2Z2c5V05zeTdSVTh3OUZMa091d0RoYkp1VjM1ZFJzWis0WEwwelZENTl5dTZmWXUwMQpTaXBUemIvSC80dzV0bllaYlozUU9nWjVXVHdVV21IRWlwclNod013MVJDb1BCSVk4WHNDbE9RVlhhNXNCb0twCk11bG9VVEdFYkVyYjBLZEpqcHc2QVRyVDBOYnFMc2RCS2YrdStTaDBDVEFka3RNUkFpVXZTZEc5c1JvZllGSmoKaldBbXFJWFlxbGt2V1ZtZGZkTHo2U1d6UlR3c1VjK0RiaGlRdTJFclF1ZE5NbExpd1QrT0k4bEF2NklVcGF4VgpYZG9aSDBSREdHV05HalUvWlRGSW1RZVRSSyszdmMzRmt3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqRXdOWUk4Y25jdE1UZGlNekkyWlRNdFpXUmlaQzAwTVdRMkxUZzBZemt0Tm1FMk5UaG0KTVRrMFpETmlMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQyRUNod1F6bm9KcE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUNqakE5c0lkVEsxZlVvM2pmRmVUOEdoSDJ6d0pwTDZsaTFVS2F1d0Z6amhlS0xqdnFKCnpFMVozdEE3TTBjbG5zSk1KcTlUbHFadkY3clpJK3IzbUZDeEpkRDY4eHAvbGhwMDQzLzNqelBjcDd0VnZ2TzIKZi9tcWk4Yk5VTkpOQUc2bjJ0aVFJWHhIQ3c1QUhvM0ZrekdUR2lEYXUvUDh1Z0VQVHBjTFZtKytCSGI0b29oWQplbThrUS93RFQzdUhZQ2dxS2JGU0gyMVcvdXUzTnhsVmt6eEpvTmZDSkw5eVBRQ29zVUFkOXpDMjZwSmJwVGZ6ClkxQ1ZGT2ZsMnkxbTV6Wm5kVHgxa0oyUWhKS09sNnJRMFd2eHBYUFRFSFE5VGNtc2VyVEsvOStaQit4bFl2VEEKMXRuSkNySzhVZ0JhcVU1NkF1VXVNdXExOEdiV2htZ1U3MTB5Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:14:41.433982Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1847"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:42 GMT
+      - Mon, 18 Dec 2023 13:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7e78f20-d819-403d-a71f-74984b240f4a
+      - 180d36b9-905e-47e5-b9e0-c511f3297c05
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223/certificate
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:15:41.255486Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805},"endpoints":[{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805}],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVU2wxcnV1aVNkOHBETDdkMnJsZEVuc1ExcE9Nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPQzR4TWpndU5UQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRndU1USTRMalV3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUQ4SkxsTGt5bk0yVFQ4SVpqZFdTMHE0L3piQkpNT1QxcDlBU0JWTFJrbGlFL3NTYXJUelN5MFRpRFIKWk54Mzhxb0Rwekt2bWc2SFl4WHozNkRUdjhMS05ldjNEalFTZENQbmJSVythYmUwc2J5MDRod0lMdFhMOWJCMQpmRXRhREtPaGZXTDlqRGRReWt3TnR0Mlh4MVV6eHk2enB0eHJWSm1Nd0QrdFJkWjRReWowWHc0RzRibVBGZzZ1Cm1rdTNCQWJyN2I2d0RPRzQ3R09kU0o2ek5GanpnZ0RoUUVHRVE1UEJZK01INThCWnpnZFhkMzJNaHVWbnZ1eTQKUWpoMnp2TlVEcmwvTitsekV4ZzVhdXpvdjRmd1c3U0VNSnRPN0lvVHc4QzJFQU8rSEtsNlJvV1FiL0IrcHJBTQp1K2RuMmlLR3pvUDZhTUFnOEJpRlEwek1FT0lsQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU0TGpFeU9DNDFnanh5ZHkxbVl6SmhOall3TUMwd01HRmxMVFJpWVRJdE9EQTJaaTAzTjJKbVpXWmkKTkdZeU1qTXVjbVJpTG01c0xXRnRjeTV6WTNjdVkyeHZkV1NDRERVeExqRTFPQzR4TWpndU5ZSThjbmN0Wm1NeQpZVFkyTURBdE1EQmhaUzAwWW1FeUxUZ3dObVl0TnpkaVptVm1ZalJtTWpJekxuSmtZaTV1YkMxaGJYTXVjMk4zCkxtTnNiM1ZraHdRekQxMGlod1F6bm9BRmh3UXpub0FGTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBZGxVU2MKS2dRcE5UelpiQ0IwS2R0ejZRVlQvYjhGWEI1amhEZUZVc1dpUTdUaHpsQUk5R29GOWxHRUw4a3ArbXlxaG9MMwpla0NYeGZuWVdFb1FzcGZGdVk3UjQvQTA1TTVvVU5wdEROakw0VTdrYllraUF1NlYweVU5c21pbWtZalF2Ly95CkZSWnROQXdlRXlKMTAycXlrSVZaVFY5YnlGZFJSUTlMM2dIblYwUjdCaGMzNmZXbGFLbS9YRTBCSHNYQXBzelEKbDRkR3d5TmxkMmFZR2dJUE8yd2xlMHV6M1k3K3dvR01LUWpQMWlIclpSdkVPdG0yY1NxMHRFYU11aDY0T0NsNwpkSlhyRndSSXgrNGRwL1B5L0s2ODFTWCtqdGVxdzZBTmtMa2FKVG5VMDVXc3RnOW9QVlJIZFN6K1dqamhra3dXCitMcGo1ZDJUVmt4NHVseTgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1247"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:42 GMT
+      - Mon, 18 Dec 2023 13:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19cbe9a9-b8a1-4575-b596-ce47042b1d15
+      - 480c7c7d-0cf8-4d1e-99d6-f5bcb34bc49c
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=fc2a6600-00ae-4ba2-806f-77bfefb4f223&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc3db9c7-34b3-41eb-b144-2f66075e05c2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
+    method: GET
+  response:
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:14:41.433982Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a248eaf-2105-4ff3-9b2f-74c27e44dd95
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: DELETE
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:15:41.255486Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805},"endpoints":[{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805}],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:14:41.433982Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:43 GMT
+      - Mon, 18 Dec 2023 13:14:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2c824a6-7493-4c0a-9f5d-4b348476c07f
+      - 4210c4d5-9544-436f-854c-84d1b252a42d
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:15:41.255486Z","retention":7},"created_at":"2023-11-21T16:12:39.476790Z","endpoint":{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805},"endpoints":[{"id":"5232e1f3-c5d0-4edc-bc2b-f8c17bb0c487","ip":"51.158.130.105","load_balancer":{},"name":null,"port":19805}],"engine":"PostgreSQL-15","id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":true,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:14:41.433982Z","retention":7},"created_at":"2023-12-18T13:11:38.299833Z","endpoint":{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784},"endpoints":[{"id":"1a43b97a-67cf-478e-8b9c-7ef20ab78522","ip":"51.158.128.5","load_balancer":{},"name":null,"port":14784}],"engine":"PostgreSQL-15","id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-backup-schedule","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:43 GMT
+      - Mon, 18 Dec 2023 13:14:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f8a9385-38c5-4659-912c-839f12a16e1b
+      - 333b7474-1644-4d12-a21f-c5e0ece0fc8f
     status: 200 OK
     code: 200
     duration: ""
@@ -904,10 +970,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -916,7 +982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:13 GMT
+      - Mon, 18 Dec 2023 13:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0f8db8d-68d7-4cae-a94c-77264baf814b
+      - bff40224-427c-4a74-8c07-e76a94dfd132
     status: 404 Not Found
     code: 404
     duration: ""
@@ -937,10 +1003,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/17b326e3-edbd-41d6-84c9-6a658f194d3b
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/fc2a6600-00ae-4ba2-806f-77bfefb4f223
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"17b326e3-edbd-41d6-84c9-6a658f194d3b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"fc2a6600-00ae-4ba2-806f-77bfefb4f223","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -949,7 +1015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:13 GMT
+      - Mon, 18 Dec 2023 13:15:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4b38a33-d79c-45cf-8221-d7317e85fe74
+      - 7bd2f1aa-5d07-4a58-91a0-d6dfb0160043
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:52 GMT
+      - Mon, 18 Dec 2023 12:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 457f1a80-0ebd-4c18-bcd3-d873a4c78818
+      - 2883a736-193b-4707-bc74-1308dff04a88
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:17 GMT
+      - Mon, 18 Dec 2023 13:01:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6df0e93-4066-4484-9e12-432a49a7f51e
+      - 43aeb117-d032-488b-a5aa-ae755061e797
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:17 GMT
+      - Mon, 18 Dec 2023 13:01:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83b86c74-5b37-4398-86ca-35d7ed3e0c5a
+      - aa10e511-edfa-49f9-893b-67ce6404a03f
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:55 GMT
+      - Mon, 18 Dec 2023 13:01:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5df7d094-e4d8-4418-ac4e-17ff69f8753b
+      - fe613ab3-16cf-4bbe-a76f-feb8da90afc8
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:25 GMT
+      - Mon, 18 Dec 2023 13:02:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f81c46b-9fe9-4634-bdbc-31f46d812b18
+      - 68baaf00-b759-4af4-ad8a-c5304b7aa82c
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:57 GMT
+      - Mon, 18 Dec 2023 13:02:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c989d3b-0b91-4c74-8f02-9ae90be83513
+      - 8c5f0a47-0fe3-4c25-8d40-5ce538aaf61a
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "754"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:27 GMT
+      - Mon, 18 Dec 2023 13:03:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47bace3e-5ad8-4ed1-a259-56902718a525
+      - fe1fd1d6-2653-46ee-96fe-37c01db10197
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1018"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:58 GMT
+      - Mon, 18 Dec 2023 13:03:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d359f90-95d3-41fb-b6fe-72db1eb4231b
+      - 4dd06d31-0a64-4a5a-8267-1dc94885bac9
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1225"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:28 GMT
+      - Mon, 18 Dec 2023 13:04:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7defce00-7df7-4703-ac39-899868f9eb3c
+      - 3f5ebf0c-82c2-4b80-b530-7079cccd5275
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVZVNGdDZCdzcvT0MwVEpJSHU1aFNaZlpZdHc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBMk5UZGFGdzB6TXpFeE1UZ3hOakEyTlRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNscVZWRDdONmlPQld0MFR2Y0VQWmtDdTlCbmR6YTZDK3NpMnB0UkphRXl6WWVWeHdBcmd3YVNDZGcKRnpFQ01xMmdQeVBWVHhiZTlYZG1QZ1Z5NTJCdFJrbW44anRJbzFETjZoUHZsNUx3M3d6VWNlcjZWaTBEM0ZvWApLZmoreVkzTkQzbHp1RS9BQmUxS0wrTkNOSWZYUkV3d2lNNEpPb3V0aFRzNlI1Skk3ZkRwY2tvb0UrWHF4aSszCjJQU0hTR21lc1BRTzFzQ25qeFhzZk9jdmNxTFM3aU1sWFNpV1BwMHgvQnplNkNJZWorNURjbEpDcGVBdkFuMSsKb1FpUC9rOEN4Mmg4QTRXT2hObXcvUG5RRzBrNHVPQWVlOUxqYk1HdlZ4K2lMK3MrVlNFSHZieHBLZHU0OUpkRgo3R0xGSk1lZEVvQi8vL2JQUXRzYkdlNndLR0F0QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RZemsxTmpabU5UWXROMlZrTVMwME9HVmlMV0U1WTJFdE5URTJaakF4TXpJelltWmsKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVJhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBQXByRDdWNVJBRHppc3ZzQnJBN05CR2R0Rlg3TTlHcWcwSHRsWUZxWkRtZnEzNFp2RGFXQWxVODBHClprTFlPYWNlRGJIUzJjOTdBU2RGTlBwYzhWTERzbHd5dEZicFVTZGFhaFArTm5zU0hmQUJpSi9tMlB4UjVySC8KRGdqRkdmNjJQcGt5SURrWGdYb2pnYWtEM0RmNDhJQlBscWswS0ZXRlNtS2JaQXVpbUp6aFoyL04xeGxIRjBwcgpaY3RaalJmbklzdjFsZ29mTTlackhNeVNNYVY3WVdjVzFlZjRrOEZXTzNGTlJKOFpaaUpHZ0E1cWFXZ25ZaXZGCklNdGtla0JwZm8xb1pydktwcHNnNDVmZjRpWENRcUhXeTdwRHllelNTaVRUZmhYMmdTTTZZMnlPaGFjN2JlWUYKcS9Md1RXVzBVYWo5TEJqM3Y1VEdsZkZ1WnJJTQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:28 GMT
+      - Mon, 18 Dec 2023 13:04:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3dc9710-8c88-48f0-9c9b-941c7cb931f0
+      - 74840ad2-b1f0-447c-a3ee-a502189f97b0
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1225"
+      - "920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:29 GMT
+      - Mon, 18 Dec 2023 13:05:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db5211b7-d294-4a00-875f-9acd2471176c
+      - cc2806d2-eba8-4730-8630-b9ed5e0146c3
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1225"
+      - "1184"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:29 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8cd5d80-e6e7-4be6-b410-1a13d656f8c1
+      - fcbb7270-331b-4faf-81ef-faa20915f596
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVZVNGdDZCdzcvT0MwVEpJSHU1aFNaZlpZdHc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBMk5UZGFGdzB6TXpFeE1UZ3hOakEyTlRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNscVZWRDdONmlPQld0MFR2Y0VQWmtDdTlCbmR6YTZDK3NpMnB0UkphRXl6WWVWeHdBcmd3YVNDZGcKRnpFQ01xMmdQeVBWVHhiZTlYZG1QZ1Z5NTJCdFJrbW44anRJbzFETjZoUHZsNUx3M3d6VWNlcjZWaTBEM0ZvWApLZmoreVkzTkQzbHp1RS9BQmUxS0wrTkNOSWZYUkV3d2lNNEpPb3V0aFRzNlI1Skk3ZkRwY2tvb0UrWHF4aSszCjJQU0hTR21lc1BRTzFzQ25qeFhzZk9jdmNxTFM3aU1sWFNpV1BwMHgvQnplNkNJZWorNURjbEpDcGVBdkFuMSsKb1FpUC9rOEN4Mmg4QTRXT2hObXcvUG5RRzBrNHVPQWVlOUxqYk1HdlZ4K2lMK3MrVlNFSHZieHBLZHU0OUpkRgo3R0xGSk1lZEVvQi8vL2JQUXRzYkdlNndLR0F0QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RZemsxTmpabU5UWXROMlZrTVMwME9HVmlMV0U1WTJFdE5URTJaakF4TXpJelltWmsKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVJhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBQXByRDdWNVJBRHppc3ZzQnJBN05CR2R0Rlg3TTlHcWcwSHRsWUZxWkRtZnEzNFp2RGFXQWxVODBHClprTFlPYWNlRGJIUzJjOTdBU2RGTlBwYzhWTERzbHd5dEZicFVTZGFhaFArTm5zU0hmQUJpSi9tMlB4UjVySC8KRGdqRkdmNjJQcGt5SURrWGdYb2pnYWtEM0RmNDhJQlBscWswS0ZXRlNtS2JaQXVpbUp6aFoyL04xeGxIRjBwcgpaY3RaalJmbklzdjFsZ29mTTlackhNeVNNYVY3WVdjVzFlZjRrOEZXTzNGTlJKOFpaaUpHZ0E1cWFXZ25ZaXZGCklNdGtla0JwZm8xb1pydktwcHNnNDVmZjRpWENRcUhXeTdwRHllelNTaVRUZmhYMmdTTTZZMnlPaGFjN2JlWUYKcS9Md1RXVzBVYWo5TEJqM3Y1VEdsZkZ1WnJJTQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:29 GMT
+      - Mon, 18 Dec 2023 13:06:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e485c59b-a045-4d9b-87bf-2ff8a94d7999
+      - 7a9a6dff-eb2b-41cd-88b4-e9ac932026f2
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZmYyNzdJeldFc280em9oYW9kb3UxUTc1ZDJBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QTFOREJhRncwek16RXlNVFV4TXpBMU5EQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2ppLzFRMHZPMXIwVEw3Kzk2VVJ5NFZxMGZiYWlweDRQRUM3ck9iem1OZHQ0RE1sZUYKOTRvUVV5Z3pQRW42aDJkbGt3QTZrWVdPMGo3aWI0dE9GVGo2ek1KaCs1bktubTNZd1lyUkwwbWkrKzF4QTVpcgpjSmFpYjA4UitGRzFTZnZ3dHdwY05hQS9MREZoZlNTYXRCOXR0SW9FcUpMNTdNUlIvVDFqYS83R0FSRFRQK25ECkxZZ2U4ejhPdzhNMTRJWS9ObkNrZVRCWFhCeVNvVWZyU3ZzWmFYUGY4eGRkZVFpeHBnem1UZW9rcnIxdmxFdmQKTi8xRzkvMFBWVkVybXdNcE5oYTg5aXZHbjhuZWR2Z0EvMUlsenQvczJWZTRIYnhFQUZQUE84QzkyditnaVdiUgp3RXBvNTFtcUVWbisrVmhNcDgxYWNTWDBUaW9BV1RlOVp5eG5BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkweFpEWTVPRGxtWkMwMk56TTFMVFE1T0RBdE9UUTUKTmkwME5qVTFNbUUwTWpjMk1HVXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNV1EyT1RnNVptUXROamN6TlMwME9UZ3dMVGswT1RZdE5EWTFOVEpoTkRJM05qQmxMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOFJYaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNiSGNzcWh6a3BLMnc3QU5Td1lKa2J2Q3RtbDYzTjNPemRndEJvMEVXTTNuNFZYeTdueFptMApDVkt1d1ZmNHpLZEMyd3JQL0h4TFlRZG5MK2tWTWxjZ3lFdEtmcnZIOXBia01VNDZidk9uVnRVZm9sZ3g4VXdOCklhb3FqckM4SUdyMzY2V3BlYWV3VElNcENDaGlCL1RlSlI2dlFPZVJzaEFyQm5SOGgrYjNaam14N0dwU1ZLTUQKSk9tbjhWWHhrR29TRjRUeFlJUTRYeGxDeUl1QTl2TG5tSTlDWThVaUJJMEo3S0dtS2FQVUxlWHg4TzE0a2xVaQpHYXJNeDRPRjJQYS9HT3RFT0o4RDdZRmR5TU5NN0ZhMGYzUDR3WFZrb2svK0FBSHhES3VyTVNyTmJGNTRGaDVGCkhjMGZtQlhtTlQ4NUMzbnc0REpFaDNCQnRESTM4cXM1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1225"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:30 GMT
+      - Mon, 18 Dec 2023 13:06:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcedf680-50b3-4743-9acc-5f6f3db203ed
+      - 4a1d7583-42b0-4a6c-afed-404802510694
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1d6989fd-6735-4980-9496-46552a42760e&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVZVNGdDZCdzcvT0MwVEpJSHU1aFNaZlpZdHc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBMk5UZGFGdzB6TXpFeE1UZ3hOakEyTlRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNscVZWRDdONmlPQld0MFR2Y0VQWmtDdTlCbmR6YTZDK3NpMnB0UkphRXl6WWVWeHdBcmd3YVNDZGcKRnpFQ01xMmdQeVBWVHhiZTlYZG1QZ1Z5NTJCdFJrbW44anRJbzFETjZoUHZsNUx3M3d6VWNlcjZWaTBEM0ZvWApLZmoreVkzTkQzbHp1RS9BQmUxS0wrTkNOSWZYUkV3d2lNNEpPb3V0aFRzNlI1Skk3ZkRwY2tvb0UrWHF4aSszCjJQU0hTR21lc1BRTzFzQ25qeFhzZk9jdmNxTFM3aU1sWFNpV1BwMHgvQnplNkNJZWorNURjbEpDcGVBdkFuMSsKb1FpUC9rOEN4Mmg4QTRXT2hObXcvUG5RRzBrNHVPQWVlOUxqYk1HdlZ4K2lMK3MrVlNFSHZieHBLZHU0OUpkRgo3R0xGSk1lZEVvQi8vL2JQUXRzYkdlNndLR0F0QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RZemsxTmpabU5UWXROMlZrTVMwME9HVmlMV0U1WTJFdE5URTJaakF4TXpJelltWmsKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVJhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBQXByRDdWNVJBRHppc3ZzQnJBN05CR2R0Rlg3TTlHcWcwSHRsWUZxWkRtZnEzNFp2RGFXQWxVODBHClprTFlPYWNlRGJIUzJjOTdBU2RGTlBwYzhWTERzbHd5dEZicFVTZGFhaFArTm5zU0hmQUJpSi9tMlB4UjVySC8KRGdqRkdmNjJQcGt5SURrWGdYb2pnYWtEM0RmNDhJQlBscWswS0ZXRlNtS2JaQXVpbUp6aFoyL04xeGxIRjBwcgpaY3RaalJmbklzdjFsZ29mTTlackhNeVNNYVY3WVdjVzFlZjRrOEZXTzNGTlJKOFpaaUpHZ0E1cWFXZ25ZaXZGCklNdGtla0JwZm8xb1pydktwcHNnNDVmZjRpWENRcUhXeTdwRHllelNTaVRUZmhYMmdTTTZZMnlPaGFjN2JlWUYKcS9Md1RXVzBVYWo5TEJqM3Y1VEdsZkZ1WnJJTQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1839"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:30 GMT
+      - Mon, 18 Dec 2023 13:06:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 564688e5-5232-41ea-b2e1-9be4a32cad26
+      - d75ababd-ac1b-47e3-adca-5548fc94a259
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1225"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:30 GMT
+      - Mon, 18 Dec 2023 13:06:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,7 +825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 134db219-f371-4805-a08a-b88bfb578fa8
+      - 0eb07661-99ea-46d9-a2eb-8254ae07efc6
     status: 200 OK
     code: 200
     duration: ""
@@ -836,19 +836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1225"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:30 GMT
+      - Mon, 18 Dec 2023 13:06:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -858,7 +858,238 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c88c3eed-7619-4f24-ad69-15178cca7c66
+      - 8ef0e0f8-b825-4df2-a94f-4edfbb3cca6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZmYyNzdJeldFc280em9oYW9kb3UxUTc1ZDJBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QTFOREJhRncwek16RXlNVFV4TXpBMU5EQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2ppLzFRMHZPMXIwVEw3Kzk2VVJ5NFZxMGZiYWlweDRQRUM3ck9iem1OZHQ0RE1sZUYKOTRvUVV5Z3pQRW42aDJkbGt3QTZrWVdPMGo3aWI0dE9GVGo2ek1KaCs1bktubTNZd1lyUkwwbWkrKzF4QTVpcgpjSmFpYjA4UitGRzFTZnZ3dHdwY05hQS9MREZoZlNTYXRCOXR0SW9FcUpMNTdNUlIvVDFqYS83R0FSRFRQK25ECkxZZ2U4ejhPdzhNMTRJWS9ObkNrZVRCWFhCeVNvVWZyU3ZzWmFYUGY4eGRkZVFpeHBnem1UZW9rcnIxdmxFdmQKTi8xRzkvMFBWVkVybXdNcE5oYTg5aXZHbjhuZWR2Z0EvMUlsenQvczJWZTRIYnhFQUZQUE84QzkyditnaVdiUgp3RXBvNTFtcUVWbisrVmhNcDgxYWNTWDBUaW9BV1RlOVp5eG5BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkweFpEWTVPRGxtWkMwMk56TTFMVFE1T0RBdE9UUTUKTmkwME5qVTFNbUUwTWpjMk1HVXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNV1EyT1RnNVptUXROamN6TlMwME9UZ3dMVGswT1RZdE5EWTFOVEpoTkRJM05qQmxMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOFJYaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNiSGNzcWh6a3BLMnc3QU5Td1lKa2J2Q3RtbDYzTjNPemRndEJvMEVXTTNuNFZYeTdueFptMApDVkt1d1ZmNHpLZEMyd3JQL0h4TFlRZG5MK2tWTWxjZ3lFdEtmcnZIOXBia01VNDZidk9uVnRVZm9sZ3g4VXdOCklhb3FqckM4SUdyMzY2V3BlYWV3VElNcENDaGlCL1RlSlI2dlFPZVJzaEFyQm5SOGgrYjNaam14N0dwU1ZLTUQKSk9tbjhWWHhrR29TRjRUeFlJUTRYeGxDeUl1QTl2TG5tSTlDWThVaUJJMEo3S0dtS2FQVUxlWHg4TzE0a2xVaQpHYXJNeDRPRjJQYS9HT3RFT0o4RDdZRmR5TU5NN0ZhMGYzUDR3WFZrb2svK0FBSHhES3VyTVNyTmJGNTRGaDVGCkhjMGZtQlhtTlQ4NUMzbnc0REpFaDNCQnRESTM4cXM1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2015"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08109e9e-9286-46a3-b7de-3935f47f1913
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1d6989fd-6735-4980-9496-46552a42760e&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 570620f9-e427-4402-b89f-3780ae298812
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1231"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e1d853cd-0129-44b8-ada3-2b2b63632523
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZmYyNzdJeldFc280em9oYW9kb3UxUTc1ZDJBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QTFOREJhRncwek16RXlNVFV4TXpBMU5EQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2ppLzFRMHZPMXIwVEw3Kzk2VVJ5NFZxMGZiYWlweDRQRUM3ck9iem1OZHQ0RE1sZUYKOTRvUVV5Z3pQRW42aDJkbGt3QTZrWVdPMGo3aWI0dE9GVGo2ek1KaCs1bktubTNZd1lyUkwwbWkrKzF4QTVpcgpjSmFpYjA4UitGRzFTZnZ3dHdwY05hQS9MREZoZlNTYXRCOXR0SW9FcUpMNTdNUlIvVDFqYS83R0FSRFRQK25ECkxZZ2U4ejhPdzhNMTRJWS9ObkNrZVRCWFhCeVNvVWZyU3ZzWmFYUGY4eGRkZVFpeHBnem1UZW9rcnIxdmxFdmQKTi8xRzkvMFBWVkVybXdNcE5oYTg5aXZHbjhuZWR2Z0EvMUlsenQvczJWZTRIYnhFQUZQUE84QzkyditnaVdiUgp3RXBvNTFtcUVWbisrVmhNcDgxYWNTWDBUaW9BV1RlOVp5eG5BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkweFpEWTVPRGxtWkMwMk56TTFMVFE1T0RBdE9UUTUKTmkwME5qVTFNbUUwTWpjMk1HVXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNV1EyT1RnNVptUXROamN6TlMwME9UZ3dMVGswT1RZdE5EWTFOVEpoTkRJM05qQmxMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOFJYaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNiSGNzcWh6a3BLMnc3QU5Td1lKa2J2Q3RtbDYzTjNPemRndEJvMEVXTTNuNFZYeTdueFptMApDVkt1d1ZmNHpLZEMyd3JQL0h4TFlRZG5MK2tWTWxjZ3lFdEtmcnZIOXBia01VNDZidk9uVnRVZm9sZ3g4VXdOCklhb3FqckM4SUdyMzY2V3BlYWV3VElNcENDaGlCL1RlSlI2dlFPZVJzaEFyQm5SOGgrYjNaam14N0dwU1ZLTUQKSk9tbjhWWHhrR29TRjRUeFlJUTRYeGxDeUl1QTl2TG5tSTlDWThVaUJJMEo3S0dtS2FQVUxlWHg4TzE0a2xVaQpHYXJNeDRPRjJQYS9HT3RFT0o4RDdZRmR5TU5NN0ZhMGYzUDR3WFZrb2svK0FBSHhES3VyTVNyTmJGNTRGaDVGCkhjMGZtQlhtTlQ4NUMzbnc0REpFaDNCQnRESTM4cXM1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2015"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a321dea8-a505-4520-9e52-ccd3b35202f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1d6989fd-6735-4980-9496-46552a42760e&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbaac5ed-eabb-493b-a2d5-8f55a8e96387
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1231"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8eb62351-f2c0-4ac7-ab3d-ffa3fc984492
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1231"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3225458c-4bfa-4535-b63d-67ee0526d17c
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1197"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:31 GMT
+      - Mon, 18 Dec 2023 13:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e786a9f-8604-4490-96d5-4cf7f8218634
+      - df6f7282-4e50-445e-ba00-72dcf3bebf37
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1197"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:31 GMT
+      - Mon, 18 Dec 2023 13:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e8ffbe5-0d03-4482-b2fd-713680fe9a1f
+      - e053784c-a690-4fa5-96f6-949d2ed5f0bf
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVZVNGdDZCdzcvT0MwVEpJSHU1aFNaZlpZdHc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBMk5UZGFGdzB6TXpFeE1UZ3hOakEyTlRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNscVZWRDdONmlPQld0MFR2Y0VQWmtDdTlCbmR6YTZDK3NpMnB0UkphRXl6WWVWeHdBcmd3YVNDZGcKRnpFQ01xMmdQeVBWVHhiZTlYZG1QZ1Z5NTJCdFJrbW44anRJbzFETjZoUHZsNUx3M3d6VWNlcjZWaTBEM0ZvWApLZmoreVkzTkQzbHp1RS9BQmUxS0wrTkNOSWZYUkV3d2lNNEpPb3V0aFRzNlI1Skk3ZkRwY2tvb0UrWHF4aSszCjJQU0hTR21lc1BRTzFzQ25qeFhzZk9jdmNxTFM3aU1sWFNpV1BwMHgvQnplNkNJZWorNURjbEpDcGVBdkFuMSsKb1FpUC9rOEN4Mmg4QTRXT2hObXcvUG5RRzBrNHVPQWVlOUxqYk1HdlZ4K2lMK3MrVlNFSHZieHBLZHU0OUpkRgo3R0xGSk1lZEVvQi8vL2JQUXRzYkdlNndLR0F0QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RZemsxTmpabU5UWXROMlZrTVMwME9HVmlMV0U1WTJFdE5URTJaakF4TXpJelltWmsKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVJhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBQXByRDdWNVJBRHppc3ZzQnJBN05CR2R0Rlg3TTlHcWcwSHRsWUZxWkRtZnEzNFp2RGFXQWxVODBHClprTFlPYWNlRGJIUzJjOTdBU2RGTlBwYzhWTERzbHd5dEZicFVTZGFhaFArTm5zU0hmQUJpSi9tMlB4UjVySC8KRGdqRkdmNjJQcGt5SURrWGdYb2pnYWtEM0RmNDhJQlBscWswS0ZXRlNtS2JaQXVpbUp6aFoyL04xeGxIRjBwcgpaY3RaalJmbklzdjFsZ29mTTlackhNeVNNYVY3WVdjVzFlZjRrOEZXTzNGTlJKOFpaaUpHZ0E1cWFXZ25ZaXZGCklNdGtla0JwZm8xb1pydktwcHNnNDVmZjRpWENRcUhXeTdwRHllelNTaVRUZmhYMmdTTTZZMnlPaGFjN2JlWUYKcS9Md1RXVzBVYWo5TEJqM3Y1VEdsZkZ1WnJJTQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZmYyNzdJeldFc280em9oYW9kb3UxUTc1ZDJBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QTFOREJhRncwek16RXlNVFV4TXpBMU5EQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2ppLzFRMHZPMXIwVEw3Kzk2VVJ5NFZxMGZiYWlweDRQRUM3ck9iem1OZHQ0RE1sZUYKOTRvUVV5Z3pQRW42aDJkbGt3QTZrWVdPMGo3aWI0dE9GVGo2ek1KaCs1bktubTNZd1lyUkwwbWkrKzF4QTVpcgpjSmFpYjA4UitGRzFTZnZ3dHdwY05hQS9MREZoZlNTYXRCOXR0SW9FcUpMNTdNUlIvVDFqYS83R0FSRFRQK25ECkxZZ2U4ejhPdzhNMTRJWS9ObkNrZVRCWFhCeVNvVWZyU3ZzWmFYUGY4eGRkZVFpeHBnem1UZW9rcnIxdmxFdmQKTi8xRzkvMFBWVkVybXdNcE5oYTg5aXZHbjhuZWR2Z0EvMUlsenQvczJWZTRIYnhFQUZQUE84QzkyditnaVdiUgp3RXBvNTFtcUVWbisrVmhNcDgxYWNTWDBUaW9BV1RlOVp5eG5BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkweFpEWTVPRGxtWkMwMk56TTFMVFE1T0RBdE9UUTUKTmkwME5qVTFNbUUwTWpjMk1HVXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNV1EyT1RnNVptUXROamN6TlMwME9UZ3dMVGswT1RZdE5EWTFOVEpoTkRJM05qQmxMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOFJYaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNiSGNzcWh6a3BLMnc3QU5Td1lKa2J2Q3RtbDYzTjNPemRndEJvMEVXTTNuNFZYeTdueFptMApDVkt1d1ZmNHpLZEMyd3JQL0h4TFlRZG5MK2tWTWxjZ3lFdEtmcnZIOXBia01VNDZidk9uVnRVZm9sZ3g4VXdOCklhb3FqckM4SUdyMzY2V3BlYWV3VElNcENDaGlCL1RlSlI2dlFPZVJzaEFyQm5SOGgrYjNaam14N0dwU1ZLTUQKSk9tbjhWWHhrR29TRjRUeFlJUTRYeGxDeUl1QTl2TG5tSTlDWThVaUJJMEo3S0dtS2FQVUxlWHg4TzE0a2xVaQpHYXJNeDRPRjJQYS9HT3RFT0o4RDdZRmR5TU5NN0ZhMGYzUDR3WFZrb2svK0FBSHhES3VyTVNyTmJGNTRGaDVGCkhjMGZtQlhtTlQ4NUMzbnc0REpFaDNCQnRESTM4cXM1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1839"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:31 GMT
+      - Mon, 18 Dec 2023 13:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a29628c-d9cf-4107-b9a6-5b1efbf2b753
+      - cf605f6d-927a-4669-b1a5-060b03053e9d
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1d6989fd-6735-4980-9496-46552a42760e&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1197"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:31 GMT
+      - Mon, 18 Dec 2023 13:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2305269-03a7-427c-bd5b-5de948b7db81
+      - fac12010-3fd6-442a-88d4-7a1c1e1a0d54
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1197"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:32 GMT
+      - Mon, 18 Dec 2023 13:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0b32e3f-71e8-4214-8342-ec82e0e1c686
+      - 7cc93bb3-9628-4aa4-add5-3cb57d51edd4
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVZVNGdDZCdzcvT0MwVEpJSHU1aFNaZlpZdHc0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBMk5UZGFGdzB6TXpFeE1UZ3hOakEyTlRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNscVZWRDdONmlPQld0MFR2Y0VQWmtDdTlCbmR6YTZDK3NpMnB0UkphRXl6WWVWeHdBcmd3YVNDZGcKRnpFQ01xMmdQeVBWVHhiZTlYZG1QZ1Z5NTJCdFJrbW44anRJbzFETjZoUHZsNUx3M3d6VWNlcjZWaTBEM0ZvWApLZmoreVkzTkQzbHp1RS9BQmUxS0wrTkNOSWZYUkV3d2lNNEpPb3V0aFRzNlI1Skk3ZkRwY2tvb0UrWHF4aSszCjJQU0hTR21lc1BRTzFzQ25qeFhzZk9jdmNxTFM3aU1sWFNpV1BwMHgvQnplNkNJZWorNURjbEpDcGVBdkFuMSsKb1FpUC9rOEN4Mmg4QTRXT2hObXcvUG5RRzBrNHVPQWVlOUxqYk1HdlZ4K2lMK3MrVlNFSHZieHBLZHU0OUpkRgo3R0xGSk1lZEVvQi8vL2JQUXRzYkdlNndLR0F0QWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RZemsxTmpabU5UWXROMlZrTVMwME9HVmlMV0U1WTJFdE5URTJaakF4TXpJelltWmsKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVJhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBQXByRDdWNVJBRHppc3ZzQnJBN05CR2R0Rlg3TTlHcWcwSHRsWUZxWkRtZnEzNFp2RGFXQWxVODBHClprTFlPYWNlRGJIUzJjOTdBU2RGTlBwYzhWTERzbHd5dEZicFVTZGFhaFArTm5zU0hmQUJpSi9tMlB4UjVySC8KRGdqRkdmNjJQcGt5SURrWGdYb2pnYWtEM0RmNDhJQlBscWswS0ZXRlNtS2JaQXVpbUp6aFoyL04xeGxIRjBwcgpaY3RaalJmbklzdjFsZ29mTTlackhNeVNNYVY3WVdjVzFlZjRrOEZXTzNGTlJKOFpaaUpHZ0E1cWFXZ25ZaXZGCklNdGtla0JwZm8xb1pydktwcHNnNDVmZjRpWENRcUhXeTdwRHllelNTaVRUZmhYMmdTTTZZMnlPaGFjN2JlWUYKcS9Md1RXVzBVYWo5TEJqM3Y1VEdsZkZ1WnJJTQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "1203"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:32 GMT
+      - Mon, 18 Dec 2023 13:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b108e5e5-37eb-42fd-82cb-481d3579a952
+      - 5e6e9336-3faa-47ec-8aa6-035bc94a8381
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZmYyNzdJeldFc280em9oYW9kb3UxUTc1ZDJBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QTFOREJhRncwek16RXlNVFV4TXpBMU5EQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2ppLzFRMHZPMXIwVEw3Kzk2VVJ5NFZxMGZiYWlweDRQRUM3ck9iem1OZHQ0RE1sZUYKOTRvUVV5Z3pQRW42aDJkbGt3QTZrWVdPMGo3aWI0dE9GVGo2ek1KaCs1bktubTNZd1lyUkwwbWkrKzF4QTVpcgpjSmFpYjA4UitGRzFTZnZ3dHdwY05hQS9MREZoZlNTYXRCOXR0SW9FcUpMNTdNUlIvVDFqYS83R0FSRFRQK25ECkxZZ2U4ejhPdzhNMTRJWS9ObkNrZVRCWFhCeVNvVWZyU3ZzWmFYUGY4eGRkZVFpeHBnem1UZW9rcnIxdmxFdmQKTi8xRzkvMFBWVkVybXdNcE5oYTg5aXZHbjhuZWR2Z0EvMUlsenQvczJWZTRIYnhFQUZQUE84QzkyditnaVdiUgp3RXBvNTFtcUVWbisrVmhNcDgxYWNTWDBUaW9BV1RlOVp5eG5BZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkweFpEWTVPRGxtWkMwMk56TTFMVFE1T0RBdE9UUTUKTmkwME5qVTFNbUUwTWpjMk1HVXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNV1EyT1RnNVptUXROamN6TlMwME9UZ3dMVGswT1RZdE5EWTFOVEpoTkRJM05qQmxMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEOFJYaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNiSGNzcWh6a3BLMnc3QU5Td1lKa2J2Q3RtbDYzTjNPemRndEJvMEVXTTNuNFZYeTdueFptMApDVkt1d1ZmNHpLZEMyd3JQL0h4TFlRZG5MK2tWTWxjZ3lFdEtmcnZIOXBia01VNDZidk9uVnRVZm9sZ3g4VXdOCklhb3FqckM4SUdyMzY2V3BlYWV3VElNcENDaGlCL1RlSlI2dlFPZVJzaEFyQm5SOGgrYjNaam14N0dwU1ZLTUQKSk9tbjhWWHhrR29TRjRUeFlJUTRYeGxDeUl1QTl2TG5tSTlDWThVaUJJMEo3S0dtS2FQVUxlWHg4TzE0a2xVaQpHYXJNeDRPRjJQYS9HT3RFT0o4RDdZRmR5TU5NN0ZhMGYzUDR3WFZrb2svK0FBSHhES3VyTVNyTmJGNTRGaDVGCkhjMGZtQlhtTlQ4NUMzbnc0REpFaDNCQnRESTM4cXM1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1197"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:32 GMT
+      - Mon, 18 Dec 2023 13:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ae01549-b294-4b8a-86de-cb1bf302b2eb
+      - d681ca18-23f7-46e5-b955-0eeac2093a22
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1333,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1d6989fd-6735-4980-9496-46552a42760e&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f65c786b-fae2-4f50-a5e3-5cd2380b5970
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1203"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40d57f36-0166-4444-8d6d-d708116dc599
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1206"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:32 GMT
+      - Mon, 18 Dec 2023 13:06:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1f2e102-b228-4485-8925-f1ef708624f8
+      - 95c51688-6f14-4e2f-b1f9-e3d7ba430481
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:04:17.644602Z","endpoint":{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295},"endpoints":[{"id":"3ef7c43e-13c1-4743-9223-a0e6b1cc2e42","ip":"51.159.11.70","load_balancer":{},"name":null,"port":19295}],"engine":"PostgreSQL-15","id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:01:12.246425Z","endpoint":{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154},"endpoints":[{"id":"d27d01a2-e1be-4837-98c2-91b1cf67e458","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23154}],"engine":"PostgreSQL-15","id":"1d6989fd-6735-4980-9496-46552a42760e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-change-tag"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1200"
+      - "1206"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:33 GMT
+      - Mon, 18 Dec 2023 13:06:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4ea9bb8-432d-4fb9-ae14-4f90ddb0b9b6
+      - 9e7ae92b-9b9f-40b6-bdd6-4c9c0e1fea92
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,10 +1465,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1d6989fd-6735-4980-9496-46552a42760e","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1180,7 +1477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:03 GMT
+      - Mon, 18 Dec 2023 13:06:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 059327e0-a770-42db-ae50-9c9b62e0ed81
+      - 967cfdb7-f18e-4eaf-9ab1-a34ef7c56089
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1201,10 +1498,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c9566f56-7ed1-48eb-a9ca-516f01323bfd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1d6989fd-6735-4980-9496-46552a42760e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"c9566f56-7ed1-48eb-a9ca-516f01323bfd","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1d6989fd-6735-4980-9496-46552a42760e","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1213,7 +1510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:03 GMT
+      - Mon, 18 Dec 2023 13:06:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbcffb30-0bbd-495b-9cc7-41cca160fa58
+      - 07eec588-70e0-4335-88cf-76057bdf2056
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-capitalize.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-capitalize.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:53 GMT
+      - Mon, 18 Dec 2023 12:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a446e67-e7d8-4482-a0c9-2078b9b15b7e
+      - ab2b06b7-1ad7-4008-9dd4-0726ceedb144
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"DB-DEV-S","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-instance-capitalize","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"DB-DEV-S","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "884"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:11 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03f06ac6-93c2-4a23-a168-c77d7a4d0c22
+      - 86911c50-954a-4a3e-aa8c-6c5d71dc4f44
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "884"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:11 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a049a01-69d7-4ebf-b8d2-80ab71629c98
+      - cab7f22a-6107-43e6-a2bb-dcd6cdd6059a
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "884"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:42 GMT
+      - Mon, 18 Dec 2023 13:15:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b30395a-5007-4259-a405-2cd9f33e1ecd
+      - 23221d6c-b495-4c0d-9269-092aa3a24bad
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "884"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:16:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d536da4-9d3c-4ae5-8d4f-a8a774c1bf23
+      - c1c8e1dd-5381-4ae8-bfa4-0b2c875cd7ec
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "884"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:42 GMT
+      - Mon, 18 Dec 2023 13:16:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18efc048-6587-414b-bcb1-a746dc698e99
+      - 87860d93-1747-4775-817f-1199c71f7bac
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "884"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:12 GMT
+      - Mon, 18 Dec 2023 13:17:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b17f244d-c6c9-4b3d-9797-6bfc14a00c4f
+      - d55ff61d-3117-46e1-abfa-548ed0b8cdb0
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "884"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:42 GMT
+      - Mon, 18 Dec 2023 13:17:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d356133a-c0a6-471b-89c7-1f0000605666
+      - ba7472c8-b4d2-44d2-a744-a4cf791ddd7f
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "962"
+      - "1148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:13 GMT
+      - Mon, 18 Dec 2023 13:18:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10fe84cc-f101-4af2-8e80-53f529c3db6d
+      - 1ab386fe-c82c-402f-a3d7-b59fcaced438
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323},"endpoints":[{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323}],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1167"
+      - "1193"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:43 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 590ab822-d619-4acf-b015-939006cef62f
+      - 73afdc34-bc17-48a8-82ec-d1df3989b2e0
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVUGk0QWJLeTdtMVBjdGpWbThSazNjNnlNa0RNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBMk1ERmFGdzB6TXpFeE1UZ3hOakEyTURGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMxcWc5L1pzZmE1Q04xZkF6cnNIaGZaT1JDakVLcnhQOEt2S2RCVnRHYmtsSUxSckt0N3lkK2EyclQKdTczcUZ6dnBjcUNKUlRVZitFTnFDR2ZNaW1VWTdOOXVRVHFZaWRhTEQ2NXhsT2YzMlFDM0ZTb3hvOHhPcm4zYgpLRmFKSlRObTJoS2oybUJZTit1ZjBqUjFUdDkvQ2ZvWFozZzhjNmpOWDI2U0tMemRQKzJRTnQyejhnbEcxVmxzCnN6M0krblU2NmZkVHBucFFIU0RVZEVyRXBlT1V4OUdVT3R3Rys1NHdYbVQwVWJIU0pkZzZ2T1hmT0daS2x2UWEKR1hxQWxOUE1GS2VsRVpQRkdFOWdmdXdtczZOVnlmWkYwQ1ZwbkQwT3N5cXlIMzFScHd6MmlKKzZlZWpCMkw1SgpaajBJMzV1bDZkS1cyaldDRUllekhkcVpRQ1ZOQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RZamMwTVRjd09XUXRPV0V5WVMwMFlqUTRMV0U0TlRRdE16TTJNVGd5TlRCa016RTAKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS0M3aHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBejczc2VjV016cDZsVXp1RjdVNkI4RERzMDlIQ2xQcFFCUGd0cmxHOG5PSDNzUVdrUGVmOFhreE5vCm1QUGRiZURJdnlzMGNoMmFQTC9SZ1Zwc0NtUHRRQUFKL1RqRHRqeTFLZmtOeXBTRzZLQXl3M0p3RkFsY2tVcWQKUVkzVFlRM0hlQy9BTHdGc0R6ajRHd09NQVdIeS9BaGh2MzNIVE1ML25CbHFmNnVyS0NkdjlnSFZuK2VTRHRnVQpSOWJrMFVocHdpWkxyZ0c2UUluUzVhYkZwL0JabnNlMDl5QW9ldHR2R20vQmZtbDdzUndlTjZzaU8wYmQ3am9sCmlTS1ZTTGxTZU0vL2ZoUEpwNnA4aUhrdHNUWlJYZmFrcFNlUGJ5dlNTUXNFVTRwUURWZFZ5R1hLOEZSblBFa2cKbW1PKzUzZm1sWWRjd0ZvQVp1T3hTK0NweVBTRwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTFRqbUV2MTE5MjBHMFNHMWlTZExxSjNhZHlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1UZ3lNVm9YRFRNek1USXhOVEV6TVRneU1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXR0VURSdXRvWVNmVWU4ZzJoNmFSZ2laMjlQVlVVcmttcG5OM2ltZXRhQ3pSKzZEK3kxdnUKL3NYalFOV1o0SlZ5d0dRSW9ZM082WEwrTWViSDFCbk9pSHdHczh5T1RtTmFVTTRkWTV1MURxeERSMWgxRUdHUQpOM01oMDNjMFRxbU12SGsyditaQjV5OWc1V2g4NFJ2N3QzL085ajhwZklrNzNTTHdsK25ubnJCZzQ2bEx6Sm9lCnRFWXFPNDV3SU1tQ0UwTjF0Q2lHZ2FLSFd1Y1c5M2FIWUJBdXJaaWs0d2gzbGl6K0NyNDhIaGdEekorZ2VneDEKSHVVREFKS2VsbHdWVE5aVm5zK21aWmNOWVgxVEZnWjY4SkNnakpQWnBoQThXMkVoL3UyekNnNjNINWNLL2p6dAozSkNZSWFnME45akV3eDFZUUVucTREekx5aHVDS3gvUjB3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTAwWW1JME9UazBNeTB3TXpNd0xUUTBNVEV0T1dVNVpDMDAKTlRJMk9UUTJZemt5TnpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwMFltSTBPVGswTXkwd016TXdMVFEwTVRFdE9XVTVaQzAwTlRJMk9UUTJZemt5TnpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGpKQ0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBc2pIZ0szVFB5R2IxS3JCZkxnZjRVd1FOYWNqK3BGaU45d1hocndYbm5aNElteTNvUllLMVU2b1JwagpBNlR6NGhoaHl5Zk5xaDBuQjkyMGwvUmRiOE5hZGVHS1R4UEZtOVI3T3BzRklwSG1aSDVaUkNXd2d5VnRhcmo3Cm42TkVLUXpwVDZkMlFLejVSYlJsb04yQjgrR0FmOFpDWGJORWdhZis0VTZWWnRkdElMOTNERUdaRFEyT1IzWHEKS0hhWGt5UWpOdTZYQWhZS3FqL3dqSjl1K2pSckQ1Q0VMK2hqeURJYU45NTRUVlBPTXRnb1NuSktVTVV5cWlHTQpSRXcrT29td1Z3N1UrSThKVzFEeisrRlJxQkVmTk16K0QxdS9hcDU3bE90aXRXbWJPTExsWUV4S3ptZzNpcUJqCjZNRXRIc0hEYTRYNWc1cEE4ZXVNaGdYbWNrTT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1839"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:43 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02e2f4d1-c53c-4c75-b7fb-4aeca212ed23
+      - 519bd2b7-8137-4fc9-87ee-5e107bfd2f86
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4bb49943-0330-4411-9e9d-4526946c9276&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323},"endpoints":[{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323}],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1167"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:43 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f87399a-fc50-4c56-8ccd-c6f9078acfa8
+      - f0e89283-9e09-44b5-a548-ebc129b4eac0
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323},"endpoints":[{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323}],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1167"
+      - "1193"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:43 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b1ccfee-96de-41ae-8922-51e8e5ddcdd0
+      - 4f7fa473-f8d8-4b9e-8c94-a2fa44724d50
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVUGk0QWJLeTdtMVBjdGpWbThSazNjNnlNa0RNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBMk1ERmFGdzB6TXpFeE1UZ3hOakEyTURGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMxcWc5L1pzZmE1Q04xZkF6cnNIaGZaT1JDakVLcnhQOEt2S2RCVnRHYmtsSUxSckt0N3lkK2EyclQKdTczcUZ6dnBjcUNKUlRVZitFTnFDR2ZNaW1VWTdOOXVRVHFZaWRhTEQ2NXhsT2YzMlFDM0ZTb3hvOHhPcm4zYgpLRmFKSlRObTJoS2oybUJZTit1ZjBqUjFUdDkvQ2ZvWFozZzhjNmpOWDI2U0tMemRQKzJRTnQyejhnbEcxVmxzCnN6M0krblU2NmZkVHBucFFIU0RVZEVyRXBlT1V4OUdVT3R3Rys1NHdYbVQwVWJIU0pkZzZ2T1hmT0daS2x2UWEKR1hxQWxOUE1GS2VsRVpQRkdFOWdmdXdtczZOVnlmWkYwQ1ZwbkQwT3N5cXlIMzFScHd6MmlKKzZlZWpCMkw1SgpaajBJMzV1bDZkS1cyaldDRUllekhkcVpRQ1ZOQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RZamMwTVRjd09XUXRPV0V5WVMwMFlqUTRMV0U0TlRRdE16TTJNVGd5TlRCa016RTAKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS0M3aHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBejczc2VjV016cDZsVXp1RjdVNkI4RERzMDlIQ2xQcFFCUGd0cmxHOG5PSDNzUVdrUGVmOFhreE5vCm1QUGRiZURJdnlzMGNoMmFQTC9SZ1Zwc0NtUHRRQUFKL1RqRHRqeTFLZmtOeXBTRzZLQXl3M0p3RkFsY2tVcWQKUVkzVFlRM0hlQy9BTHdGc0R6ajRHd09NQVdIeS9BaGh2MzNIVE1ML25CbHFmNnVyS0NkdjlnSFZuK2VTRHRnVQpSOWJrMFVocHdpWkxyZ0c2UUluUzVhYkZwL0JabnNlMDl5QW9ldHR2R20vQmZtbDdzUndlTjZzaU8wYmQ3am9sCmlTS1ZTTGxTZU0vL2ZoUEpwNnA4aUhrdHNUWlJYZmFrcFNlUGJ5dlNTUXNFVTRwUURWZFZ5R1hLOEZSblBFa2cKbW1PKzUzZm1sWWRjd0ZvQVp1T3hTK0NweVBTRwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "1193"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:43 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a299d724-d8da-45c1-8d04-06a1e27ed1bc
+      - f17deaec-465c-4b29-b01e-7488d1ffec22
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323},"endpoints":[{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323}],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTFRqbUV2MTE5MjBHMFNHMWlTZExxSjNhZHlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1UZ3lNVm9YRFRNek1USXhOVEV6TVRneU1Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXR0VURSdXRvWVNmVWU4ZzJoNmFSZ2laMjlQVlVVcmttcG5OM2ltZXRhQ3pSKzZEK3kxdnUKL3NYalFOV1o0SlZ5d0dRSW9ZM082WEwrTWViSDFCbk9pSHdHczh5T1RtTmFVTTRkWTV1MURxeERSMWgxRUdHUQpOM01oMDNjMFRxbU12SGsyditaQjV5OWc1V2g4NFJ2N3QzL085ajhwZklrNzNTTHdsK25ubnJCZzQ2bEx6Sm9lCnRFWXFPNDV3SU1tQ0UwTjF0Q2lHZ2FLSFd1Y1c5M2FIWUJBdXJaaWs0d2gzbGl6K0NyNDhIaGdEekorZ2VneDEKSHVVREFKS2VsbHdWVE5aVm5zK21aWmNOWVgxVEZnWjY4SkNnakpQWnBoQThXMkVoL3UyekNnNjNINWNLL2p6dAozSkNZSWFnME45akV3eDFZUUVucTREekx5aHVDS3gvUjB3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTAwWW1JME9UazBNeTB3TXpNd0xUUTBNVEV0T1dVNVpDMDAKTlRJMk9UUTJZemt5TnpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkwMFltSTBPVGswTXkwd016TXdMVFEwTVRFdE9XVTVaQzAwTlRJMk9UUTJZemt5TnpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGpKQ0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFBc2pIZ0szVFB5R2IxS3JCZkxnZjRVd1FOYWNqK3BGaU45d1hocndYbm5aNElteTNvUllLMVU2b1JwagpBNlR6NGhoaHl5Zk5xaDBuQjkyMGwvUmRiOE5hZGVHS1R4UEZtOVI3T3BzRklwSG1aSDVaUkNXd2d5VnRhcmo3Cm42TkVLUXpwVDZkMlFLejVSYlJsb04yQjgrR0FmOFpDWGJORWdhZis0VTZWWnRkdElMOTNERUdaRFEyT1IzWHEKS0hhWGt5UWpOdTZYQWhZS3FqL3dqSjl1K2pSckQ1Q0VMK2hqeURJYU45NTRUVlBPTXRnb1NuSktVTVV5cWlHTQpSRXcrT29td1Z3N1UrSThKVzFEeisrRlJxQkVmTk16K0QxdS9hcDU3bE90aXRXbWJPTExsWUV4S3ptZzNpcUJqCjZNRXRIc0hEYTRYNWc1cEE4ZXVNaGdYbWNrTT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1167"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:44 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 101b2a4b-0684-4552-90a3-b1936949428f
+      - a1edd35b-e374-48f2-90b4-1f7dc8c0a854
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +803,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=4bb49943-0330-4411-9e9d-4526946c9276&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a0ea21f-3db6-4536-98a1-fafbb2a5d6d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1193"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 665a3005-e012-42ee-8973-0db734822a31
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323},"endpoints":[{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323}],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1196"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:44 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,7 +891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 391b175b-b0e2-4eda-8afe-6b64b37ce3f5
+      - a2af688a-2d9a-4634-a587-8499860b493c
     status: 200 OK
     code: 200
     duration: ""
@@ -836,19 +902,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:11.605463Z","endpoint":{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323},"endpoints":[{"id":"bf8baab9-90cd-4cf5-84b8-e21ebda7ac1c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3323}],"engine":"PostgreSQL-15","id":"b741709d-9a2a-4b48-a854-33618250d314","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:15:10.637054Z","endpoint":{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075},"endpoints":[{"id":"f91ac7fa-a2b1-4a42-ad64-9180cb509347","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26075}],"engine":"PostgreSQL-15","id":"4bb49943-0330-4411-9e9d-4526946c9276","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-capitalize","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1170"
+      - "1196"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:45 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -858,7 +924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4e0c692-2e26-4108-a9bb-de11ab5e0276
+      - 19469675-65b4-4704-876f-6187bf220861
     status: 200 OK
     code: 200
     duration: ""
@@ -869,10 +935,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"b741709d-9a2a-4b48-a854-33618250d314","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4bb49943-0330-4411-9e9d-4526946c9276","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -881,7 +947,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:15 GMT
+      - Mon, 18 Dec 2023 13:19:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -891,7 +957,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6d8663cb-5d81-46fd-a9e6-1913da030946
+      - f7b6a444-0a4d-499a-8852-8aa25b70a814
     status: 404 Not Found
     code: 404
     duration: ""
@@ -902,10 +968,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/b741709d-9a2a-4b48-a854-33618250d314
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/4bb49943-0330-4411-9e9d-4526946c9276
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"b741709d-9a2a-4b48-a854-33618250d314","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"4bb49943-0330-4411-9e9d-4526946c9276","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -914,7 +980,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:15 GMT
+      - Mon, 18 Dec 2023 13:19:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -924,7 +990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 488ebb2a-d468-40b7-8a8f-5f0087657768
+      - 5f48e0ef-b840-402b-a975-668525fed075
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-endpoints.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-endpoints.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:54 GMT
+      - Mon, 18 Dec 2023 12:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09d2f121-31c8-4d02-8c82-f194097b0ca3
+      - 61ddc428-7202-4133-9469-5729b47b260c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-rdb-disable-public-endpoint","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-rdb-endpoints","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "715"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:05 GMT
+      - Mon, 18 Dec 2023 13:10:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb146438-9c63-4eea-8baf-f992a6333548
+      - 5e328114-8914-4c44-b1df-67afadf05030
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "715"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:05 GMT
+      - Mon, 18 Dec 2023 13:10:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,12 +396,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 102c69a2-41b6-4bdc-a557-6f2cbba77f09
+      - 7871c9fa-5a6e-4490-8c7f-51b9233e8e4a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-disable-public-endpoint","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","ipam_config":{}}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","ipam_config":{}}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -412,16 +412,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1004"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:06 GMT
+      - Mon, 18 Dec 2023 13:10:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 049b29fd-016c-4d4c-85dc-c3307a3a4879
+      - 48591651-2f7a-4f56-b713-f2649c49d8d8
     status: 200 OK
     code: 200
     duration: ""
@@ -442,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1004"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:06 GMT
+      - Mon, 18 Dec 2023 13:10:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab18bd93-6083-40f5-929b-0ef2a538a936
+      - 01758275-ff9b-4517-b9d0-dac1bc983039
     status: 200 OK
     code: 200
     duration: ""
@@ -475,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1004"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:36 GMT
+      - Mon, 18 Dec 2023 13:10:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c049f4a-ce77-4278-829e-f9a10443564b
+      - 27b6a23a-5b0c-478c-bcad-1a476cf98e9b
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1004"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:00:07 GMT
+      - Mon, 18 Dec 2023 13:11:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48030ea0-0307-4a29-8708-562a003a0954
+      - a97e3cfe-29a0-4c6c-a629-dce372e968a3
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1004"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:00:37 GMT
+      - Mon, 18 Dec 2023 13:11:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1306298a-9fe1-47a3-98cd-2038fba8768d
+      - 5ca8b82c-11b4-4e48-b922-c90fec8138c7
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1004"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:01:07 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17ca876c-4c83-471a-a12a-73524a099de8
+      - df7b6570-0076-4de9-b4a1-7221921ca98f
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1004"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:01:37 GMT
+      - Mon, 18 Dec 2023 13:12:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 391b4828-6b6b-47e4-923f-611fc2983c13
+      - 3b4933f6-e283-462a-8ecb-174026859bbc
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:07 GMT
+      - Mon, 18 Dec 2023 13:13:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 120b2cdf-526a-4b90-9215-d3d3e8b758f3
+      - b6017e57-bae3-4769-ac1e-0e77ba88ea80
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"93946f50-5d25-4178-9edb-88387ae9b6e4","ip":"51.159.204.200","load_balancer":{},"name":null,"port":27011},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"93946f50-5d25-4178-9edb-88387ae9b6e4","ip":"51.159.204.200","load_balancer":{},"name":null,"port":27011}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1480"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:38 GMT
+      - Mon, 18 Dec 2023 13:13:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75f408d1-e15f-4f08-8d3c-301a07f6aaca
+      - 986c10bf-305f-470c-84f4-cf0419981552
     status: 200 OK
     code: 200
     duration: ""
@@ -706,50 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/93946f50-5d25-4178-9edb-88387ae9b6e4
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:02:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2eaa02d9-dc29-4444-ba27-89c185c3d98c
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"93946f50-5d25-4178-9edb-88387ae9b6e4","ip":"51.159.204.200","load_balancer":{},"name":null,"port":27011},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"93946f50-5d25-4178-9edb-88387ae9b6e4","ip":"51.159.204.200","load_balancer":{},"name":null,"port":27011}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1486"
+      - "516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:38 GMT
+      - Mon, 18 Dec 2023 13:13:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa99aa04-9b00-4edc-b458-39dfdba2e74b
+      - 74803641-69be-41dc-8895-266fd6c0efd9
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:08 GMT
+      - Mon, 18 Dec 2023 13:13:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2920d4b2-2ab5-4afa-83a8-372b143d4d79
+      - 62c468a1-a20a-4513-b6fa-267aad4654c1
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVkw4NjRVcmxUSUZEeEIrbk9jWENlNDFuMTRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTQwTkM0eU1CNFhEVEl6Ck1URXlNVEUyTURJd00xb1hEVE16TVRFeE9ERTJNREl3TTFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ME5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzTHNsMXBlODdVNDI5aEJFL0dndzNnUjM2RHNtY05tL1BBSGF0QUhEM1kvNzVBaW8vemdaTjIxN0tUYUIKTUlQVXlCYitjNURHME84ZnFoSm9zQlFWbUd4YVIzVnRwMEdtdHBSaHZma0MrRVp6YnJ6ejZiK0dPaCtPVHRVZwpHY25iSmNaQzhOYW14VFNUNkFtdjkwYWtRT3psY2gxcHhReVFSQ3VNLzFGNUduY1E0WWNGTlVXWUszbzNHemF1ClByZ0RhUTN0bVpmWHA5NXRrbGt2RlprU1dRZVdjNXZLRjg1WTdXMlhSeEgvb0YvZVNWNkNQZGhuWElaVDhtOUgKQnpHUGZ3c3FXSUR6aVQ0WVpxODRxZUQvZVAraytzTW1nMU12aTNJeTV1cmFHSitDaHJFbWJtNjlCemlrU2I1Swp0QlNWNGo4R1ZGTG5FN3gzRDA4SzFnVjVHd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck5EUXVNb0lPTlRFdU1UVTVMakl3TkM0eU1EQ0NQSEozTFdKbVlURXpaRGs1TFRjeFpEWXROREV3TXkwNE9EY3cKTFdaa01qUTNNRE5pTlROaU55NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5T1JZY0VyQkFzQW9jRQpNNS9NeURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW1Zck9uS21CTUIrc3NkaVZlZnNLWTdSYStiK2NOUGFBCkdjc3FmMjRLYm5ibkJKRm9IOXpJV3JHbkFFOWRpNStNREVvWWpZR2o3QmNiaThicUtQdXZVbmtLL010VGdrN2gKc2JlRVM0b25JV0ZQc0FjOC95Y08wYWtFOEpOWlorZERYNkVNREFSRU5aWkcwNEpKcHRBczEreEJ0LzZqdTZpSApvS3d3ZDBZSXBLdEp6dFEyVytEM2IxMExKdjB1eTB3RklZSVVEeTdLdWNlK24xQzdibGtxQ1c4MEUydkpGUnp0CnRSRkhIR1JxZ01pMUMzeG05VCtNTlN3b0FiektyaStNZTV6aVprK1pqbHAweDVIM1AzMG9HRmJOQzR4NGJpRjAKNlVlSllhK3R1YU9qRTV6L0ExYnZ5NkJna0pvQ3VNbXk2VVczblNJSDMwKzQvWUF6dmpEVDJ3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1875"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:08 GMT
+      - Mon, 18 Dec 2023 13:13:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49b168cc-02e4-41c1-a411-7f329085195f
+      - 09283d10-bf04-4e04-821d-cddf556a1797
     status: 200 OK
     code: 200
     duration: ""
@@ -836,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1261"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:09 GMT
+      - Mon, 18 Dec 2023 13:13:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -858,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04344ec8-49d4-4206-b3aa-4621485cf484
+      - bf65c333-ef5f-4c29-b2f1-b3fb0e53577a
     status: 200 OK
     code: 200
     duration: ""
@@ -869,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "715"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:09 GMT
+      - Mon, 18 Dec 2023 13:13:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -891,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b4819bc-384a-430c-b733-ee65c44d7475
+      - 9aa84655-47a9-4078-b992-2303ee1d9a20
     status: 200 OK
     code: 200
     duration: ""
@@ -902,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "715"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:10 GMT
+      - Mon, 18 Dec 2023 13:13:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -924,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7665e14e-f4cf-49c6-b685-2a0802aca49d
+      - 373d0a1e-c011-442c-a55d-66917337e369
     status: 200 OK
     code: 200
     duration: ""
@@ -935,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1261"
+      - "516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:10 GMT
+      - Mon, 18 Dec 2023 13:13:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -957,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9deb3849-150f-4cdd-ad1d-a855b108c522
+      - 1385ace5-bcd6-43d3-9912-7237d8805f78
     status: 200 OK
     code: 200
     duration: ""
@@ -968,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVkw4NjRVcmxUSUZEeEIrbk9jWENlNDFuMTRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTQwTkM0eU1CNFhEVEl6Ck1URXlNVEUyTURJd00xb1hEVE16TVRFeE9ERTJNREl3TTFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ME5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzTHNsMXBlODdVNDI5aEJFL0dndzNnUjM2RHNtY05tL1BBSGF0QUhEM1kvNzVBaW8vemdaTjIxN0tUYUIKTUlQVXlCYitjNURHME84ZnFoSm9zQlFWbUd4YVIzVnRwMEdtdHBSaHZma0MrRVp6YnJ6ejZiK0dPaCtPVHRVZwpHY25iSmNaQzhOYW14VFNUNkFtdjkwYWtRT3psY2gxcHhReVFSQ3VNLzFGNUduY1E0WWNGTlVXWUszbzNHemF1ClByZ0RhUTN0bVpmWHA5NXRrbGt2RlprU1dRZVdjNXZLRjg1WTdXMlhSeEgvb0YvZVNWNkNQZGhuWElaVDhtOUgKQnpHUGZ3c3FXSUR6aVQ0WVpxODRxZUQvZVAraytzTW1nMU12aTNJeTV1cmFHSitDaHJFbWJtNjlCemlrU2I1Swp0QlNWNGo4R1ZGTG5FN3gzRDA4SzFnVjVHd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck5EUXVNb0lPTlRFdU1UVTVMakl3TkM0eU1EQ0NQSEozTFdKbVlURXpaRGs1TFRjeFpEWXROREV3TXkwNE9EY3cKTFdaa01qUTNNRE5pTlROaU55NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5T1JZY0VyQkFzQW9jRQpNNS9NeURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW1Zck9uS21CTUIrc3NkaVZlZnNLWTdSYStiK2NOUGFBCkdjc3FmMjRLYm5ibkJKRm9IOXpJV3JHbkFFOWRpNStNREVvWWpZR2o3QmNiaThicUtQdXZVbmtLL010VGdrN2gKc2JlRVM0b25JV0ZQc0FjOC95Y08wYWtFOEpOWlorZERYNkVNREFSRU5aWkcwNEpKcHRBczEreEJ0LzZqdTZpSApvS3d3ZDBZSXBLdEp6dFEyVytEM2IxMExKdjB1eTB3RklZSVVEeTdLdWNlK24xQzdibGtxQ1c4MEUydkpGUnp0CnRSRkhIR1JxZ01pMUMzeG05VCtNTlN3b0FiektyaStNZTV6aVprK1pqbHAweDVIM1AzMG9HRmJOQzR4NGJpRjAKNlVlSllhK3R1YU9qRTV6L0ExYnZ5NkJna0pvQ3VNbXk2VVczblNJSDMwKzQvWUF6dmpEVDJ3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1875"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:10 GMT
+      - Mon, 18 Dec 2023 13:13:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -990,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4c862a2-c09b-4421-8672-03f0df7a8469
+      - b1c76667-2ca2-4929-8e79-478bc4f88a93
     status: 200 OK
     code: 200
     duration: ""
@@ -1001,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "715"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:11 GMT
+      - Mon, 18 Dec 2023 13:13:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1023,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaa72e64-aafc-4b23-9598-a5a674af5435
+      - 3a0c9dff-8dc2-4000-ac69-c118652ecd34
     status: 200 OK
     code: 200
     duration: ""
@@ -1034,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1261"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:11 GMT
+      - Mon, 18 Dec 2023 13:13:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1056,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd714b9e-265c-4511-b4d5-df539cd18225
+      - 30bed6f1-1f9e-4523-9988-8fe2aad15749
     status: 200 OK
     code: 200
     duration: ""
@@ -1067,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVkw4NjRVcmxUSUZEeEIrbk9jWENlNDFuMTRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTQwTkM0eU1CNFhEVEl6Ck1URXlNVEUyTURJd00xb1hEVE16TVRFeE9ERTJNREl3TTFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ME5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzTHNsMXBlODdVNDI5aEJFL0dndzNnUjM2RHNtY05tL1BBSGF0QUhEM1kvNzVBaW8vemdaTjIxN0tUYUIKTUlQVXlCYitjNURHME84ZnFoSm9zQlFWbUd4YVIzVnRwMEdtdHBSaHZma0MrRVp6YnJ6ejZiK0dPaCtPVHRVZwpHY25iSmNaQzhOYW14VFNUNkFtdjkwYWtRT3psY2gxcHhReVFSQ3VNLzFGNUduY1E0WWNGTlVXWUszbzNHemF1ClByZ0RhUTN0bVpmWHA5NXRrbGt2RlprU1dRZVdjNXZLRjg1WTdXMlhSeEgvb0YvZVNWNkNQZGhuWElaVDhtOUgKQnpHUGZ3c3FXSUR6aVQ0WVpxODRxZUQvZVAraytzTW1nMU12aTNJeTV1cmFHSitDaHJFbWJtNjlCemlrU2I1Swp0QlNWNGo4R1ZGTG5FN3gzRDA4SzFnVjVHd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck5EUXVNb0lPTlRFdU1UVTVMakl3TkM0eU1EQ0NQSEozTFdKbVlURXpaRGs1TFRjeFpEWXROREV3TXkwNE9EY3cKTFdaa01qUTNNRE5pTlROaU55NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5T1JZY0VyQkFzQW9jRQpNNS9NeURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW1Zck9uS21CTUIrc3NkaVZlZnNLWTdSYStiK2NOUGFBCkdjc3FmMjRLYm5ibkJKRm9IOXpJV3JHbkFFOWRpNStNREVvWWpZR2o3QmNiaThicUtQdXZVbmtLL010VGdrN2gKc2JlRVM0b25JV0ZQc0FjOC95Y08wYWtFOEpOWlorZERYNkVNREFSRU5aWkcwNEpKcHRBczEreEJ0LzZqdTZpSApvS3d3ZDBZSXBLdEp6dFEyVytEM2IxMExKdjB1eTB3RklZSVVEeTdLdWNlK24xQzdibGtxQ1c4MEUydkpGUnp0CnRSRkhIR1JxZ01pMUMzeG05VCtNTlN3b0FiektyaStNZTV6aVprK1pqbHAweDVIM1AzMG9HRmJOQzR4NGJpRjAKNlVlSllhK3R1YU9qRTV6L0ExYnZ5NkJna0pvQ3VNbXk2VVczblNJSDMwKzQvWUF6dmpEVDJ3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1875"
+      - "516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:11 GMT
+      - Mon, 18 Dec 2023 13:13:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1089,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 871db5bb-734b-4f5f-8bbb-f0a4d6866b18
+      - cd4dcd86-8283-40ee-ab6b-da4100ccf794
     status: 200 OK
     code: 200
     duration: ""
@@ -1100,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:12 GMT
+      - Mon, 18 Dec 2023 13:13:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1122,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8bcc297-ba2f-4e42-80d5-b99e768ed832
+      - 412f6739-4162-459d-8988-1637cd2f4793
     status: 200 OK
     code: 200
     duration: ""
@@ -1133,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:12 GMT
+      - Mon, 18 Dec 2023 13:13:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1155,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22225335-9f06-466f-80fb-cdfdeefaae4d
+      - f8b5b63c-20f5-4796-a5b2-4bbb5287904d
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:12 GMT
+      - Mon, 18 Dec 2023 13:13:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c980ee20-8982-4046-bfb6-c33613ed6c5f
+      - 473638fb-45e6-4ab5-8626-0e8cb1e0f2a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:12 GMT
+      - Mon, 18 Dec 2023 13:13:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1192,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c364d2a-a44d-443a-a395-ab89d95282fd
+      - 0f6eb063-c28a-4c2d-8b52-4fbbaf467f6a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1240"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:13:30 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1b835e50-d041-4cb5-b695-65bc894a3d05
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,7 +1238,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/endpoints
     method: POST
   response:
     body: '{"id":"","name":null,"port":0}'
@@ -1248,7 +1250,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:12 GMT
+      - Mon, 18 Dec 2023 13:13:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 075c1a80-dead-4542-a83d-a41f519a848e
+      - ab6b32f0-3047-447d-86ff-7f2aab3fc9c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1247"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:13 GMT
+      - Mon, 18 Dec 2023 13:13:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a1b5340-ae13-4b53-a2db-f978f242b3b0
+      - a12c581c-e913-4783-95ba-a9bc38563ea6
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1476"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:43 GMT
+      - Mon, 18 Dec 2023 13:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cdf752b-70fd-461b-8989-3bc2cdad3a26
+      - ff90b403-7eb4-4bdd-931a-05ec5cb32152
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVkw4NjRVcmxUSUZEeEIrbk9jWENlNDFuMTRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTQwTkM0eU1CNFhEVEl6Ck1URXlNVEUyTURJd00xb1hEVE16TVRFeE9ERTJNREl3TTFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ME5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzTHNsMXBlODdVNDI5aEJFL0dndzNnUjM2RHNtY05tL1BBSGF0QUhEM1kvNzVBaW8vemdaTjIxN0tUYUIKTUlQVXlCYitjNURHME84ZnFoSm9zQlFWbUd4YVIzVnRwMEdtdHBSaHZma0MrRVp6YnJ6ejZiK0dPaCtPVHRVZwpHY25iSmNaQzhOYW14VFNUNkFtdjkwYWtRT3psY2gxcHhReVFSQ3VNLzFGNUduY1E0WWNGTlVXWUszbzNHemF1ClByZ0RhUTN0bVpmWHA5NXRrbGt2RlprU1dRZVdjNXZLRjg1WTdXMlhSeEgvb0YvZVNWNkNQZGhuWElaVDhtOUgKQnpHUGZ3c3FXSUR6aVQ0WVpxODRxZUQvZVAraytzTW1nMU12aTNJeTV1cmFHSitDaHJFbWJtNjlCemlrU2I1Swp0QlNWNGo4R1ZGTG5FN3gzRDA4SzFnVjVHd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck5EUXVNb0lPTlRFdU1UVTVMakl3TkM0eU1EQ0NQSEozTFdKbVlURXpaRGs1TFRjeFpEWXROREV3TXkwNE9EY3cKTFdaa01qUTNNRE5pTlROaU55NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5T1JZY0VyQkFzQW9jRQpNNS9NeURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW1Zck9uS21CTUIrc3NkaVZlZnNLWTdSYStiK2NOUGFBCkdjc3FmMjRLYm5ibkJKRm9IOXpJV3JHbkFFOWRpNStNREVvWWpZR2o3QmNiaThicUtQdXZVbmtLL010VGdrN2gKc2JlRVM0b25JV0ZQc0FjOC95Y08wYWtFOEpOWlorZERYNkVNREFSRU5aWkcwNEpKcHRBczEreEJ0LzZqdTZpSApvS3d3ZDBZSXBLdEp6dFEyVytEM2IxMExKdjB1eTB3RklZSVVEeTdLdWNlK24xQzdibGtxQ1c4MEUydkpGUnp0CnRSRkhIR1JxZ01pMUMzeG05VCtNTlN3b0FiektyaStNZTV6aVprK1pqbHAweDVIM1AzMG9HRmJOQzR4NGJpRjAKNlVlSllhK3R1YU9qRTV6L0ExYnZ5NkJna0pvQ3VNbXk2VVczblNJSDMwKzQvWUF6dmpEVDJ3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1875"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:43 GMT
+      - Mon, 18 Dec 2023 13:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba66a583-5953-4fe9-b6dc-a2aa4e1d9d0d
+      - d308e33f-95d1-4334-82c4-100ed8faef13
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1476"
+      - "516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:43 GMT
+      - Mon, 18 Dec 2023 13:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32fd957a-fd68-40a0-bbda-efe8670c3c26
+      - 5e253845-183f-418b-b2e2-dd2285008e70
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "715"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:43 GMT
+      - Mon, 18 Dec 2023 13:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eeea87b9-224c-402d-b409-4e6de3cd2db6
+      - 5eecc60b-f399-4b4f-96e3-11b02a433a93
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "715"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:44 GMT
+      - Mon, 18 Dec 2023 13:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afa53707-eff6-410f-8c6d-3a379637d984
+      - 7e6f7a33-c89f-4b5e-8192-e3b5ec8ae4b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1476"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:44 GMT
+      - Mon, 18 Dec 2023 13:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8126af2d-63b7-4e96-bbee-b7b759995a75
+      - a67c81f2-9514-457c-b01f-6d080ea8d170
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1502,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVkw4NjRVcmxUSUZEeEIrbk9jWENlNDFuMTRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTQwTkM0eU1CNFhEVEl6Ck1URXlNVEUyTURJd00xb1hEVE16TVRFeE9ERTJNREl3TTFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ME5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzTHNsMXBlODdVNDI5aEJFL0dndzNnUjM2RHNtY05tL1BBSGF0QUhEM1kvNzVBaW8vemdaTjIxN0tUYUIKTUlQVXlCYitjNURHME84ZnFoSm9zQlFWbUd4YVIzVnRwMEdtdHBSaHZma0MrRVp6YnJ6ejZiK0dPaCtPVHRVZwpHY25iSmNaQzhOYW14VFNUNkFtdjkwYWtRT3psY2gxcHhReVFSQ3VNLzFGNUduY1E0WWNGTlVXWUszbzNHemF1ClByZ0RhUTN0bVpmWHA5NXRrbGt2RlprU1dRZVdjNXZLRjg1WTdXMlhSeEgvb0YvZVNWNkNQZGhuWElaVDhtOUgKQnpHUGZ3c3FXSUR6aVQ0WVpxODRxZUQvZVAraytzTW1nMU12aTNJeTV1cmFHSitDaHJFbWJtNjlCemlrU2I1Swp0QlNWNGo4R1ZGTG5FN3gzRDA4SzFnVjVHd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck5EUXVNb0lPTlRFdU1UVTVMakl3TkM0eU1EQ0NQSEozTFdKbVlURXpaRGs1TFRjeFpEWXROREV3TXkwNE9EY3cKTFdaa01qUTNNRE5pTlROaU55NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5T1JZY0VyQkFzQW9jRQpNNS9NeURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW1Zck9uS21CTUIrc3NkaVZlZnNLWTdSYStiK2NOUGFBCkdjc3FmMjRLYm5ibkJKRm9IOXpJV3JHbkFFOWRpNStNREVvWWpZR2o3QmNiaThicUtQdXZVbmtLL010VGdrN2gKc2JlRVM0b25JV0ZQc0FjOC95Y08wYWtFOEpOWlorZERYNkVNREFSRU5aWkcwNEpKcHRBczEreEJ0LzZqdTZpSApvS3d3ZDBZSXBLdEp6dFEyVytEM2IxMExKdjB1eTB3RklZSVVEeTdLdWNlK24xQzdibGtxQ1c4MEUydkpGUnp0CnRSRkhIR1JxZ01pMUMzeG05VCtNTlN3b0FiektyaStNZTV6aVprK1pqbHAweDVIM1AzMG9HRmJOQzR4NGJpRjAKNlVlSllhK3R1YU9qRTV6L0ExYnZ5NkJna0pvQ3VNbXk2VVczblNJSDMwKzQvWUF6dmpEVDJ3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1875"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:44 GMT
+      - Mon, 18 Dec 2023 13:14:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a3cb9fc-8589-4b56-a1a0-84bb3f01e3fb
+      - 39e0cef1-4f30-421e-a290-e35876d65fe9
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1535,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "715"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:44 GMT
+      - Mon, 18 Dec 2023 13:14:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9fceb4d-2d94-4d19-8a4a-21b62ba2d5e8
+      - 9b13bed2-549a-4ede-97da-219e9a2e725b
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1568,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1476"
+      - "516"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:44 GMT
+      - Mon, 18 Dec 2023 13:14:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d00f84f-e526-4831-9a97-95c246260896
+      - 8f203573-46e4-491c-b35c-58234db8c0dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1601,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVkw4NjRVcmxUSUZEeEIrbk9jWENlNDFuMTRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTQwTkM0eU1CNFhEVEl6Ck1URXlNVEUyTURJd00xb1hEVE16TVRFeE9ERTJNREl3TTFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ME5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzTHNsMXBlODdVNDI5aEJFL0dndzNnUjM2RHNtY05tL1BBSGF0QUhEM1kvNzVBaW8vemdaTjIxN0tUYUIKTUlQVXlCYitjNURHME84ZnFoSm9zQlFWbUd4YVIzVnRwMEdtdHBSaHZma0MrRVp6YnJ6ejZiK0dPaCtPVHRVZwpHY25iSmNaQzhOYW14VFNUNkFtdjkwYWtRT3psY2gxcHhReVFSQ3VNLzFGNUduY1E0WWNGTlVXWUszbzNHemF1ClByZ0RhUTN0bVpmWHA5NXRrbGt2RlprU1dRZVdjNXZLRjg1WTdXMlhSeEgvb0YvZVNWNkNQZGhuWElaVDhtOUgKQnpHUGZ3c3FXSUR6aVQ0WVpxODRxZUQvZVAraytzTW1nMU12aTNJeTV1cmFHSitDaHJFbWJtNjlCemlrU2I1Swp0QlNWNGo4R1ZGTG5FN3gzRDA4SzFnVjVHd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck5EUXVNb0lPTlRFdU1UVTVMakl3TkM0eU1EQ0NQSEozTFdKbVlURXpaRGs1TFRjeFpEWXROREV3TXkwNE9EY3cKTFdaa01qUTNNRE5pTlROaU55NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5T1JZY0VyQkFzQW9jRQpNNS9NeURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW1Zck9uS21CTUIrc3NkaVZlZnNLWTdSYStiK2NOUGFBCkdjc3FmMjRLYm5ibkJKRm9IOXpJV3JHbkFFOWRpNStNREVvWWpZR2o3QmNiaThicUtQdXZVbmtLL010VGdrN2gKc2JlRVM0b25JV0ZQc0FjOC95Y08wYWtFOEpOWlorZERYNkVNREFSRU5aWkcwNEpKcHRBczEreEJ0LzZqdTZpSApvS3d3ZDBZSXBLdEp6dFEyVytEM2IxMExKdjB1eTB3RklZSVVEeTdLdWNlK24xQzdibGtxQ1c4MEUydkpGUnp0CnRSRkhIR1JxZ01pMUMzeG05VCtNTlN3b0FiektyaStNZTV6aVprK1pqbHAweDVIM1AzMG9HRmJOQzR4NGJpRjAKNlVlSllhK3R1YU9qRTV6L0ExYnZ5NkJna0pvQ3VNbXk2VVczblNJSDMwKzQvWUF6dmpEVDJ3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1875"
+      - "703"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 13:14:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 061436a6-3332-4504-937f-9ec2884dee61
+      - ad3936c9-5d20-4912-84c7-0f5076f2d236
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,19 +1634,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1476"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 13:14:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a4bf77a-d180-44dc-b8ab-9b9d465e796d
+      - f2f8ff26-c90d-4f3b-88b9-d0e7f2bdbb2b
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,19 +1667,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1476"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 13:14:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1689,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03e91b2f-9383-45cb-9686-85a33c5b02ea
+      - 571198c1-2260-49dd-b291-4079901027fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "516"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e2e64ab7-3866-4b19-a670-c4743b6265ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1457"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1966cf31-2238-4ec4-b742-127faa698015
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1457"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 02576053-ebbe-42f9-a54f-c17f09ffacd9
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1801,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1476"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 13:14:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c0aecac-1fef-4a0a-99e8-16cb18d1da1b
+      - 0942bd20-2fd8-42b6-92bc-faec50b73c38
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,19 +1834,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1476"
+      - "1457"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 13:14:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78552cbf-2aee-408c-819d-4fef96e18caf
+      - d89d1dd3-63b7-42f2-b130-290084b8694e
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,7 +1867,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/9b37e65c-3ad8-4571-9e2e-d77e102a7c40
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/dbd79c5f-682c-4cc5-9b3a-7bae6e683cde
     method: DELETE
   response:
     body: ""
@@ -1776,7 +1877,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:15 GMT
+      - Mon, 18 Dec 2023 13:14:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f60ee37f-9671-4ab0-8d9e-63871981bb16
+      - f3e3bf13-138c-417d-b35c-6ce95a2caa64
     status: 204 No Content
     code: 204
     duration: ""
@@ -1797,19 +1898,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"9b37e65c-3ad8-4571-9e2e-d77e102a7c40","ip":"172.16.44.2","name":null,"port":5432,"private_network":{"private_network_id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","service_ip":"172.16.44.2/22","zone":"fr-par-1"}},{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1482"
+      - "1463"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:16 GMT
+      - Mon, 18 Dec 2023 13:14:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ff566bd-dd68-4179-861d-af1e0634aac5
+      - 0951546f-4ff7-4ec8-a71d-40c4cd78aabe
     status: 200 OK
     code: 200
     duration: ""
@@ -1830,19 +1931,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1259"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:13 GMT
+      - Mon, 18 Dec 2023 13:14:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,7 +1953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d17b01c1-a67c-4b3e-929c-d442bc573390
+      - 9383af9e-a60a-4d05-afb0-5f45fdcdd883
     status: 200 OK
     code: 200
     duration: ""
@@ -1863,19 +1964,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1259"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:14 GMT
+      - Mon, 18 Dec 2023 13:14:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1885,7 +1986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2eb39d4-c2ec-4b3d-9d02-6947084f86e1
+      - 570f7ad9-4da1-4e47-a3d6-04b9a0211ca3
     status: 200 OK
     code: 200
     duration: ""
@@ -1896,7 +1997,337 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/8707e85f-e740-48ea-83a7-db9736de4952
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1731"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7157b578-c169-4030-b1d9-b32fefa6180b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62c4129f-aa1a-4394-a8bc-dda240c4e513
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1238"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 69cefdac-3a34-43e0-b571-9de1099034a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "703"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 24c93b7a-2ce1-49bd-a4ae-0ace59047bdb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1238"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c59a2d83-bd74-409a-8db3-f164b8e2f459
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1731"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbba8fef-b935-4127-af02-b55819ca8d4b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8d57173b-0d10-4cdb-9094-450e92ee2b0f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1238"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 125f5451-7b5c-40c1-acba-ec1f2334ea47
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1241"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 50778161-b10f-4c20-adfd-3bb6b7409f88
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1241"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56926c43-7317-480e-84b2-0537d5b97b5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
     method: DELETE
   response:
     body: ""
@@ -1906,7 +2337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:14 GMT
+      - Mon, 18 Dec 2023 13:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1916,7 +2347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5406036-f634-4937-8add-9e9e99b07514
+      - a8cb473d-533a-4933-8e39-94837e47a276
     status: 204 No Content
     code: 204
     duration: ""
@@ -1927,371 +2358,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156},"endpoints":[{"id":"8707e85f-e740-48ea-83a7-db9736de4952","ip":"51.159.26.205","load_balancer":{},"name":null,"port":5156}],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1265"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4ce7b0e5-77d9-4f72-a321-1659c6909c19
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1045"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5178e3cf-9e49-4cb4-8bc9-e4b577c873b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVkw4NjRVcmxUSUZEeEIrbk9jWENlNDFuMTRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTQwTkM0eU1CNFhEVEl6Ck1URXlNVEUyTURJd00xb1hEVE16TVRFeE9ERTJNREl3TTFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ME5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzTHNsMXBlODdVNDI5aEJFL0dndzNnUjM2RHNtY05tL1BBSGF0QUhEM1kvNzVBaW8vemdaTjIxN0tUYUIKTUlQVXlCYitjNURHME84ZnFoSm9zQlFWbUd4YVIzVnRwMEdtdHBSaHZma0MrRVp6YnJ6ejZiK0dPaCtPVHRVZwpHY25iSmNaQzhOYW14VFNUNkFtdjkwYWtRT3psY2gxcHhReVFSQ3VNLzFGNUduY1E0WWNGTlVXWUszbzNHemF1ClByZ0RhUTN0bVpmWHA5NXRrbGt2RlprU1dRZVdjNXZLRjg1WTdXMlhSeEgvb0YvZVNWNkNQZGhuWElaVDhtOUgKQnpHUGZ3c3FXSUR6aVQ0WVpxODRxZUQvZVAraytzTW1nMU12aTNJeTV1cmFHSitDaHJFbWJtNjlCemlrU2I1Swp0QlNWNGo4R1ZGTG5FN3gzRDA4SzFnVjVHd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck5EUXVNb0lPTlRFdU1UVTVMakl3TkM0eU1EQ0NQSEozTFdKbVlURXpaRGs1TFRjeFpEWXROREV3TXkwNE9EY3cKTFdaa01qUTNNRE5pTlROaU55NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5T1JZY0VyQkFzQW9jRQpNNS9NeURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW1Zck9uS21CTUIrc3NkaVZlZnNLWTdSYStiK2NOUGFBCkdjc3FmMjRLYm5ibkJKRm9IOXpJV3JHbkFFOWRpNStNREVvWWpZR2o3QmNiaThicUtQdXZVbmtLL010VGdrN2gKc2JlRVM0b25JV0ZQc0FjOC95Y08wYWtFOEpOWlorZERYNkVNREFSRU5aWkcwNEpKcHRBczEreEJ0LzZqdTZpSApvS3d3ZDBZSXBLdEp6dFEyVytEM2IxMExKdjB1eTB3RklZSVVEeTdLdWNlK24xQzdibGtxQ1c4MEUydkpGUnp0CnRSRkhIR1JxZ01pMUMzeG05VCtNTlN3b0FiektyaStNZTV6aVprK1pqbHAweDVIM1AzMG9HRmJOQzR4NGJpRjAKNlVlSllhK3R1YU9qRTV6L0ExYnZ5NkJna0pvQ3VNbXk2VVczblNJSDMwKzQvWUF6dmpEVDJ3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1875"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0c29357c-48ca-44e4-b08b-fcc36681732a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1045"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42281fd9-9e31-4d74-8b9b-bc71ba0eb5df
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T15:59:04.384175Z","dhcp_enabled":true,"id":"05a40e93-6f04-4bf9-82e3-ee21beeb0524","name":"test-rdb-disable-public-endpoint","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T15:59:04.384175Z","id":"53a292e4-21f4-44ba-834b-ae7355a8539b","subnet":"172.16.44.0/22","updated_at":"2023-11-21T15:59:04.384175Z"},{"created_at":"2023-11-21T15:59:04.384175Z","id":"9baa2558-a907-4634-8294-0e258148ab2c","subnet":"fd5f:519c:6d46:8cf::/64","updated_at":"2023-11-21T15:59:04.384175Z"}],"tags":[],"updated_at":"2023-11-21T15:59:04.384175Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "715"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8296360a-2456-4472-8edb-d017e4169ffa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1045"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f17b706-5895-4b35-b5dd-152a696dfdbd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVVkw4NjRVcmxUSUZEeEIrbk9jWENlNDFuMTRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTQwTkM0eU1CNFhEVEl6Ck1URXlNVEUyTURJd00xb1hEVE16TVRFeE9ERTJNREl3TTFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ME5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFzTHNsMXBlODdVNDI5aEJFL0dndzNnUjM2RHNtY05tL1BBSGF0QUhEM1kvNzVBaW8vemdaTjIxN0tUYUIKTUlQVXlCYitjNURHME84ZnFoSm9zQlFWbUd4YVIzVnRwMEdtdHBSaHZma0MrRVp6YnJ6ejZiK0dPaCtPVHRVZwpHY25iSmNaQzhOYW14VFNUNkFtdjkwYWtRT3psY2gxcHhReVFSQ3VNLzFGNUduY1E0WWNGTlVXWUszbzNHemF1ClByZ0RhUTN0bVpmWHA5NXRrbGt2RlprU1dRZVdjNXZLRjg1WTdXMlhSeEgvb0YvZVNWNkNQZGhuWElaVDhtOUgKQnpHUGZ3c3FXSUR6aVQ0WVpxODRxZUQvZVAraytzTW1nMU12aTNJeTV1cmFHSitDaHJFbWJtNjlCemlrU2I1Swp0QlNWNGo4R1ZGTG5FN3gzRDA4SzFnVjVHd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck5EUXVNb0lPTlRFdU1UVTVMakl3TkM0eU1EQ0NQSEozTFdKbVlURXpaRGs1TFRjeFpEWXROREV3TXkwNE9EY3cKTFdaa01qUTNNRE5pTlROaU55NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5T1JZY0VyQkFzQW9jRQpNNS9NeURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW1Zck9uS21CTUIrc3NkaVZlZnNLWTdSYStiK2NOUGFBCkdjc3FmMjRLYm5ibkJKRm9IOXpJV3JHbkFFOWRpNStNREVvWWpZR2o3QmNiaThicUtQdXZVbmtLL010VGdrN2gKc2JlRVM0b25JV0ZQc0FjOC95Y08wYWtFOEpOWlorZERYNkVNREFSRU5aWkcwNEpKcHRBczEreEJ0LzZqdTZpSApvS3d3ZDBZSXBLdEp6dFEyVytEM2IxMExKdjB1eTB3RklZSVVEeTdLdWNlK24xQzdibGtxQ1c4MEUydkpGUnp0CnRSRkhIR1JxZ01pMUMzeG05VCtNTlN3b0FiektyaStNZTV6aVprK1pqbHAweDVIM1AzMG9HRmJOQzR4NGJpRjAKNlVlSllhK3R1YU9qRTV6L0ExYnZ5NkJna0pvQ3VNbXk2VVczblNJSDMwKzQvWUF6dmpEVDJ3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1875"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 163a7b53-676a-4ec2-a13c-6baa8691c3ec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1045"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 624e787f-825b-40b1-9d8e-a7c855e11f7f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1048"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d1ffdd03-9852-4048-b453-39e57ee0bbff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a40e93-6f04-4bf9-82e3-ee21beeb0524
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c652040-06b3-4a04-8232-586ea27469ce
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:05.983601Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"bfa13d99-71d6-4103-8870-fd24703b53b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-disable-public-endpoint","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","disable_public_endpoint"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1048"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:05:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33116d34-4242-4c54-9038-c42dbf31aabd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"bfa13d99-71d6-4103-8870-fd24703b53b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2300,7 +2370,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:20 GMT
+      - Mon, 18 Dec 2023 13:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2310,7 +2380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78297f8f-05aa-45e4-950a-9fdcbcdb3426
+      - 55f53ad9-c330-40f9-87ee-c5009be34fc4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2321,10 +2391,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/bfa13d99-71d6-4103-8870-fd24703b53b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"bfa13d99-71d6-4103-8870-fd24703b53b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2333,7 +2403,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:20 GMT
+      - Mon, 18 Dec 2023 13:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2343,7 +2413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21523367-b040-4a43-b338-52636180da16
+      - 5f5f800c-682a-4f60-a0d8-0790ea6ea8da
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-init-settings.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-init-settings.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:53 GMT
+      - Mon, 18 Dec 2023 12:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bd21e3c-9a5a-48d2-8fc6-97324d3352e8
+      - 320697f1-2144-4076-adcc-3a414e3ec634
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-init-settings","engine":"MySQL-8","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":[{"name":"lower_case_table_names","value":"1"}],"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-init-settings","engine":"MySQL-8","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":[{"name":"lower_case_table_names","value":"1"}],"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:44 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa46c16d-a3b6-4088-9aa8-3837867b05f3
+      - 00b11073-5b36-40ec-ba28-acde2d7b9ded
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:44 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b2d9d16-f66d-4555-8d27-f3037b300b59
+      - bdd3ed75-9ee8-44d7-b7bb-f4391db0fc3a
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:15 GMT
+      - Mon, 18 Dec 2023 12:57:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74a9be4e-373b-43a5-a44d-098b176ae8ff
+      - c1def08f-badc-4b08-a955-5ecddc74c0c1
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:45 GMT
+      - Mon, 18 Dec 2023 12:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c48dad8-24db-4e73-8c51-dca686bc787d
+      - aa9c074f-56a3-4a1d-bf5d-c412b1784a2c
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:15 GMT
+      - Mon, 18 Dec 2023 12:58:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efa9d3f2-7bf0-48df-93b1-588182b7c85c
+      - ceb3fa1f-cf8b-4cb7-a11a-9005e5f89fc8
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:45 GMT
+      - Mon, 18 Dec 2023 12:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 013eafe8-1d20-408e-b118-73a30eebbd8b
+      - a7946a29-2c53-42a0-97db-846589b6c319
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:15 GMT
+      - Mon, 18 Dec 2023 12:59:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef66b4a4-561d-41f1-a6d7-5f4c043f0767
+      - 9f72c4a6-e3bb-4e7d-a406-58d0774bac54
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "751"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:49 GMT
+      - Mon, 18 Dec 2023 13:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f3469e2-3e54-417d-bf9f-32ddfc5c8476
+      - cd1ce16b-3981-4abd-b37e-805edf02bc57
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":null,"endpoints":[],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"100"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:19 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f02a0190-16f1-4d9b-b46e-fe2a0629a584
+      - 669f80e5-c01e-4532-a36a-09b1437bb3a1
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947},"endpoints":[{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947}],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"100"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","load_balancer":{},"name":null,"port":0}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:50 GMT
+      - Mon, 18 Dec 2023 13:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da0ad83d-2b42-4d9e-bac7-1bdb96686dc5
+      - 06aeef8a-a88e-4e97-989c-5e6dd462cf7f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"100"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1004"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 469f5704-9a1c-451f-82ed-44ca84e25ebb
     status: 200 OK
     code: 200
     duration: ""
@@ -673,7 +706,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640/settings
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482/settings
     method: PUT
   response:
     body: '{"settings":[{"name":"max_connections","value":"350"}]}'
@@ -685,7 +718,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:50 GMT
+      - Mon, 18 Dec 2023 13:01:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1429774-4008-4231-8344-c74b2b536012
+      - ab19e608-2900-4210-bccb-6769bddcd811
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947},"endpoints":[{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947}],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1006"
+      - "1010"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:51 GMT
+      - Mon, 18 Dec 2023 13:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4050d2a5-f7c7-4256-bea9-bd9ef6d2d596
+      - 42bea3f0-7ef4-4239-a602-4de22cc2a815
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947},"endpoints":[{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947}],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "1004"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:21 GMT
+      - Mon, 18 Dec 2023 13:02:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ffb241d-32e1-4db2-a298-75f6f2025294
+      - 106dfc03-d7e3-4382-86ac-5fa5590cd7e6
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWEZzaC91RFltRWsyekszYWdoTjd4V1IwV0Rjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZd056QTFXaGNOTXpNeE1URTRNVFl3TnpBMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtKNWhkOWkrdVZDcDBhNEFOdzY5c0FJTHlXaGRVQTJxZG1BZGE3NkxGRjZLSFcrczd0TmJKeE4KRE1HQzNpMEdJNERsb3JwNEFDOENoRVo5cFI4NUlKQkJHNUYrbzYyWDNFNTJUSnpEcnk5aE5GQmJjbmlZOFBLagpoL05KNWh2Ty9yMldjYkU4Tkdua3drVkJKMldDOW1OOUVDTXhlUkxlOU5rQWpISXQ0cGU4VmVzeE9URHZpYmp0CjBhaUk3a1RKNjBhUHNQUkdxRlpkRHROUFJBbGZ5THA3WFU3L29tV2YwT3l2NEN4U3FmZUVPY1U5dm50TS9EMW4KcjduMnF3NkNsZzBMR0hNVnlIZ1c3dnM1UjA3VTJBVENFSFFCcy9UZUloYnI1NlFtVGNxVCtSc1hsT05nd1lnawpvUFdrYXhKNkZnanJvMG1GQy9Fdm9wTlFjSUpjWU84Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0TlRSaU1UTXlPR1l0WW1SbE55MDBOek01TFdFNFptWXRZVGRqTVRsaE1tUTQKTmpRd0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckloZ2h3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQi9ZZ1ZSMC9rcUpMM2lWenVvNWNkN1hvSVpWMmp6Z0tabGN5VTlFMXJHN01KUWo2THJ0RE9HCmxINGY5dHNHL2wwcXhtalM2SVZuRjM4QWRQY2ZWM29WSCswR0hjUGFTbzhhY2gyYU5ZZ3Y3SE1DTUxEbUlsczUKRzdrenJxMmZiR1RGYTk5OXd2bU90TnhINGx6UXcySVpaUCszZjFmeTg0RkY5ZnJmdWhKMFhJMi9lVWg2TFlzZQo4a2N3VkFMZzBXY1BVRzFwa3dncVM4bXpxd2drYkNwamlFR1lmakd3dTNiQUtSV0VaSkZTWkw5b2kxRDc0OXIxCllrcFNIdVNhSzJOLzFkN256OGVYSDhVa09VS2VpZFFlVFNxZnd5Y0E1MllpZ1NZbUlJWEtHNThnY0c1cUZNekUKcjFmZVFMck1WU0tZMWRUd1ZpVkJvd2I4Um1NSklncnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVQzA4L1F5YmFpZXMzdzBsQnhWVkdHYTVSZC80d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QXhNak5hRncwek16RXlNVFV4TXpBeE1qTmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ1g0ZmJnam9mTHhUcjZYSDFKczMrUWRhcFhpOU5kaW9tN2U5V1lwMmsxVG1OMGEvREoKLzNXM0JNRmIvWTdKQlV1QmdPSndLMU9MNmI3Yzllb25laVMzd090UzdEZnJZakM4dVhna1FVa1diSjFxN1BMcAprc2VNbk03K0pScDV6TTllZXhCWmJJV214OEdGNDdlVldMakkwWmFBanZua200VDkwa2thSHc4L1BCZzErczZRCjcyODhXRjI2ZHU2YkpXQ0JjbDZGcytrOWMvR0NlRzVINmFya3pCL21MQmRGd01yMFhyLysyaTgzYzBXUjY2c1gKNUlIL2J3N0phbTMveW1HVUpBQStUTnRpbUZUSHhGWE9YbUFrTGJnRkhNQXhVM2YwWUM1OXp1RVNvdHVEblVoaQpOdmhtRE5ENnFFdDlzc2hwSFhGc3NiUmF3RlZ2amNxQjVZbVhBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwM05HRmpZVE14WWkwM09UWXpMVFEzT0RFdE9UTmgKTUMwNE9UUTROV0poTmpZME9ESXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3ROelJoWTJFek1XSXROemsyTXkwME56Z3hMVGt6WVRBdE9EazBPRFZpWVRZMk5EZ3lMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpENHlRaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUJXYjFSQitXL1dLektUZTdFNmZiTFRXUjMwK2NaL0d1eE9sRUMyK29kWFFaNGJaWWI3NXRNaAphZ0FrSGR3WWl6YjdqNitTMGk3cDhlaEI3SVUvWjY2a0lOampZMXpYblRtWjZXK0NVSFdmb3BSdXQ5NG0xK1k0CkxwOEpEbXBXK3VGajZ4aWpuNGg5T3craU5nQ1c2OGVZSnE5eVFYbjZ1TkJlZndDWlJJd0l0NC9QWlJhRFR2Z0UKVGNobWlKSlEvUVFVV2dXZGFLN29EMVU3bkZhcW9zdm5KREtqbldlMDRhcVJxN2x1YzFVZ3hXdExDcGQ1cEZWRAowWG1QRGcxRjhjRGJwbmh1YmY4SXAzTlU2RmVRYzE5ZGZRRGMvSEV5MEI1amRNbU9GMFJtMkVEZFRsZFVxZzdZCk5WT0tJaVhYZUkzUWIrTklNUklCN2k4RjliTU1ycVhMCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:21 GMT
+      - Mon, 18 Dec 2023 13:02:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8061b9d9-b988-479a-a64b-c5c465f0fd9f
+      - 55c0a14f-6f36-4382-842e-efaf8e266a0c
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=74aca31b-7963-4781-93a0-89485ba66482&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947},"endpoints":[{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947}],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1000"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:21 GMT
+      - Mon, 18 Dec 2023 13:02:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04e8e1a3-81e6-4026-90c1-0f350954efa2
+      - d632c595-7d45-4777-8e4e-8f2fd1ee62ab
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947},"endpoints":[{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947}],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1000"
+      - "1004"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:21 GMT
+      - Mon, 18 Dec 2023 13:02:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 028c53ac-9b1a-4a17-addb-bb52cdf1895e
+      - 77e22012-091e-4bdc-9faf-20af03e82956
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVWEZzaC91RFltRWsyekszYWdoTjd4V1IwV0Rjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZd056QTFXaGNOTXpNeE1URTRNVFl3TnpBMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtKNWhkOWkrdVZDcDBhNEFOdzY5c0FJTHlXaGRVQTJxZG1BZGE3NkxGRjZLSFcrczd0TmJKeE4KRE1HQzNpMEdJNERsb3JwNEFDOENoRVo5cFI4NUlKQkJHNUYrbzYyWDNFNTJUSnpEcnk5aE5GQmJjbmlZOFBLagpoL05KNWh2Ty9yMldjYkU4Tkdua3drVkJKMldDOW1OOUVDTXhlUkxlOU5rQWpISXQ0cGU4VmVzeE9URHZpYmp0CjBhaUk3a1RKNjBhUHNQUkdxRlpkRHROUFJBbGZ5THA3WFU3L29tV2YwT3l2NEN4U3FmZUVPY1U5dm50TS9EMW4KcjduMnF3NkNsZzBMR0hNVnlIZ1c3dnM1UjA3VTJBVENFSFFCcy9UZUloYnI1NlFtVGNxVCtSc1hsT05nd1lnawpvUFdrYXhKNkZnanJvMG1GQy9Fdm9wTlFjSUpjWU84Q0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0TlRSaU1UTXlPR1l0WW1SbE55MDBOek01TFdFNFptWXRZVGRqTVRsaE1tUTQKTmpRd0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckloZ2h3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQi9ZZ1ZSMC9rcUpMM2lWenVvNWNkN1hvSVpWMmp6Z0tabGN5VTlFMXJHN01KUWo2THJ0RE9HCmxINGY5dHNHL2wwcXhtalM2SVZuRjM4QWRQY2ZWM29WSCswR0hjUGFTbzhhY2gyYU5ZZ3Y3SE1DTUxEbUlsczUKRzdrenJxMmZiR1RGYTk5OXd2bU90TnhINGx6UXcySVpaUCszZjFmeTg0RkY5ZnJmdWhKMFhJMi9lVWg2TFlzZQo4a2N3VkFMZzBXY1BVRzFwa3dncVM4bXpxd2drYkNwamlFR1lmakd3dTNiQUtSV0VaSkZTWkw5b2kxRDc0OXIxCllrcFNIdVNhSzJOLzFkN256OGVYSDhVa09VS2VpZFFlVFNxZnd5Y0E1MllpZ1NZbUlJWEtHNThnY0c1cUZNekUKcjFmZVFMck1WU0tZMWRUd1ZpVkJvd2I4Um1NSklncnQKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1004"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:21 GMT
+      - Mon, 18 Dec 2023 13:02:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 529aa9a2-a98c-4f02-a947-c5af08617da7
+      - f038cf48-c0a6-41c5-be63-da9068a5406e
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947},"endpoints":[{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947}],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVQzA4L1F5YmFpZXMzdzBsQnhWVkdHYTVSZC80d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QXhNak5hRncwek16RXlNVFV4TXpBeE1qTmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ1g0ZmJnam9mTHhUcjZYSDFKczMrUWRhcFhpOU5kaW9tN2U5V1lwMmsxVG1OMGEvREoKLzNXM0JNRmIvWTdKQlV1QmdPSndLMU9MNmI3Yzllb25laVMzd090UzdEZnJZakM4dVhna1FVa1diSjFxN1BMcAprc2VNbk03K0pScDV6TTllZXhCWmJJV214OEdGNDdlVldMakkwWmFBanZua200VDkwa2thSHc4L1BCZzErczZRCjcyODhXRjI2ZHU2YkpXQ0JjbDZGcytrOWMvR0NlRzVINmFya3pCL21MQmRGd01yMFhyLysyaTgzYzBXUjY2c1gKNUlIL2J3N0phbTMveW1HVUpBQStUTnRpbUZUSHhGWE9YbUFrTGJnRkhNQXhVM2YwWUM1OXp1RVNvdHVEblVoaQpOdmhtRE5ENnFFdDlzc2hwSFhGc3NiUmF3RlZ2amNxQjVZbVhBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwM05HRmpZVE14WWkwM09UWXpMVFEzT0RFdE9UTmgKTUMwNE9UUTROV0poTmpZME9ESXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3ROelJoWTJFek1XSXROemsyTXkwME56Z3hMVGt6WVRBdE9EazBPRFZpWVRZMk5EZ3lMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpENHlRaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUJXYjFSQitXL1dLektUZTdFNmZiTFRXUjMwK2NaL0d1eE9sRUMyK29kWFFaNGJaWWI3NXRNaAphZ0FrSGR3WWl6YjdqNitTMGk3cDhlaEI3SVUvWjY2a0lOampZMXpYblRtWjZXK0NVSFdmb3BSdXQ5NG0xK1k0CkxwOEpEbXBXK3VGajZ4aWpuNGg5T3craU5nQ1c2OGVZSnE5eVFYbjZ1TkJlZndDWlJJd0l0NC9QWlJhRFR2Z0UKVGNobWlKSlEvUVFVV2dXZGFLN29EMVU3bkZhcW9zdm5KREtqbldlMDRhcVJxN2x1YzFVZ3hXdExDcGQ1cEZWRAowWG1QRGcxRjhjRGJwbmh1YmY4SXAzTlU2RmVRYzE5ZGZRRGMvSEV5MEI1amRNbU9GMFJtMkVEZFRsZFVxZzdZCk5WT0tJaVhYZUkzUWIrTklNUklCN2k4RjliTU1ycVhMCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1000"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:22 GMT
+      - Mon, 18 Dec 2023 13:02:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59856d58-1a1c-4b1d-bbe4-514b39c0b3d8
+      - 636d6d07-efe9-49cf-b16e-8ced772b6f0d
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +970,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=74aca31b-7963-4781-93a0-89485ba66482&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:02:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fdd5bc57-b605-459c-80a4-2450af397b4b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1004"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:02:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df38016a-3108-4ba2-a45a-d09679767305
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947},"endpoints":[{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947}],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1003"
+      - "1007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:22 GMT
+      - Mon, 18 Dec 2023 13:02:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09c93df3-7814-4363-86c5-5a8061d55d8c
+      - 05d21ee1-f192-49c8-b146-f5daef7938c8
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:03:44.455504Z","endpoint":{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947},"endpoints":[{"id":"6cd8a432-5c98-407e-afd2-5a5c2ca7e13d","ip":"51.159.26.205","load_balancer":{},"name":null,"port":19947}],"engine":"MySQL-8","id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.511524Z","endpoint":{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826},"endpoints":[{"id":"0478297d-e823-4303-90ef-eef3a9907a2f","ip":"195.154.197.252","load_balancer":{},"name":null,"port":11826}],"engine":"MySQL-8","id":"74aca31b-7963-4781-93a0-89485ba66482","init_settings":[{"name":"lower_case_table_names","value":"1"}],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-init-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"max_connections","value":"350"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1003"
+      - "1007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:22 GMT
+      - Mon, 18 Dec 2023 13:02:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a16af661-6edf-456c-8290-e639980c7fc1
+      - 33daa89a-5551-4512-ab3a-3947db00a1ad
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,10 +1102,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"74aca31b-7963-4781-93a0-89485ba66482","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1015,7 +1114,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:52 GMT
+      - Mon, 18 Dec 2023 13:02:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fca3bb3-a5fd-43d8-b8ff-0549caf2bf3d
+      - 275174e4-15cf-472d-a789-93848b803ff9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1036,10 +1135,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/54b1328f-bde7-4739-a8ff-a7c19a2d8640
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/74aca31b-7963-4781-93a0-89485ba66482
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"54b1328f-bde7-4739-a8ff-a7c19a2d8640","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"74aca31b-7963-4781-93a0-89485ba66482","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1048,7 +1147,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:52 GMT
+      - Mon, 18 Dec 2023 13:02:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f3fca73-b797-4ff0-9f35-40137a312d3d
+      - 7ef3c357-ef02-432a-a494-fa6d555fd63b
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:54 GMT
+      - Mon, 18 Dec 2023 12:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7b37b98-4417-4aa2-b13d-7fd783c9f9d8
+      - de8a9f3a-ccd0-4670-a24c-2c7db9867bfa
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:13 GMT
+      - Mon, 18 Dec 2023 13:12:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 015aad22-b2e7-4b53-9425-c1fd71b385fe
+      - c9c673cf-02a4-4d42-b654-cb486574308f
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/86935912-ad61-44bc-a510-a7cfa6761fd4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1beb022d-a42b-40cb-b2de-0ec91b4a21af
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:13 GMT
+      - Mon, 18 Dec 2023 13:12:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,75 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36ae26e7-277d-4e27-baa8-67d1086dd436
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"my_private_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2023-11-21T16:12:13.562888Z","dhcp_enabled":true,"id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:12:13.562888Z","id":"39d579a9-a48a-4bb3-991f-5819eb09ac43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:12:13.562888Z"},{"created_at":"2023-11-21T16:12:13.562888Z","id":"6a282a47-3647-4e0d-87d4-c7489e1f3748","subnet":"fd5c:d510:d730:4345::/64","updated_at":"2023-11-21T16:12:13.562888Z"}],"tags":[],"updated_at":"2023-11-21T16:12:13.562888Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
-    headers:
-      Content-Length:
-      - "701"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:12:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7d47ea5f-2019-4c8e-8397-3d95dfad1f42
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3ebe3d56-511d-4433-96ad-e2e9a1be47b0
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:12:13.562888Z","dhcp_enabled":true,"id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:12:13.562888Z","id":"39d579a9-a48a-4bb3-991f-5819eb09ac43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:12:13.562888Z"},{"created_at":"2023-11-21T16:12:13.562888Z","id":"6a282a47-3647-4e0d-87d4-c7489e1f3748","subnet":"fd5c:d510:d730:4345::/64","updated_at":"2023-11-21T16:12:13.562888Z"}],"tags":[],"updated_at":"2023-11-21T16:12:13.562888Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
-    headers:
-      Content-Length:
-      - "701"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:12:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e5104b25-d460-458b-90cb-ce537518a8ed
+      - a9e20217-b0d0-4210-9169-6bc94924cc20
     status: 200 OK
     code: 200
     duration: ""
@@ -480,16 +412,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
-    body: '{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":null,"id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":null,"id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "354"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:14 GMT
+      - Mon, 18 Dec 2023 13:12:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -499,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc1192d3-d04d-45dc-84bc-76d3a54ac472
+      - 8c9310dd-4f23-4bfb-8165-5cdfbc3e9006
     status: 200 OK
     code: 200
     duration: ""
@@ -510,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/49db43d1-fd61-4b7d-ae9f-512a482a252b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/32db68aa-b0f4-4f91-98c3-1edff23c735f
     method: GET
   response:
-    body: '{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":null,"id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":null,"id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "354"
+      - "356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:14 GMT
+      - Mon, 18 Dec 2023 13:12:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -532,12 +464,80 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25a53be9-d336-4be3-9dd3-860e0b85c0cd
+      - 404907bf-5f4e-40e1-98db-0d435607a0bb
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","enable_smtp":false,"enable_bastion":false}'
+    body: '{"name":"my_private_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"172.16.8.0/22","updated_at":"2023-12-18T13:12:05.727743Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:05.727743Z"}],"tags":[],"updated_at":"2023-12-18T13:12:05.727743Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    headers:
+      Content-Length:
+      - "701"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f81c4a6-839d-47d1-8d19-3550c5c8fc6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"172.16.8.0/22","updated_at":"2023-12-18T13:12:05.727743Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:05.727743Z"}],"tags":[],"updated_at":"2023-12-18T13:12:05.727743Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    headers:
+      Content-Length:
+      - "701"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 626dd5a6-fe46-4230-abda-c6ce7a94f1eb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -548,16 +548,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:14.342515Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:06.473486Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "936"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:14 GMT
+      - Mon, 18 Dec 2023 13:12:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -567,7 +567,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62638324-762a-477d-8f13-e6a9c826c2e6
+      - d890f65e-2d0e-4a6b-b0c1-2501efe56576
     status: 200 OK
     code: 200
     duration: ""
@@ -578,19 +578,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:14.399572Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:06.513848Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "939"
+      - "941"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:14 GMT
+      - Mon, 18 Dec 2023 13:12:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -600,12 +600,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31d9b3cf-fef6-4e03-a375-e8f7904eda2a
+      - 8f6c62e0-0e51-463e-bf74-a5490519f56f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-private-network-dhcp","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -616,16 +616,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":null,"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:15 GMT
+      - Mon, 18 Dec 2023 13:12:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -635,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8dc577f8-d6a9-4e66-9047-46aa9bbf522b
+      - 3d959d08-6d1e-42aa-8a65-4a0fbfa4ba40
     status: 200 OK
     code: 200
     duration: ""
@@ -646,19 +646,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":null,"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:15 GMT
+      - Mon, 18 Dec 2023 13:12:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -668,7 +668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90a79c2a-bec9-4d9b-92db-ce7d2c116b0d
+      - f8500093-a68a-45d5-8e8e-27bd15e3de0b
     status: 200 OK
     code: 200
     duration: ""
@@ -679,19 +679,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:15.070844Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:07.117243Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "936"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:19 GMT
+      - Mon, 18 Dec 2023 13:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -701,7 +701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed175c7b-55f3-4efe-abc2-b5f6d2702f79
+      - 42ea3c99-11b8-4fc7-b95b-b4ef2b77cc32
     status: 200 OK
     code: 200
     duration: ""
@@ -712,19 +712,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:15.070844Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:07.117243Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "936"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:19 GMT
+      - Mon, 18 Dec 2023 13:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -734,7 +734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2bccb1c-609c-4da9-abb6-c3b4eb6c605a
+      - 8a28c3f2-7b6f-409d-afd3-1a0016c40bb6
     status: 200 OK
     code: 200
     duration: ""
@@ -745,19 +745,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:15.070844Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:07.117243Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "936"
+      - "938"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:19 GMT
+      - Mon, 18 Dec 2023 13:12:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -767,12 +767,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dda714c6-17fb-4dc5-b2a3-d11f27d93138
+      - 351176e3-0beb-410f-a45d-84cbab8c8357
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"86935912-ad61-44bc-a510-a7cfa6761fd4"}'
+    body: '{"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af"}'
     form: {}
     headers:
       Content-Type:
@@ -783,7 +783,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":null,"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"created","updated_at":"2023-11-21T16:12:20.623566Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":null,"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"created","updated_at":"2023-12-18T13:12:12.805688Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "953"
@@ -792,7 +792,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:20 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -802,7 +802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e65496ae-3fec-4aa1-8256-0d766bfe6f58
+      - 298da923-e02b-4a80-af04-5a84d84c12d4
     status: 200 OK
     code: 200
     duration: ""
@@ -813,19 +813,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":null,"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"created","updated_at":"2023-11-21T16:12:20.623566Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:20.802611Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":null,"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"created","updated_at":"2023-12-18T13:12:12.805688Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:13.004873Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1892"
+      - "1894"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:21 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -835,7 +835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 678814dc-0548-460a-bc60-2c9fb42a3f9d
+      - 29351e36-21b9-4472-893a-b27d98432fff
     status: 200 OK
     code: 200
     duration: ""
@@ -846,19 +846,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":null,"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"created","updated_at":"2023-11-21T16:12:20.623566Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:20.802611Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":null,"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"created","updated_at":"2023-12-18T13:12:12.805688Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:13.004873Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1892"
+      - "1894"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:26 GMT
+      - Mon, 18 Dec 2023 13:12:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -868,7 +868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4aeb1f0e-e557-482f-979e-1d998877fad2
+      - de8254d5-7b0f-415d-9ce4-a66935193525
     status: 200 OK
     code: 200
     duration: ""
@@ -879,19 +879,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1901"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:31 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -901,7 +901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7353338-4016-4fd3-b356-6d89752854e5
+      - 6ed62c34-930c-4d5b-aef4-cfe52cbaf937
     status: 200 OK
     code: 200
     duration: ""
@@ -912,43 +912,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:12:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e60c2a0d-e700-4036-b719-9df4698ade44
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -957,7 +924,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:31 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -967,7 +934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02d85717-e33c-42f4-85e4-99c9060619b6
+      - 87b363b3-e24b-411e-8dd5-3e70aa98accd
     status: 200 OK
     code: 200
     duration: ""
@@ -978,43 +945,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1901"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:12:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a683d83-82cd-4ff5-854e-65960abf23f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -1023,7 +957,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:31 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1033,7 +967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ee931bf-be25-47c9-8c32-5e982150ec14
+      - fbdb00a8-e607-4770-88e3-a3131e9151d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1044,19 +978,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":null,"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "977"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:45 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1066,7 +1000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c64794e9-c3a4-4276-a0c3-102845d55f0d
+      - 06a3b752-1835-43d6-95a6-f3d074492507
     status: 200 OK
     code: 200
     duration: ""
@@ -1077,19 +1011,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":null,"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "977"
+      - "966"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:16 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1099,7 +1033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57d7e613-3f43-4f1c-a856-b13d4f563f08
+      - 3ee65e88-38b2-43da-94b9-596779211dee
     status: 200 OK
     code: 200
     duration: ""
@@ -1110,19 +1044,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":null,"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:46 GMT
+      - Mon, 18 Dec 2023 13:12:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1132,7 +1066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b018b0f7-6404-465f-b2be-6e535217f7d9
+      - 624b3f4a-d3f9-484e-bcec-2fc8f12fdf3a
     status: 200 OK
     code: 200
     duration: ""
@@ -1143,19 +1077,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":null,"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:16 GMT
+      - Mon, 18 Dec 2023 13:13:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1165,7 +1099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f711e45-e4d2-409c-868f-9bc68376a28d
+      - af0d040d-ad47-485c-a27f-61a937dd9a21
     status: 200 OK
     code: 200
     duration: ""
@@ -1176,19 +1110,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":null,"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "977"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:46 GMT
+      - Mon, 18 Dec 2023 13:13:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1198,7 +1132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 235bf801-82ef-4056-846a-ed910c0a75b6
+      - 7d35740b-5679-43ba-a8f6-c7b9cfe2e56b
     status: 200 OK
     code: 200
     duration: ""
@@ -1209,19 +1143,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":null,"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1241"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:17 GMT
+      - Mon, 18 Dec 2023 13:14:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1231,7 +1165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 260b2d80-39aa-46f4-b766-6485e40b5b17
+      - 5de463ba-d88c-4678-a154-602574f8dff1
     status: 200 OK
     code: 200
     duration: ""
@@ -1242,19 +1176,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:47 GMT
+      - Mon, 18 Dec 2023 13:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1264,7 +1198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fa2441b-b87d-4351-8f37-314bd1dfe995
+      - ab16f896-d42f-4be3-918f-df8dc0974fa3
     status: 200 OK
     code: 200
     duration: ""
@@ -1275,19 +1209,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYmdleFBYU0dBaHhnenkxTDJ0ZHhHbHZBbXdRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEl4TVRZeE5URXdXaGNOTXpNeE1URTRNVFl4TlRFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpjNmxIWTdnU1o4ZFRELzhtWUg4Y0tMcUZQYVdwbjhPbG1PK1JHOVM1bld2elZ3d3R5Umk2WFQKamFKK3dGRWhlZ0JMSTZiZ0RBUEZwc3J4ZzR1Q0NNQlFTaEw4ODVEYWdKd0tBYzNHRE5uNkxiVk5DYnlLc1ozNQpHd3BkYnRvWUJuS0pOaWRtdFg1MVR6MU04SlpIcjlSM1FRejhOQnM3NWVjOXJEOG51NzVKV01oZStnV01Wd01VCjNUWHFtTzBIdDhKSUs4SmY2K1dLbzZwenFzS2FDSVdpdGlkVjVwNWI1VkkyTFlIRUhRVDA4RzJxMkpNRTBQNnMKWUIzdjBXRzdKWkZveWF4K3NWS1V2WVJRT01BMU8xRWxNblZxT2dnUDEvY2Z5dGlVTGNKN1N4a2JFRkJaTXFlcApVOENHRTd5c2VhQ0tzaWZ4aGI4NVdIWlc3anhsUHVFQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGhsTnpnek5HTXdMVGxtTldNdE5ETTQKTWkwNVpETXlMV0l5WVRkbVkyWTNPREJpT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlkLzRjRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQjI3RGVLOS9KWGpFYjV1bWN1TG13SDdHCjdpRktoeUdiRjcrYjFNWC9hZU9TN3gxYjYzOUhCWWFNandXTHVnNWQ4SmhhMDlQbnV1YVZ3YnFQOEpnR1ZPRVoKVW1nL1pRM1FiNXNOaGlMM0c0OUZyaFBWR2p5NTRjdTgvUHZhS1B3eFA4K1VjMEJadXVIU1F1bTJmOHU0elVSTApCT3U1NlRnMWVMMnhBY1NVdWkweUxVcFZOWVFhanRodE5acDByRGN6Rml1R1lXdTJFa1RmVmhJZWNjc3J2eVpmCkVVWWZVYUVQZkN0ZFVlOGt6SDExck5wU3lkR0xOUWpadS8yTXJWOVF3THR1SGhxMlZ3SC9OUHFuSGl0OUJpUTcKMGpEVlAvdUxYb2g3SzV2dGFraVJJZE9XRU9adlA3aVRvRnhCUDgrdWNhRkY1REoxaC82Tk9QVEcxNzQvc2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1887"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:47 GMT
+      - Mon, 18 Dec 2023 13:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1297,7 +1231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25cef952-2ae8-4a20-b109-583a4852bf27
+      - c9d1347f-4f8d-4f94-b603-7d48df8abdcd
     status: 200 OK
     code: 200
     duration: ""
@@ -1308,19 +1242,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1901"
+      - "1735"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:47 GMT
+      - Mon, 18 Dec 2023 13:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1330,7 +1264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 271f65d5-1246-4527-a8c2-93275f81badd
+      - 041ee327-532c-4806-9ada-12fb36b477dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1341,19 +1275,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1901"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:47 GMT
+      - Mon, 18 Dec 2023 13:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1363,12 +1297,78 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39efeff3-9b53-4532-be22-08180e3b3b46
+      - 7bf2cd97-d3a2-4a82-9d95-3af714c99e49
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 30ab5eb7-24ac-4483-ac89-c44dd8843993
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5aae22e3-2909-4f67-a136-4cb21776d64b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
@@ -1379,7 +1379,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T16:15:47.658693Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"fc797a64-84fc-4609-85df-7c7ca6a434c3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:15:47.658693Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -1388,7 +1388,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:47 GMT
+      - Mon, 18 Dec 2023 13:15:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1398,7 +1398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 057970f0-e467-4252-a776-1c4999612125
+      - fcbf5bf6-cfd4-4c2f-aedf-fb4e04082b38
     status: 200 OK
     code: 200
     duration: ""
@@ -1409,19 +1409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1901"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:47 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1431,7 +1431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 022833b0-5b8d-4d84-875d-962b5b40b928
+      - a877efd0-f1f5-4d3e-a3ab-b27a1ab46b74
     status: 200 OK
     code: 200
     duration: ""
@@ -1442,10 +1442,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/fc797a64-84fc-4609-85df-7c7ca6a434c3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:15:47.658693Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"fc797a64-84fc-4609-85df-7c7ca6a434c3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:15:47.658693Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -1454,7 +1454,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:47 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1464,7 +1464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcc2fb2a-31b9-4a03-ba02-2a8bc534be8b
+      - 70eca5e9-9d0d-4c05-8629-f51ab4276436
     status: 200 OK
     code: 200
     duration: ""
@@ -1475,19 +1475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:48 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1497,7 +1497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2cf4f47-d851-4e05-8dad-b4b795f644c2
+      - 5f8de29d-4dad-4967-9e06-73b223004f9e
     status: 200 OK
     code: 200
     duration: ""
@@ -1508,19 +1508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/49db43d1-fd61-4b7d-ae9f-512a482a252b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/32db68aa-b0f4-4f91-98c3-1edff23c735f
     method: GET
   response:
-    body: '{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "388"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1530,7 +1530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64e75734-62d6-4ae6-be5d-90f6aca9f09e
+      - d3034d53-f1fe-42a4-aa77-ebc41aed0154
     status: 200 OK
     code: 200
     duration: ""
@@ -1541,43 +1541,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/86935912-ad61-44bc-a510-a7cfa6761fd4
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "568"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7e117868-8100-4090-a344-b4d83a030d14
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3ebe3d56-511d-4433-96ad-e2e9a1be47b0
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:12:13.562888Z","dhcp_enabled":true,"id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:12:13.562888Z","id":"39d579a9-a48a-4bb3-991f-5819eb09ac43","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:20.102021Z"},{"created_at":"2023-11-21T16:12:13.562888Z","id":"6a282a47-3647-4e0d-87d4-c7489e1f3748","subnet":"fd5c:d510:d730:4345::/64","updated_at":"2023-11-21T16:12:20.106890Z"}],"tags":[],"updated_at":"2023-11-21T16:12:27.159738Z","vpc_id":"55e76fec-ea56-4796-9ba0-fb268ffa60f3"}'
+    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:12.252645Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:12.257657Z"}],"tags":[],"updated_at":"2023-12-18T13:12:19.395677Z","vpc_id":"2b3f79e3-074e-4215-8a45-5556223283a1"}'
     headers:
       Content-Length:
       - "702"
@@ -1586,7 +1553,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1596,7 +1563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b2ab7b4-a673-477f-87a0-3d9df5a73f3b
+      - e2fba459-74ff-427b-b39c-40421860d440
     status: 200 OK
     code: 200
     duration: ""
@@ -1607,340 +1574,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1beb022d-a42b-40cb-b2de-0ec91b4a21af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1901"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 851052a7-df3d-4048-a688-47e64e52f0a7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1451"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b3567d6-8f46-4943-9c4e-ca0d88dc63d3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d76158a8-c4e1-4eda-8dbb-2abc8871bde5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1901"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f8acc498-babe-4789-8d11-33cfddd0c8fb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYmdleFBYU0dBaHhnenkxTDJ0ZHhHbHZBbXdRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEl4TVRZeE5URXdXaGNOTXpNeE1URTRNVFl4TlRFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpjNmxIWTdnU1o4ZFRELzhtWUg4Y0tMcUZQYVdwbjhPbG1PK1JHOVM1bld2elZ3d3R5Umk2WFQKamFKK3dGRWhlZ0JMSTZiZ0RBUEZwc3J4ZzR1Q0NNQlFTaEw4ODVEYWdKd0tBYzNHRE5uNkxiVk5DYnlLc1ozNQpHd3BkYnRvWUJuS0pOaWRtdFg1MVR6MU04SlpIcjlSM1FRejhOQnM3NWVjOXJEOG51NzVKV01oZStnV01Wd01VCjNUWHFtTzBIdDhKSUs4SmY2K1dLbzZwenFzS2FDSVdpdGlkVjVwNWI1VkkyTFlIRUhRVDA4RzJxMkpNRTBQNnMKWUIzdjBXRzdKWkZveWF4K3NWS1V2WVJRT01BMU8xRWxNblZxT2dnUDEvY2Z5dGlVTGNKN1N4a2JFRkJaTXFlcApVOENHRTd5c2VhQ0tzaWZ4aGI4NVdIWlc3anhsUHVFQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGhsTnpnek5HTXdMVGxtTldNdE5ETTQKTWkwNVpETXlMV0l5WVRkbVkyWTNPREJpT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlkLzRjRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQjI3RGVLOS9KWGpFYjV1bWN1TG13SDdHCjdpRktoeUdiRjcrYjFNWC9hZU9TN3gxYjYzOUhCWWFNandXTHVnNWQ4SmhhMDlQbnV1YVZ3YnFQOEpnR1ZPRVoKVW1nL1pRM1FiNXNOaGlMM0c0OUZyaFBWR2p5NTRjdTgvUHZhS1B3eFA4K1VjMEJadXVIU1F1bTJmOHU0elVSTApCT3U1NlRnMWVMMnhBY1NVdWkweUxVcFZOWVFhanRodE5acDByRGN6Rml1R1lXdTJFa1RmVmhJZWNjc3J2eVpmCkVVWWZVYUVQZkN0ZFVlOGt6SDExck5wU3lkR0xOUWpadS8yTXJWOVF3THR1SGhxMlZ3SC9OUHFuSGl0OUJpUTcKMGpEVlAvdUxYb2g3SzV2dGFraVJJZE9XRU9adlA3aVRvRnhCUDgrdWNhRkY1REoxaC82Tk9QVEcxNzQvc2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1887"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2c21c2f9-7a87-44c3-a01d-e6d3c18472e7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 80511749-d453-4195-ab8a-7ab835593465
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/fc797a64-84fc-4609-85df-7c7ca6a434c3
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:15:47.658693Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"fc797a64-84fc-4609-85df-7c7ca6a434c3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:15:47.658693Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 559f5f52-dbd5-4445-b384-0f2b20d95bc9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/fc797a64-84fc-4609-85df-7c7ca6a434c3
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:15:47.658693Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"fc797a64-84fc-4609-85df-7c7ca6a434c3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:15:47.658693Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 72ec3881-e308-47dd-b53b-8dd8f7be5331
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1901"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c12df55-89fb-49f5-965f-1e7652494fb2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3ebe3d56-511d-4433-96ad-e2e9a1be47b0
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:12:13.562888Z","dhcp_enabled":true,"id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:12:13.562888Z","id":"39d579a9-a48a-4bb3-991f-5819eb09ac43","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:20.102021Z"},{"created_at":"2023-11-21T16:12:13.562888Z","id":"6a282a47-3647-4e0d-87d4-c7489e1f3748","subnet":"fd5c:d510:d730:4345::/64","updated_at":"2023-11-21T16:12:20.106890Z"}],"tags":[],"updated_at":"2023-11-21T16:12:27.159738Z","vpc_id":"55e76fec-ea56-4796-9ba0-fb268ffa60f3"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bdbb22f1-3699-40d0-8d29-b1a4388c891e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/86935912-ad61-44bc-a510-a7cfa6761fd4
-    method: GET
-  response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -1949,7 +1586,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1959,7 +1596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afb66f66-f96a-4673-ae09-41a505b96d30
+      - 79b328f2-5d1f-4977-85f6-cfbb9e040a95
     status: 200 OK
     code: 200
     duration: ""
@@ -1970,19 +1607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/49db43d1-fd61-4b7d-ae9f-512a482a252b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "388"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1992,7 +1629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b92f664-6a13-4e12-ba84-56f8893a380b
+      - c0401b6f-9862-4cb3-ad8f-a3e69e5294eb
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,109 +1640,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2923e84e-4d16-4a41-a6fc-85b40fadfaec
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1901"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 598a3c4c-647d-4134-b8aa-1b674490911b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1451"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 78e1ee09-fdad-44fd-8c79-97db747d93c1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -2114,7 +1652,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2124,7 +1662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1464001e-eb84-4080-9f18-970332b6c5ee
+      - 2636e6d1-817d-40e6-a6dd-a95c792ccd0d
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,19 +1673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYmdleFBYU0dBaHhnenkxTDJ0ZHhHbHZBbXdRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEl4TVRZeE5URXdXaGNOTXpNeE1URTRNVFl4TlRFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpjNmxIWTdnU1o4ZFRELzhtWUg4Y0tMcUZQYVdwbjhPbG1PK1JHOVM1bld2elZ3d3R5Umk2WFQKamFKK3dGRWhlZ0JMSTZiZ0RBUEZwc3J4ZzR1Q0NNQlFTaEw4ODVEYWdKd0tBYzNHRE5uNkxiVk5DYnlLc1ozNQpHd3BkYnRvWUJuS0pOaWRtdFg1MVR6MU04SlpIcjlSM1FRejhOQnM3NWVjOXJEOG51NzVKV01oZStnV01Wd01VCjNUWHFtTzBIdDhKSUs4SmY2K1dLbzZwenFzS2FDSVdpdGlkVjVwNWI1VkkyTFlIRUhRVDA4RzJxMkpNRTBQNnMKWUIzdjBXRzdKWkZveWF4K3NWS1V2WVJRT01BMU8xRWxNblZxT2dnUDEvY2Z5dGlVTGNKN1N4a2JFRkJaTXFlcApVOENHRTd5c2VhQ0tzaWZ4aGI4NVdIWlc3anhsUHVFQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGhsTnpnek5HTXdMVGxtTldNdE5ETTQKTWkwNVpETXlMV0l5WVRkbVkyWTNPREJpT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlkLzRjRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQjI3RGVLOS9KWGpFYjV1bWN1TG13SDdHCjdpRktoeUdiRjcrYjFNWC9hZU9TN3gxYjYzOUhCWWFNandXTHVnNWQ4SmhhMDlQbnV1YVZ3YnFQOEpnR1ZPRVoKVW1nL1pRM1FiNXNOaGlMM0c0OUZyaFBWR2p5NTRjdTgvUHZhS1B3eFA4K1VjMEJadXVIU1F1bTJmOHU0elVSTApCT3U1NlRnMWVMMnhBY1NVdWkweUxVcFZOWVFhanRodE5acDByRGN6Rml1R1lXdTJFa1RmVmhJZWNjc3J2eVpmCkVVWWZVYUVQZkN0ZFVlOGt6SDExck5wU3lkR0xOUWpadS8yTXJWOVF3THR1SGhxMlZ3SC9OUHFuSGl0OUJpUTcKMGpEVlAvdUxYb2g3SzV2dGFraVJJZE9XRU9adlA3aVRvRnhCUDgrdWNhRkY1REoxaC82Tk9QVEcxNzQvc2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1887"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:50 GMT
+      - Mon, 18 Dec 2023 13:15:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2157,7 +1695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b495207-8047-44db-86a4-970dbee59fff
+      - 4f1b0a94-7da1-4969-ab7f-c6d3ae542d75
     status: 200 OK
     code: 200
     duration: ""
@@ -2168,10 +1706,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/fc797a64-84fc-4609-85df-7c7ca6a434c3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:15:47.658693Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"fc797a64-84fc-4609-85df-7c7ca6a434c3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:15:47.658693Z","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0fa11c7-e4ff-44e5-9ec9-d0152c5fbaee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 24c4f67a-f4d7-4df3-b3b0-7d9da55b116d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1735"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f6a050b-3cd7-4416-8d43-cf16e692d641
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4a79f18-2497-4533-b960-88f5e061f19b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -2180,7 +1850,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2190,7 +1860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0141fc29-7356-4d5b-b574-dc904b0f2da8
+      - 1b1801ef-2fe9-4eae-8dfd-bec3693ca108
     status: 200 OK
     code: 200
     duration: ""
@@ -2201,19 +1871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/32db68aa-b0f4-4f91-98c3-1edff23c735f
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1901"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2223,7 +1893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24a44e96-d8a0-4546-a056-e2b6e6d73199
+      - 66b48610-8307-4ca0-a602-7f271643d504
     status: 200 OK
     code: 200
     duration: ""
@@ -2234,7 +1904,403 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/fc797a64-84fc-4609-85df-7c7ca6a434c3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1beb022d-a42b-40cb-b2de-0ec91b4a21af
+    method: GET
+  response:
+    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "568"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 04b62612-9572-42f1-ae2e-758523a42443
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "283"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73192001-01cf-4d4a-8dc5-1e3ace98ffc5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1406212e-dbdf-405c-bef2-0ee0f9b6441c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aa604e2b-739c-47a8-a947-ae8b9202169f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:12.252645Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:12.257657Z"}],"tags":[],"updated_at":"2023-12-18T13:12:19.395677Z","vpc_id":"2b3f79e3-074e-4215-8a45-5556223283a1"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a020705c-6f90-4c74-baa2-80a06d0b1fcf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a19a8c76-a2da-4693-b71f-fce33697ebfd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 27ce7733-c28f-4317-a5a5-0456d660cf87
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f15840e3-1135-4938-835b-36374fdc4a88
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1735"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 051950b0-33b2-4f99-a111-63c500ecddf4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85687f42-d0a1-464a-955b-4a0afa9212c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "283"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 38baa75f-63d4-4fbf-97ec-5f6454473971
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - caf09f14-a6a9-4c13-ba82-eee25ecf2dbd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
     method: DELETE
   response:
     body: ""
@@ -2244,7 +2310,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2254,7 +2320,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77f22ca9-7d6a-4a33-9775-49006fd3f916
+      - 09fcfbbd-b083-4883-bb6a-4f27d12ce6d5
     status: 204 No Content
     code: 204
     duration: ""
@@ -2265,19 +2331,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1901"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2287,7 +2353,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc9ca968-2ba6-4c05-96fb-92053355cf2c
+      - dd0c7c8f-4445-43f6-b2fe-432e4bd892c9
     status: 200 OK
     code: 200
     duration: ""
@@ -2298,10 +2364,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"ready","updated_at":"2023-11-21T16:12:29.791871Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -2310,7 +2376,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2320,7 +2386,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da66d2b8-aefd-4230-a750-652caa179473
+      - 8c00de2b-d7b7-4016-a333-99fb59364235
     status: 200 OK
     code: 200
     duration: ""
@@ -2331,19 +2397,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2353,7 +2419,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fde9d79-fc28-49ef-8c68-19962a2b0cc3
+      - face7c32-9bf2-47b0-819b-6d35ee323564
     status: 200 OK
     code: 200
     duration: ""
@@ -2364,7 +2430,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2374,7 +2440,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2384,7 +2450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a7994ce-d9c3-4fe4-bb5d-39f322ee40fa
+      - a04d8b20-6a60-49cf-8d8b-45f352e451d1
     status: 204 No Content
     code: 204
     duration: ""
@@ -2395,19 +2461,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2417,7 +2483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6e3573a-ac48-4a5c-9527-3eff0f808121
+      - 15287076-cb91-442d-a7dc-0604222c6239
     status: 200 OK
     code: 200
     duration: ""
@@ -2428,10 +2494,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:12:20.623566Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:12:13.554055Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"86935912-ad61-44bc-a510-a7cfa6761fd4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:13.554055Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"296ce60c-fc64-480e-88d5-21761b047f4f","ipam_config":null,"mac_address":"02:00:00:11:FB:E6","private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","status":"detaching","updated_at":"2023-11-21T16:15:51.393837Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"detaching","updated_at":"2023-12-18T13:15:12.400032Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "970"
@@ -2440,7 +2506,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2450,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fb5ac87-0888-4e7a-b5c4-579e80415524
+      - c988f879-bcae-4ea2-b5ec-91e1cfa4e38e
     status: 200 OK
     code: 200
     duration: ""
@@ -2463,19 +2529,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2485,7 +2551,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1897abed-810f-4b17-bb2f-6ccb26409552
+      - 8350000c-8d01-4a0c-9687-f226deb308c7
     status: 200 OK
     code: 200
     duration: ""
@@ -2496,19 +2562,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:51 GMT
+      - Mon, 18 Dec 2023 13:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2518,7 +2584,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c7fcd66-2ee5-42db-8d7f-5e98bff5f6c0
+      - c178cb89-18d3-4742-868f-1231d36be7dd
     status: 200 OK
     code: 200
     duration: ""
@@ -2529,7 +2595,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/3d31da32-8be4-4f4a-9538-5307fdb8b519
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/aaf7c7fb-ccba-4682-969c-d3f8eb837b37
     method: DELETE
   response:
     body: ""
@@ -2539,7 +2605,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:52 GMT
+      - Mon, 18 Dec 2023 13:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2549,7 +2615,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1c91320-ab0e-40d0-a686-ac7e230c439b
+      - c1f72f1e-b348-4094-92c2-de9a837703e9
     status: 204 No Content
     code: 204
     duration: ""
@@ -2560,19 +2626,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"3d31da32-8be4-4f4a-9538-5307fdb8b519","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1261"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:52 GMT
+      - Mon, 18 Dec 2023 13:15:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2582,7 +2648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3457057c-b3c0-4ae1-b0e1-825d975156d7
+      - a73c392b-f432-45d7-82f0-64cc31437c19
     status: 200 OK
     code: 200
     duration: ""
@@ -2593,10 +2659,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/296ce60c-fc64-480e-88d5-21761b047f4f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"296ce60c-fc64-480e-88d5-21761b047f4f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2605,7 +2671,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:56 GMT
+      - Mon, 18 Dec 2023 13:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2615,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2711960-0e7f-4442-9b08-4dc63048f506
+      - 75833449-2d43-4117-b4f0-c556c3e2aee7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2626,19 +2692,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "937"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:56 GMT
+      - Mon, 18 Dec 2023 13:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2648,7 +2714,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2beda348-0ad5-465a-8afb-3de169325af6
+      - fb4da720-bfb7-4fbc-958a-cd09cc4d2c87
     status: 200 OK
     code: 200
     duration: ""
@@ -2659,10 +2725,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/86935912-ad61-44bc-a510-a7cfa6761fd4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1beb022d-a42b-40cb-b2de-0ec91b4a21af
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"86935912-ad61-44bc-a510-a7cfa6761fd4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2671,7 +2737,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:56 GMT
+      - Mon, 18 Dec 2023 13:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2681,7 +2747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79c4e731-aad9-4ab4-8372-c39383de5bb7
+      - f33bc006-d7fc-4193-bcda-f7075acb969b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2692,19 +2758,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:12:14.342515Z","gateway_networks":[],"id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","ip":{"address":"51.15.97.12","created_at":"2023-11-21T16:12:14.169305Z","gateway_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","id":"49db43d1-fd61-4b7d-ae9f-512a482a252b","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"12-97-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:12:14.169305Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:12:29.916234Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "935"
+      - "937"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:56 GMT
+      - Mon, 18 Dec 2023 13:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2714,7 +2780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99ad9dbd-cca7-422e-b1dd-bc5c94d64c2b
+      - 9c71e152-b322-4108-97ef-98aefe8ac027
     status: 200 OK
     code: 200
     duration: ""
@@ -2725,7 +2791,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -2735,7 +2801,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:56 GMT
+      - Mon, 18 Dec 2023 13:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2745,7 +2811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 160b2722-ce17-4e2a-8bb9-27e2e050a845
+      - d03ee3b5-eaf5-4a04-9780-504ac2600a2d
     status: 204 No Content
     code: 204
     duration: ""
@@ -2756,10 +2822,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/b134f75e-9ae2-4022-b6e2-75ce51d555d2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"b134f75e-9ae2-4022-b6e2-75ce51d555d2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2768,7 +2834,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:56 GMT
+      - Mon, 18 Dec 2023 13:15:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2778,7 +2844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8ad3ba6-aff2-4a6d-859d-c41a7a6ad6f0
+      - c8329d67-730c-4d56-bc31-321c9ff254ca
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2789,7 +2855,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/49db43d1-fd61-4b7d-ae9f-512a482a252b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/32db68aa-b0f4-4f91-98c3-1edff23c735f
     method: DELETE
   response:
     body: ""
@@ -2799,7 +2865,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:57 GMT
+      - Mon, 18 Dec 2023 13:15:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2809,7 +2875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ac1700a-86df-4c6d-8922-54249fce2cd1
+      - b9715e94-94b8-41ba-b8c1-4142c1f794d5
     status: 204 No Content
     code: 204
     duration: ""
@@ -2820,19 +2886,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1035"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:22 GMT
+      - Mon, 18 Dec 2023 13:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2842,7 +2908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dec3f669-aa39-4cda-9176-509fe12bb8cd
+      - bf7cd3d3-4e6c-4c5b-987c-50e7c7f43b48
     status: 200 OK
     code: 200
     duration: ""
@@ -2853,19 +2919,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1035"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:22 GMT
+      - Mon, 18 Dec 2023 13:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2875,7 +2941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 469a931e-0c27-47e0-9046-3972a6105112
+      - 39d288cc-75c9-418e-972b-2e599c25e326
     status: 200 OK
     code: 200
     duration: ""
@@ -2886,19 +2952,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYmdleFBYU0dBaHhnenkxTDJ0ZHhHbHZBbXdRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEl4TVRZeE5URXdXaGNOTXpNeE1URTRNVFl4TlRFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpjNmxIWTdnU1o4ZFRELzhtWUg4Y0tMcUZQYVdwbjhPbG1PK1JHOVM1bld2elZ3d3R5Umk2WFQKamFKK3dGRWhlZ0JMSTZiZ0RBUEZwc3J4ZzR1Q0NNQlFTaEw4ODVEYWdKd0tBYzNHRE5uNkxiVk5DYnlLc1ozNQpHd3BkYnRvWUJuS0pOaWRtdFg1MVR6MU04SlpIcjlSM1FRejhOQnM3NWVjOXJEOG51NzVKV01oZStnV01Wd01VCjNUWHFtTzBIdDhKSUs4SmY2K1dLbzZwenFzS2FDSVdpdGlkVjVwNWI1VkkyTFlIRUhRVDA4RzJxMkpNRTBQNnMKWUIzdjBXRzdKWkZveWF4K3NWS1V2WVJRT01BMU8xRWxNblZxT2dnUDEvY2Z5dGlVTGNKN1N4a2JFRkJaTXFlcApVOENHRTd5c2VhQ0tzaWZ4aGI4NVdIWlc3anhsUHVFQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGhsTnpnek5HTXdMVGxtTldNdE5ETTQKTWkwNVpETXlMV0l5WVRkbVkyWTNPREJpT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlkLzRjRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQjI3RGVLOS9KWGpFYjV1bWN1TG13SDdHCjdpRktoeUdiRjcrYjFNWC9hZU9TN3gxYjYzOUhCWWFNandXTHVnNWQ4SmhhMDlQbnV1YVZ3YnFQOEpnR1ZPRVoKVW1nL1pRM1FiNXNOaGlMM0c0OUZyaFBWR2p5NTRjdTgvUHZhS1B3eFA4K1VjMEJadXVIU1F1bTJmOHU0elVSTApCT3U1NlRnMWVMMnhBY1NVdWkweUxVcFZOWVFhanRodE5acDByRGN6Rml1R1lXdTJFa1RmVmhJZWNjc3J2eVpmCkVVWWZVYUVQZkN0ZFVlOGt6SDExck5wU3lkR0xOUWpadS8yTXJWOVF3THR1SGhxMlZ3SC9OUHFuSGl0OUJpUTcKMGpEVlAvdUxYb2g3SzV2dGFraVJJZE9XRU9adlA3aVRvRnhCUDgrdWNhRkY1REoxaC82Tk9QVEcxNzQvc2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1887"
+      - "1735"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:22 GMT
+      - Mon, 18 Dec 2023 13:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2908,7 +2974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2da74d8c-2501-41aa-a667-4c007c3e90e6
+      - 114aee9c-e5a9-4ace-9ccc-05943fdb8420
     status: 200 OK
     code: 200
     duration: ""
@@ -2919,10 +2985,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3ebe3d56-511d-4433-96ad-e2e9a1be47b0
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:12:13.562888Z","dhcp_enabled":true,"id":"3ebe3d56-511d-4433-96ad-e2e9a1be47b0","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:12:13.562888Z","id":"39d579a9-a48a-4bb3-991f-5819eb09ac43","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:12:20.102021Z"},{"created_at":"2023-11-21T16:12:13.562888Z","id":"6a282a47-3647-4e0d-87d4-c7489e1f3748","subnet":"fd5c:d510:d730:4345::/64","updated_at":"2023-11-21T16:12:20.106890Z"}],"tags":[],"updated_at":"2023-11-21T16:15:51.545309Z","vpc_id":"55e76fec-ea56-4796-9ba0-fb268ffa60f3"}'
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 651266bd-236c-4d35-abf4-02fd15f1bc6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:12.252645Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:12.257657Z"}],"tags":[],"updated_at":"2023-12-18T13:15:12.580185Z","vpc_id":"2b3f79e3-074e-4215-8a45-5556223283a1"}'
     headers:
       Content-Length:
       - "702"
@@ -2931,7 +3030,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:23 GMT
+      - Mon, 18 Dec 2023 13:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2941,7 +3040,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f0e9a46-edec-4276-b35a-93bbe79b93a0
+      - 1c913761-51cd-4c0a-976a-e101b496138f
     status: 200 OK
     code: 200
     duration: ""
@@ -2952,19 +3051,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1035"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:23 GMT
+      - Mon, 18 Dec 2023 13:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2974,7 +3073,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5e5dfaa-fe02-4fff-8b38-bcab7dddc946
+      - 52655dba-4e3c-45bc-98d2-8f633fbf721d
     status: 200 OK
     code: 200
     duration: ""
@@ -2985,19 +3084,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR1akNDQXFLZ0F3SUJBZ0lVYmdleFBYU0dBaHhnenkxTDJ0ZHhHbHZBbXdRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNVEl4TVRZeE5URXdXaGNOTXpNeE1URTRNVFl4TlRFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUpjNmxIWTdnU1o4ZFRELzhtWUg4Y0tMcUZQYVdwbjhPbG1PK1JHOVM1bld2elZ3d3R5Umk2WFQKamFKK3dGRWhlZ0JMSTZiZ0RBUEZwc3J4ZzR1Q0NNQlFTaEw4ODVEYWdKd0tBYzNHRE5uNkxiVk5DYnlLc1ozNQpHd3BkYnRvWUJuS0pOaWRtdFg1MVR6MU04SlpIcjlSM1FRejhOQnM3NWVjOXJEOG51NzVKV01oZStnV01Wd01VCjNUWHFtTzBIdDhKSUs4SmY2K1dLbzZwenFzS2FDSVdpdGlkVjVwNWI1VkkyTFlIRUhRVDA4RzJxMkpNRTBQNnMKWUIzdjBXRzdKWkZveWF4K3NWS1V2WVJRT01BMU8xRWxNblZxT2dnUDEvY2Z5dGlVTGNKN1N4a2JFRkJaTXFlcApVOENHRTd5c2VhQ0tzaWZ4aGI4NVdIWlc3anhsUHVFQ0F3RUFBYU44TUhvd2VBWURWUjBSQkhFd2I0SU5NVGt5CkxqRTJPQzR4TGpJMU5JSU9OVEV1TVRVNExqRXpNUzR4T1RHQ1BISjNMVGhsTnpnek5HTXdMVGxtTldNdE5ETTQKTWkwNVpETXlMV0l5WVRkbVkyWTNPREJpT0M1eVpHSXVibXd0WVcxekxuTmpkeTVqYkc5MVpJY0VNdzlkLzRjRQp3S2dCL29jRU01NkR2ekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQjI3RGVLOS9KWGpFYjV1bWN1TG13SDdHCjdpRktoeUdiRjcrYjFNWC9hZU9TN3gxYjYzOUhCWWFNandXTHVnNWQ4SmhhMDlQbnV1YVZ3YnFQOEpnR1ZPRVoKVW1nL1pRM1FiNXNOaGlMM0c0OUZyaFBWR2p5NTRjdTgvUHZhS1B3eFA4K1VjMEJadXVIU1F1bTJmOHU0elVSTApCT3U1NlRnMWVMMnhBY1NVdWkweUxVcFZOWVFhanRodE5acDByRGN6Rml1R1lXdTJFa1RmVmhJZWNjc3J2eVpmCkVVWWZVYUVQZkN0ZFVlOGt6SDExck5wU3lkR0xOUWpadS8yTXJWOVF3THR1SGhxMlZ3SC9OUHFuSGl0OUJpUTcKMGpEVlAvdUxYb2g3SzV2dGFraVJJZE9XRU9adlA3aVRvRnhCUDgrdWNhRkY1REoxaC82Tk9QVEcxNzQvc2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1887"
+      - "1735"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:23 GMT
+      - Mon, 18 Dec 2023 13:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3007,7 +3106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eff34994-b32e-4f55-95b0-da3f7ad6fa14
+      - e3e81fd9-7b6d-46db-8328-2db6ec8da79a
     status: 200 OK
     code: 200
     duration: ""
@@ -3018,19 +3117,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1230"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:24 GMT
+      - Mon, 18 Dec 2023 13:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3040,7 +3139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc8a8e49-91d2-478d-b365-3083d60d7e0f
+      - 4d31093f-0a18-4e3c-8ad4-586b829dafc6
     status: 200 OK
     code: 200
     duration: ""
@@ -3051,7 +3150,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/3ebe3d56-511d-4433-96ad-e2e9a1be47b0
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1035"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aaa3ce22-6b2f-483f-baaa-ed0d5c6f30db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
     method: DELETE
   response:
     body: ""
@@ -3061,7 +3193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:24 GMT
+      - Mon, 18 Dec 2023 13:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3071,7 +3203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba7a0948-9138-44b6-954c-4e7f79a33294
+      - b4f33efb-828e-441f-8f03-1eb56cd1d1af
     status: 204 No Content
     code: 204
     duration: ""
@@ -3082,19 +3214,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1233"
+      - "1038"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:24 GMT
+      - Mon, 18 Dec 2023 13:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3104,7 +3236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7172fc2-334f-47ce-ba34-e702cf3d4c6c
+      - 92c50d36-03f4-49d4-bdd1-512a8efeb324
     status: 200 OK
     code: 200
     duration: ""
@@ -3115,19 +3247,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:12:14.788419Z","endpoint":{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659},"endpoints":[{"id":"20aa8366-3deb-4389-b51c-97b791e31e8a","ip":"51.158.131.191","load_balancer":{},"name":null,"port":8659}],"engine":"PostgreSQL-15","id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1233"
+      - "1038"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:24 GMT
+      - Mon, 18 Dec 2023 13:15:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3137,7 +3269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3755c425-b845-45ce-be08-88d7d0bbc931
+      - 3c915dcb-3bce-49dd-a974-2f522113c884
     status: 200 OK
     code: 200
     duration: ""
@@ -3148,10 +3280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"50542597-2b06-4638-b994-75a604f5f044","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3160,7 +3292,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:54 GMT
+      - Mon, 18 Dec 2023 13:16:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3170,7 +3302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22c9fb10-b20f-49fe-9c8e-d2855f12b969
+      - 625a781f-8b82-4559-a8c4-b0a769ff7a37
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3181,10 +3313,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/8e7834c0-9f5c-4382-9d32-b2a7fcf780b8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"8e7834c0-9f5c-4382-9d32-b2a7fcf780b8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"50542597-2b06-4638-b994-75a604f5f044","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3193,7 +3325,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:54 GMT
+      - Mon, 18 Dec 2023 13:16:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3203,7 +3335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d98a662-2b58-4655-be4a-53e6294784a7
+      - 5d7ac595-379d-4714-9107-6a0f1a10fb11
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network-update.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-update.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:53 GMT
+      - Mon, 18 Dec 2023 12:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a5c6223-e186-46b6-ae2c-75a00d3a5e8d
+      - f2e1ffa5-d966-4b3d-9520-f89fab5af7e6
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T16:13:31.024012Z","dhcp_enabled":true,"id":"b5640e59-9d96-4055-98ef-4b940637a62c","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:13:31.024012Z","id":"5cd5f581-239e-47d6-b0f0-1d67151fbc5b","subnet":"172.16.32.0/22","updated_at":"2023-11-21T16:13:31.024012Z"},{"created_at":"2023-11-21T16:13:31.024012Z","id":"1062875f-dfec-4962-9c67-da2c125eb56c","subnet":"fd5f:519c:6d46:8c16::/64","updated_at":"2023-11-21T16:13:31.024012Z"}],"tags":[],"updated_at":"2023-11-21T16:13:31.024012Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "702"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:31 GMT
+      - Mon, 18 Dec 2023 13:11:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08b6e639-211f-430d-8999-2398de22bffb
+      - 6a7779d6-b052-4d3b-8052-ecc2715ad7c9
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b5640e59-9d96-4055-98ef-4b940637a62c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:13:31.024012Z","dhcp_enabled":true,"id":"b5640e59-9d96-4055-98ef-4b940637a62c","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:13:31.024012Z","id":"5cd5f581-239e-47d6-b0f0-1d67151fbc5b","subnet":"172.16.32.0/22","updated_at":"2023-11-21T16:13:31.024012Z"},{"created_at":"2023-11-21T16:13:31.024012Z","id":"1062875f-dfec-4962-9c67-da2c125eb56c","subnet":"fd5f:519c:6d46:8c16::/64","updated_at":"2023-11-21T16:13:31.024012Z"}],"tags":[],"updated_at":"2023-11-21T16:13:31.024012Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "702"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:31 GMT
+      - Mon, 18 Dec 2023 13:11:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,78 +396,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f33dc73-b2ae-43b1-a318-85cae6de64d9
+      - c99097d6-741b-4587-a706-5e1cd7901748
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b5640e59-9d96-4055-98ef-4b940637a62c
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:13:31.024012Z","dhcp_enabled":true,"id":"b5640e59-9d96-4055-98ef-4b940637a62c","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:13:31.024012Z","id":"5cd5f581-239e-47d6-b0f0-1d67151fbc5b","subnet":"172.16.32.0/22","updated_at":"2023-11-21T16:13:31.024012Z"},{"created_at":"2023-11-21T16:13:31.024012Z","id":"1062875f-dfec-4962-9c67-da2c125eb56c","subnet":"fd5f:519c:6d46:8c16::/64","updated_at":"2023-11-21T16:13:31.024012Z"}],"tags":[],"updated_at":"2023-11-21T16:13:31.024012Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:13:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4843f63b-3e1a-49fd-a440-63e3c53d46ae
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b5640e59-9d96-4055-98ef-4b940637a62c
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:13:31.024012Z","dhcp_enabled":true,"id":"b5640e59-9d96-4055-98ef-4b940637a62c","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:13:31.024012Z","id":"5cd5f581-239e-47d6-b0f0-1d67151fbc5b","subnet":"172.16.32.0/22","updated_at":"2023-11-21T16:13:31.024012Z"},{"created_at":"2023-11-21T16:13:31.024012Z","id":"1062875f-dfec-4962-9c67-da2c125eb56c","subnet":"fd5f:519c:6d46:8c16::/64","updated_at":"2023-11-21T16:13:31.024012Z"}],"tags":[],"updated_at":"2023-11-21T16:13:31.024012Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:13:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - da5e85e9-cfd7-4531-9740-6668b69a761c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","ipam_config":{}}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-private-network-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","ipam_config":{}}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -478,16 +412,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:33 GMT
+      - Mon, 18 Dec 2023 13:11:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b968650c-dcf6-442d-b8b5-8a234315046d
+      - a52baf06-6952-42c4-a3ba-74b8ecfab673
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:33 GMT
+      - Mon, 18 Dec 2023 13:11:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 726dd847-ecdf-4267-997a-135a52b18ac6
+      - 58244741-5c7f-432b-bd66-d50e056de424
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:04 GMT
+      - Mon, 18 Dec 2023 13:11:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 358cff3d-f253-4209-8a69-f3aef3c63122
+      - 472b0afd-0f72-4e86-8206-7be5193b9aa2
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:34 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10a6c042-fbd8-44a5-8720-4682b6ecc08b
+      - 7f47098d-b6c1-400b-b427-207fa399efa2
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:04 GMT
+      - Mon, 18 Dec 2023 13:12:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 037a2e1c-c596-488a-a3ec-d4299c25dccf
+      - 655e1617-7cd7-4895-a639-44a364c4ded8
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:34 GMT
+      - Mon, 18 Dec 2023 13:13:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90bdd8eb-650f-4400-8efa-4932440f0a55
+      - 4a65dcb2-a664-4a6d-8da9-80b82c14eba1
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:04 GMT
+      - Mon, 18 Dec 2023 13:13:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70970141-eaa1-4cdd-ac66-f5ec231b37f8
+      - 746a42af-878a-4598-ac49-85fb7f595af7
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "973"
+      - "1253"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:34 GMT
+      - Mon, 18 Dec 2023 13:14:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cad30248-9101-46eb-b2c0-b4d6770d9e41
+      - dc5ede8f-48c9-424a-b55f-93fa9f0c78c3
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":null,"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1237"
+      - "1723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:05 GMT
+      - Mon, 18 Dec 2023 13:14:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec856428-96f4-436d-81fe-88a41374471b
+      - 2caa5dc4-2af5-4a8f-ad45-93c984acd14a
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"ips":[{"address":"172.16.32.2/22","created_at":"2023-12-18T13:11:12.333430Z","id":"07b72054-9c99-4864-ad2c-34d33190028d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:10","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:11:55.863244Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1449"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:35 GMT
+      - Mon, 18 Dec 2023 13:14:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57902f26-7386-4350-b352-85e7c5a426b6
+      - be098fc0-e2c1-4750-b4f9-33a84a59993a
     status: 200 OK
     code: 200
     duration: ""
@@ -805,76 +739,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVWDlqbkxpOHYzSkFWVERGMllVekhNd3NXcmwwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXlNVEUyTVRZMU9Gb1hEVE16TVRFeE9ERTJNVFkxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFockpDMkV3OGhMc21scFg0RlA0TjVTTzgwZ2JtdlJYWjFCOXdkbmhjR3BUMW9LK1NIejd3T1RialVSbG0KRFppOHNOd09Sd2JsV0liQmNleTlvbjVpbXBBbzRYL1FtRVI5dGFNVDZydGJXRS9IbzBMRU83NXlqaVJlc3hiVApLOEp1clNFN0l3Nnd6eXM1T2VUN1R2RWw3UDU1S01uODlSQlczYm0rRFJMMUpmV2YxOU5jQkphZnFLNVJ2Ym9wCjRhUklWNGVXeldLQkUreW5tT2FlMXNJenZYNy9xeDJldjRmbnBGVXB0QW5SZm1GUVd3d1NCTWNQeDFudXAvcmEKQ1hOdWpDS2RKRlFXV0VHVVpYQ3A3bWRyNWdlam5WaVN3djUzdWs0SHltamI2Njg5M0RGQXhtTVZBd3NDWUp3ZwpxMHFiK1NraldSVXJHeW1VSHVYMVZUaitUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck16SXVNb0lPTVRrMUxqRTFOQzQzTUM0eU1ET0NQSEozTFRWak1XRTNOamc0TFRrMVpUa3RORFUwWWkxaU0yVmoKTFdVeFpUVmxPREJrTmpGa1l5NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5SVlJY0VyQkFnQW9jRQp3NXBHeXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWNZelFZUWVoTWZ4dVd3RmlQSEdralVHajAycnd5NHZzCmtoN3R1YXYra0tJeGY5cWZpVmVOUWJpMkhhUm5BYitxdXA2YXc1S0VYeFdCbFVJZURxVUR1RVBkWGZZaWdldmwKeUVKaXh1USt3OVJBQmtUemxZOW8vZ3NmR0FXWVJ3VWo2UnRYOGhqY3V4YVZGK0pYdXRRNG5zYmNZdmRWcWFmMQp6V3RXNktmb2dzNkZkZmI3RzJnaWUvSSs5bXZKejJyY3luUmhqd0lhS3Z4OTJPRS8rMzVpbjJwajkvc054Nlc3CnpRa1lpNVdwTmtGMVBJbTF4S29mSGZJM05vWFVjeUpCWjhkVklyNzBZUDhCMmc0OTNGQ2VqZi9UdEdydFVFQmgKdTlsSk4rYlhQRUIrRU5xNjZBY2lGVlg2UVV2UzVVTWtVWVhjV2dxTVNpbU9nMDJZQUtPNnhRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1875"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:17:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f3d84468-04e1-4931-85ad-177efbfc7734
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1449"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:17:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4c4b8ecc-8816-4ccc-9d2d-31b5dedc4139
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b5640e59-9d96-4055-98ef-4b940637a62c
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:13:31.024012Z","dhcp_enabled":true,"id":"b5640e59-9d96-4055-98ef-4b940637a62c","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:13:31.024012Z","id":"5cd5f581-239e-47d6-b0f0-1d67151fbc5b","subnet":"172.16.32.0/22","updated_at":"2023-11-21T16:13:31.024012Z"},{"created_at":"2023-11-21T16:13:31.024012Z","id":"1062875f-dfec-4962-9c67-da2c125eb56c","subnet":"fd5f:519c:6d46:8c16::/64","updated_at":"2023-11-21T16:13:31.024012Z"}],"tags":[],"updated_at":"2023-11-21T16:13:31.024012Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "702"
@@ -883,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:36 GMT
+      - Mon, 18 Dec 2023 13:14:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ba79799-3e57-4b77-8459-5ae7d784bec5
+      - 58906fe0-55da-42b9-90fc-ee31683ad66f
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1449"
+      - "1253"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:36 GMT
+      - Mon, 18 Dec 2023 13:14:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa2fae23-f2ac-4384-a434-c3ced48159ce
+      - a90837a7-654c-47dd-94b8-f9208e8b8b8c
     status: 200 OK
     code: 200
     duration: ""
@@ -937,43 +805,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVWDlqbkxpOHYzSkFWVERGMllVekhNd3NXcmwwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXlNVEUyTVRZMU9Gb1hEVE16TVRFeE9ERTJNVFkxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFockpDMkV3OGhMc21scFg0RlA0TjVTTzgwZ2JtdlJYWjFCOXdkbmhjR3BUMW9LK1NIejd3T1RialVSbG0KRFppOHNOd09Sd2JsV0liQmNleTlvbjVpbXBBbzRYL1FtRVI5dGFNVDZydGJXRS9IbzBMRU83NXlqaVJlc3hiVApLOEp1clNFN0l3Nnd6eXM1T2VUN1R2RWw3UDU1S01uODlSQlczYm0rRFJMMUpmV2YxOU5jQkphZnFLNVJ2Ym9wCjRhUklWNGVXeldLQkUreW5tT2FlMXNJenZYNy9xeDJldjRmbnBGVXB0QW5SZm1GUVd3d1NCTWNQeDFudXAvcmEKQ1hOdWpDS2RKRlFXV0VHVVpYQ3A3bWRyNWdlam5WaVN3djUzdWs0SHltamI2Njg5M0RGQXhtTVZBd3NDWUp3ZwpxMHFiK1NraldSVXJHeW1VSHVYMVZUaitUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck16SXVNb0lPTVRrMUxqRTFOQzQzTUM0eU1ET0NQSEozTFRWak1XRTNOamc0TFRrMVpUa3RORFUwWWkxaU0yVmoKTFdVeFpUVmxPREJrTmpGa1l5NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5SVlJY0VyQkFnQW9jRQp3NXBHeXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWNZelFZUWVoTWZ4dVd3RmlQSEdralVHajAycnd5NHZzCmtoN3R1YXYra0tJeGY5cWZpVmVOUWJpMkhhUm5BYitxdXA2YXc1S0VYeFdCbFVJZURxVUR1RVBkWGZZaWdldmwKeUVKaXh1USt3OVJBQmtUemxZOW8vZ3NmR0FXWVJ3VWo2UnRYOGhqY3V4YVZGK0pYdXRRNG5zYmNZdmRWcWFmMQp6V3RXNktmb2dzNkZkZmI3RzJnaWUvSSs5bXZKejJyY3luUmhqd0lhS3Z4OTJPRS8rMzVpbjJwajkvc054Nlc3CnpRa1lpNVdwTmtGMVBJbTF4S29mSGZJM05vWFVjeUpCWjhkVklyNzBZUDhCMmc0OTNGQ2VqZi9UdEdydFVFQmgKdTlsSk4rYlhQRUIrRU5xNjZBY2lGVlg2UVV2UzVVTWtVWVhjV2dxTVNpbU9nMDJZQUtPNnhRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1875"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:17:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a1e68562-9522-4b5d-a557-3692a2c634da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b5640e59-9d96-4055-98ef-4b940637a62c
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:13:31.024012Z","dhcp_enabled":true,"id":"b5640e59-9d96-4055-98ef-4b940637a62c","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:13:31.024012Z","id":"5cd5f581-239e-47d6-b0f0-1d67151fbc5b","subnet":"172.16.32.0/22","updated_at":"2023-11-21T16:13:31.024012Z"},{"created_at":"2023-11-21T16:13:31.024012Z","id":"1062875f-dfec-4962-9c67-da2c125eb56c","subnet":"fd5f:519c:6d46:8c16::/64","updated_at":"2023-11-21T16:13:31.024012Z"}],"tags":[],"updated_at":"2023-11-21T16:13:31.024012Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "702"
@@ -982,7 +817,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:36 GMT
+      - Mon, 18 Dec 2023 13:14:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fcbf8e4-32d6-4909-b41a-b72c2ecf9c6e
+      - 61fed899-8ce9-4dc7-9c01-83fded566cd6
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1449"
+      - "1253"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:36 GMT
+      - Mon, 18 Dec 2023 13:14:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 667fd11a-386b-4fcb-90f1-6337e8f94134
+      - 6079955b-e121-44e3-9811-e316f9db2cd1
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVWDlqbkxpOHYzSkFWVERGMllVekhNd3NXcmwwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXlNVEUyTVRZMU9Gb1hEVE16TVRFeE9ERTJNVFkxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFockpDMkV3OGhMc21scFg0RlA0TjVTTzgwZ2JtdlJYWjFCOXdkbmhjR3BUMW9LK1NIejd3T1RialVSbG0KRFppOHNOd09Sd2JsV0liQmNleTlvbjVpbXBBbzRYL1FtRVI5dGFNVDZydGJXRS9IbzBMRU83NXlqaVJlc3hiVApLOEp1clNFN0l3Nnd6eXM1T2VUN1R2RWw3UDU1S01uODlSQlczYm0rRFJMMUpmV2YxOU5jQkphZnFLNVJ2Ym9wCjRhUklWNGVXeldLQkUreW5tT2FlMXNJenZYNy9xeDJldjRmbnBGVXB0QW5SZm1GUVd3d1NCTWNQeDFudXAvcmEKQ1hOdWpDS2RKRlFXV0VHVVpYQ3A3bWRyNWdlam5WaVN3djUzdWs0SHltamI2Njg5M0RGQXhtTVZBd3NDWUp3ZwpxMHFiK1NraldSVXJHeW1VSHVYMVZUaitUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck16SXVNb0lPTVRrMUxqRTFOQzQzTUM0eU1ET0NQSEozTFRWak1XRTNOamc0TFRrMVpUa3RORFUwWWkxaU0yVmoKTFdVeFpUVmxPREJrTmpGa1l5NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5SVlJY0VyQkFnQW9jRQp3NXBHeXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWNZelFZUWVoTWZ4dVd3RmlQSEdralVHajAycnd5NHZzCmtoN3R1YXYra0tJeGY5cWZpVmVOUWJpMkhhUm5BYitxdXA2YXc1S0VYeFdCbFVJZURxVUR1RVBkWGZZaWdldmwKeUVKaXh1USt3OVJBQmtUemxZOW8vZ3NmR0FXWVJ3VWo2UnRYOGhqY3V4YVZGK0pYdXRRNG5zYmNZdmRWcWFmMQp6V3RXNktmb2dzNkZkZmI3RzJnaWUvSSs5bXZKejJyY3luUmhqd0lhS3Z4OTJPRS8rMzVpbjJwajkvc054Nlc3CnpRa1lpNVdwTmtGMVBJbTF4S29mSGZJM05vWFVjeUpCWjhkVklyNzBZUDhCMmc0OTNGQ2VqZi9UdEdydFVFQmgKdTlsSk4rYlhQRUIrRU5xNjZBY2lGVlg2UVV2UzVVTWtVWVhjV2dxTVNpbU9nMDJZQUtPNnhRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1875"
+      - "1723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:37 GMT
+      - Mon, 18 Dec 2023 13:14:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 603f9d1c-12dc-464d-8d37-05ac8f3e4f54
+      - f0c38146-6012-4fd6-99f8-c4d02103a916
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"ips":[{"address":"172.16.32.2/22","created_at":"2023-12-18T13:11:12.333430Z","id":"07b72054-9c99-4864-ad2c-34d33190028d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:10","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:11:55.863244Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1449"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:37 GMT
+      - Mon, 18 Dec 2023 13:14:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3de9ea19-aadd-4d58-9c0c-616d9b28c4d0
+      - 6b8a64ab-dc31-4149-8285-9f750dbbbb43
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1449"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:37 GMT
+      - Mon, 18 Dec 2023 13:14:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +959,240 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a78f6cb7-8929-4ad8-b8e0-a21e937df1bc
+      - de34ca50-56a8-4fdd-8e10-c400c06cb303
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90c65e46-c83b-4294-80a0-4df0a40379d6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c124070-51ea-419a-8e28-608bd5a0cf2d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.32.2/22","created_at":"2023-12-18T13:11:12.333430Z","id":"07b72054-9c99-4864-ad2c-34d33190028d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:10","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:11:55.863244Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "528"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61f9249c-fc3e-44e6-acbf-e1710be92ac4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"my_second_private_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 020cd957-340e-4908-a251-820a393b136d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee0425fa-350e-46db-a12c-124d634d7712
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ccf20c0-8da1-4655-a52c-7c2686587f71
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35800d3a-45a0-4d69-9f06-7626efa98c9d
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1205,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1449"
+      - "1253"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:38 GMT
+      - Mon, 18 Dec 2023 13:14:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 770fcc29-468e-496e-b8ae-e4d1569ace75
+      - 0ed6ef6e-d3ae-48bf-b02d-9e9a8e1f58cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1449"
+      - "1253"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:38 GMT
+      - Mon, 18 Dec 2023 13:14:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50e1f85e-b701-4f1d-bada-db0545132e96
+      - dfbf0a83-cec4-4f49-99ba-82fdc26bcde5
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,7 +1271,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/3644308c-8bee-4082-9650-c429004418c7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/da8c6a95-e2f9-497d-9fff-7c94237a17ae
     method: DELETE
   response:
     body: ""
@@ -1213,7 +1281,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:38 GMT
+      - Mon, 18 Dec 2023 13:14:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94b42ced-4273-4a95-8c4b-0199218b0819
+      - 16e24149-184c-4be3-9a03-9f9ccddd91e2
     status: 204 No Content
     code: 204
     duration: ""
@@ -1234,19 +1302,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"3644308c-8bee-4082-9650-c429004418c7","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.2/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1455"
+      - "1259"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:38 GMT
+      - Mon, 18 Dec 2023 13:14:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32f93a05-6ab6-4d2a-a792-c1269f04817a
+      - 91890826-fcb8-4fff-b240-4bcb99124c1d
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1037"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:09 GMT
+      - Mon, 18 Dec 2023 13:14:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,12 +1357,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7db082fc-bfe8-402f-8dc4-80d7efb39d6a
+      - 4053286c-c779-4f2a-844c-30f8a89a75bf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","ipam_config":{}}}}'
     form: {}
     headers:
       Content-Type:
@@ -1302,19 +1370,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/endpoints
     method: POST
   response:
-    body: '{"id":"4922744d-a7f5-4f08-9dcc-9e2f0bad7a50","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}'
+    body: '{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "216"
+      - "218"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:09 GMT
+      - Mon, 18 Dec 2023 13:14:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83e6dc68-5731-4ff0-9da4-cea4a6ccf1b4
+      - eefd8bd8-f006-4011-a919-9d3c4e42b412
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1403,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"4922744d-a7f5-4f08-9dcc-9e2f0bad7a50","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1456"
+      - "1262"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:09 GMT
+      - Mon, 18 Dec 2023 13:14:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20c2765d-dd76-423f-950a-bbd45a217783
+      - 42ad1971-a4bc-48ad-be48-647bb1282dad
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1436,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"4922744d-a7f5-4f08-9dcc-9e2f0bad7a50","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1449"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:39 GMT
+      - Mon, 18 Dec 2023 13:15:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be07a962-256d-474e-9af4-a598191d8b29
+      - 66a57e09-e77c-4863-bf1f-f80b4a77da9d
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVWDlqbkxpOHYzSkFWVERGMllVekhNd3NXcmwwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXlNVEUyTVRZMU9Gb1hEVE16TVRFeE9ERTJNVFkxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFockpDMkV3OGhMc21scFg0RlA0TjVTTzgwZ2JtdlJYWjFCOXdkbmhjR3BUMW9LK1NIejd3T1RialVSbG0KRFppOHNOd09Sd2JsV0liQmNleTlvbjVpbXBBbzRYL1FtRVI5dGFNVDZydGJXRS9IbzBMRU83NXlqaVJlc3hiVApLOEp1clNFN0l3Nnd6eXM1T2VUN1R2RWw3UDU1S01uODlSQlczYm0rRFJMMUpmV2YxOU5jQkphZnFLNVJ2Ym9wCjRhUklWNGVXeldLQkUreW5tT2FlMXNJenZYNy9xeDJldjRmbnBGVXB0QW5SZm1GUVd3d1NCTWNQeDFudXAvcmEKQ1hOdWpDS2RKRlFXV0VHVVpYQ3A3bWRyNWdlam5WaVN3djUzdWs0SHltamI2Njg5M0RGQXhtTVZBd3NDWUp3ZwpxMHFiK1NraldSVXJHeW1VSHVYMVZUaitUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck16SXVNb0lPTVRrMUxqRTFOQzQzTUM0eU1ET0NQSEozTFRWak1XRTNOamc0TFRrMVpUa3RORFUwWWkxaU0yVmoKTFdVeFpUVmxPREJrTmpGa1l5NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5SVlJY0VyQkFnQW9jRQp3NXBHeXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWNZelFZUWVoTWZ4dVd3RmlQSEdralVHajAycnd5NHZzCmtoN3R1YXYra0tJeGY5cWZpVmVOUWJpMkhhUm5BYitxdXA2YXc1S0VYeFdCbFVJZURxVUR1RVBkWGZZaWdldmwKeUVKaXh1USt3OVJBQmtUemxZOW8vZ3NmR0FXWVJ3VWo2UnRYOGhqY3V4YVZGK0pYdXRRNG5zYmNZdmRWcWFmMQp6V3RXNktmb2dzNkZkZmI3RzJnaWUvSSs5bXZKejJyY3luUmhqd0lhS3Z4OTJPRS8rMzVpbjJwajkvc054Nlc3CnpRa1lpNVdwTmtGMVBJbTF4S29mSGZJM05vWFVjeUpCWjhkVklyNzBZUDhCMmc0OTNGQ2VqZi9UdEdydFVFQmgKdTlsSk4rYlhQRUIrRU5xNjZBY2lGVlg2UVV2UzVVTWtVWVhjV2dxTVNpbU9nMDJZQUtPNnhRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1875"
+      - "1723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:40 GMT
+      - Mon, 18 Dec 2023 13:15:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9244daeb-530e-4cfe-97de-7c7b59d86cf9
+      - 887086da-dba7-4fb9-b96e-0a8c44146851
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1502,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"4922744d-a7f5-4f08-9dcc-9e2f0bad7a50","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"ips":[{"address":"172.16.112.2/22","created_at":"2023-12-18T13:14:54.913878Z","id":"ba564d68-537c-4a92-a4a0-1b0503c6acfa","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:19","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"38e04ba4-c22c-46fe-8425-af85dcf01b16"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:14:56.649295Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1449"
+      - "529"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:40 GMT
+      - Mon, 18 Dec 2023 13:15:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77fd92fe-8956-4031-aa56-f3f9930c143a
+      - fdd34dac-9663-4c70-a316-f3786e6036b2
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,10 +1535,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b5640e59-9d96-4055-98ef-4b940637a62c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:13:31.024012Z","dhcp_enabled":true,"id":"b5640e59-9d96-4055-98ef-4b940637a62c","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:13:31.024012Z","id":"5cd5f581-239e-47d6-b0f0-1d67151fbc5b","subnet":"172.16.32.0/22","updated_at":"2023-11-21T16:13:31.024012Z"},{"created_at":"2023-11-21T16:13:31.024012Z","id":"1062875f-dfec-4962-9c67-da2c125eb56c","subnet":"fd5f:519c:6d46:8c16::/64","updated_at":"2023-11-21T16:13:31.024012Z"}],"tags":[],"updated_at":"2023-11-21T16:13:31.024012Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "702"
@@ -1479,7 +1547,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:40 GMT
+      - Mon, 18 Dec 2023 13:15:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b5ab57d-5880-42a9-b410-b671c9ab3381
+      - c3f18d46-859e-47ba-9d12-d85bdb306a20
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1568,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"4922744d-a7f5-4f08-9dcc-9e2f0bad7a50","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1449"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:41 GMT
+      - Mon, 18 Dec 2023 13:15:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afed1cbb-e4f9-4c8f-a3e7-2996e77a7b8f
+      - e3ddf278-95b0-409f-9886-9eda9e97e33d
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1601,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0RENDQXB5Z0F3SUJBZ0lVWDlqbkxpOHYzSkFWVERGMllVekhNd3NXcmwwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1URXlNVEUyTVRZMU9Gb1hEVE16TVRFeE9ERTJNVFkxT0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFockpDMkV3OGhMc21scFg0RlA0TjVTTzgwZ2JtdlJYWjFCOXdkbmhjR3BUMW9LK1NIejd3T1RialVSbG0KRFppOHNOd09Sd2JsV0liQmNleTlvbjVpbXBBbzRYL1FtRVI5dGFNVDZydGJXRS9IbzBMRU83NXlqaVJlc3hiVApLOEp1clNFN0l3Nnd6eXM1T2VUN1R2RWw3UDU1S01uODlSQlczYm0rRFJMMUpmV2YxOU5jQkphZnFLNVJ2Ym9wCjRhUklWNGVXeldLQkUreW5tT2FlMXNJenZYNy9xeDJldjRmbnBGVXB0QW5SZm1GUVd3d1NCTWNQeDFudXAvcmEKQ1hOdWpDS2RKRlFXV0VHVVpYQ3A3bWRyNWdlam5WaVN3djUzdWs0SHltamI2Njg5M0RGQXhtTVZBd3NDWUp3ZwpxMHFiK1NraldSVXJHeW1VSHVYMVZUaitUd0lEQVFBQm8zb3dlREIyQmdOVkhSRUViekJ0Z2dzeE56SXVNVFl1Ck16SXVNb0lPTVRrMUxqRTFOQzQzTUM0eU1ET0NQSEozTFRWak1XRTNOamc0TFRrMVpUa3RORFUwWWkxaU0yVmoKTFdVeFpUVmxPREJrTmpGa1l5NXlaR0l1Wm5JdGNHRnlMbk5qZHk1amJHOTFaSWNFbzZ5SVlJY0VyQkFnQW9jRQp3NXBHeXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWNZelFZUWVoTWZ4dVd3RmlQSEdralVHajAycnd5NHZzCmtoN3R1YXYra0tJeGY5cWZpVmVOUWJpMkhhUm5BYitxdXA2YXc1S0VYeFdCbFVJZURxVUR1RVBkWGZZaWdldmwKeUVKaXh1USt3OVJBQmtUemxZOW8vZ3NmR0FXWVJ3VWo2UnRYOGhqY3V4YVZGK0pYdXRRNG5zYmNZdmRWcWFmMQp6V3RXNktmb2dzNkZkZmI3RzJnaWUvSSs5bXZKejJyY3luUmhqd0lhS3Z4OTJPRS8rMzVpbjJwajkvc054Nlc3CnpRa1lpNVdwTmtGMVBJbTF4S29mSGZJM05vWFVjeUpCWjhkVklyNzBZUDhCMmc0OTNGQ2VqZi9UdEdydFVFQmgKdTlsSk4rYlhQRUIrRU5xNjZBY2lGVlg2UVV2UzVVTWtVWVhjV2dxTVNpbU9nMDJZQUtPNnhRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1875"
+      - "1255"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:41 GMT
+      - Mon, 18 Dec 2023 13:15:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6e5361c-bb77-4788-a961-ca0409c05725
+      - 71dd2243-8f55-4ec1-aaf2-66864b588c8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1634,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"4922744d-a7f5-4f08-9dcc-9e2f0bad7a50","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1449"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:41 GMT
+      - Mon, 18 Dec 2023 13:15:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d0fde28-03d9-4836-8194-dc24ad9d5b85
+      - 6c6bfdc5-192d-4982-aac6-acf5d525021d
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,19 +1667,448 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2712e33a-1f6b-4821-902e-67f82b9c0c43
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6ff389bd-81bd-4918-a0e4-e57c79a03e5d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 771733c1-afde-4da0-b315-74fd75140222
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.112.2/22","created_at":"2023-12-18T13:14:54.913878Z","id":"ba564d68-537c-4a92-a4a0-1b0503c6acfa","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:19","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"38e04ba4-c22c-46fe-8425-af85dcf01b16"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:14:56.649295Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "529"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:32 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3db4211e-8feb-441e-befb-2f623391bbd9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 98f5a948-bf98-42dc-b20e-7e8fd2a8c401
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e2071d42-f8ed-4972-b809-df51b5fc0f30
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77550f4e-4a37-4746-b61a-81aae95a64a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3e3b64ef-dcd3-4ef8-b6c6-bdc4694d5b46
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.112.2/22","created_at":"2023-12-18T13:14:54.913878Z","id":"ba564d68-537c-4a92-a4a0-1b0503c6acfa","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:19","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"38e04ba4-c22c-46fe-8425-af85dcf01b16"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:14:56.649295Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "529"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 42f8ef28-e1e8-44e6-b05d-db5fdbb92e6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22c546a9-8d48-444a-beed-d9f57fa7d433
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82785c9b-e65b-4104-90d8-2e3d78b3b80f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: PATCH
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 96d4a744-0710-4721-9514-4a73eba4fe9c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb997d82-589a-4603-b0b3-aa8e83561c3e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/8450a676-f697-48d5-bbd3-bd30560a9d02
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"4922744d-a7f5-4f08-9dcc-9e2f0bad7a50","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: ""
     headers:
-      Content-Length:
-      - "1452"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:42 GMT
+      - Mon, 18 Dec 2023 13:15:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +2118,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c5312a1-47be-4e06-88d3-ba55b14adadf
+      - d3499a08-8c60-41b1-b7ea-0db85b2174a7
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1261"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:15:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1d9187c9-5fc8-4016-8911-1d67d6a2c202
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,19 +2162,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:13:33.024036Z","endpoint":{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116},"endpoints":[{"id":"4922744d-a7f5-4f08-9dcc-9e2f0bad7a50","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b5640e59-9d96-4055-98ef-4b940637a62c","service_ip":"172.16.32.4/22","zone":"fr-par-1"}},{"id":"cfc404c8-f43f-4f90-8be4-285e89c70aa5","ip":"195.154.70.203","load_balancer":{},"name":null,"port":11116}],"engine":"PostgreSQL-15","id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1452"
+      - "1037"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:42 GMT
+      - Mon, 18 Dec 2023 13:16:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +2184,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2027c0ba-b28e-4abf-be29-a8e56ae948d5
+      - a5a9fde4-0b54-45b2-aa67-4f69b41de62c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22"}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/endpoints
+    method: POST
+  response:
+    body: '{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "218"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4495009a-57bc-4e41-bddc-9e407c1f8e7c
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,10 +2230,1693 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1262"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 849da146-7252-405a-a6de-939a17d3aaea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 31e72a40-df9a-4a53-864a-16c1ee78cbc9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb05fe4b-4bfa-4441-9d3c-d94e027ef8ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82b284ef-e47f-4792-bd47-084bcaab14d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed104feb-b8bf-4380-a8ef-cb55752613dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8d27be4-00fe-459d-afa9-eb2938026fd2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 69599299-e326-4565-9dfe-f1fa0f0b8966
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec3ad2df-a08e-4fed-a7e0-b664ca404c1b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5d4b1852-d8e9-4a73-9f53-6486175c056f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7d60b7f3-f0b3-43f2-9f89-add997ff51b2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ecfc3d3-1c5f-43c9-aca5-83f211768933
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f97d60d7-e9f4-4bf2-9b3e-6268983d4340
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6334e7c3-d10e-46dc-8dcc-65e08dfa4e19
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56a1a3a7-207f-4f07-8e06-10f2edb8a741
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c8ec92d-526a-47a7-90eb-0503b9aac26f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4e91be4-0a58-4e85-a0b1-d42df5f53a5b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e5ac15fe-7eee-4a72-a96f-64b27581370a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4d137430-b7ce-463b-aa78-0c5fa7dd431b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: PATCH
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 81456f5f-9f37-4af8-b931-f4de28b17924
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1255"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a1808bc-7047-443b-b884-a8c8c15791ae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/a294d2ef-8d5f-4c58-975a-87889661c0fd
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8407917a-c9b2-4c88-8df8-0e4b524127a9
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1261"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:16:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a30ebf3a-b693-4738-a3eb-fae2f173e3f1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1037"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8713533d-7f4a-478a-a3fa-ab31c270ca84
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22"}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/endpoints
+    method: POST
+  response:
+    body: '{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "216"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7d7072a2-26fc-42d7-a30f-1b9c00bdf691
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1260"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f978e83a-f04b-4d0e-8f0e-7ceba59f5a9b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c61a678-e6b4-4a58-9759-78d7c5f4245d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a357501-d717-4eaf-a123-5415c0537d17
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5150e999-d434-41b8-ae27-b9052bbe5923
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1d96fe73-91ae-43b9-ad7b-cd2836355bd0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c068e03e-bb5f-48ca-8a0a-f8b2408c519c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bd8b41e5-a982-4fd8-be69-012f16a0afb6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 909f3c0e-359f-450a-b911-828f5407210e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 53882cbe-4f22-4765-9f02-69089b7d7428
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bd3c6ee7-885d-4dc4-9585-3e3853bd28c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fc8d469d-a469-4322-82f3-e6bfbd9469f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e28e8993-af4d-4386-8243-20a598f0a79d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "710"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b9685d4-f070-4302-8f41-43521ccf752f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8011c83-8b09-4e17-99d6-ae2dd17ca52d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c5f6ea65-26bf-417c-8faa-23e34154b1ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0913f225-1724-4a67-915e-35c347d97bcf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0fe0bb5-7edc-4a60-9c86-e4ce983ae6c4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a869ca5-4495-46b2-9c43-2568469e2adc
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5e36ee24-c534-4fc0-b479-995ba04a4ffd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 266e16e1-1556-4ee7-a6e1-abeacf2bc0e2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - caf1cccd-3fe9-49b6-b9ab-ee7a87689060
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77727631-5d78-48af-8683-e5fef018be83
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 63f2ed2d-0be1-4400-8811-8a7b67af6349
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ee8d7d0-9550-44cb-a76c-31069b2733a2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1253"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 342df190-62eb-4040-a990-4746fc64acd9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52107bc9-3efe-44df-84d5-092b8b0826f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1256"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1fb0ddc5-860e-44e0-9758-4d4345eebee1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1677,7 +3925,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:12 GMT
+      - Mon, 18 Dec 2023 13:18:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +3935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cf78efc-13f2-4ccb-8312-b83626b24b78
+      - f8366b4b-3e82-446a-bd4c-c5f56cb0c461
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1698,7 +3946,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b5640e59-9d96-4055-98ef-4b940637a62c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
     method: DELETE
   response:
     body: ""
@@ -1708,7 +3956,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:13 GMT
+      - Mon, 18 Dec 2023 13:18:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1718,7 +3966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1963023-61b4-41e7-a6e4-f6cc28a28274
+      - 415e2898-38ea-4e75-a0e4-f7613713856e
     status: 204 No Content
     code: 204
     duration: ""
@@ -1729,10 +3977,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5c1a7688-95e9-454b-b3ec-e1e5e80d61dc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5c1a7688-95e9-454b-b3ec-e1e5e80d61dc","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1741,7 +3989,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:13 GMT
+      - Mon, 18 Dec 2023 13:18:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1751,7 +3999,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 871a9fde-60e1-4906-92e9-7d8dde0d9492
+      - 66502db6-f6ef-43f6-8d47-fe7f3b5eac59
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"b1140239-acf5-4862-b7df-3e03e16fa170","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "136"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f6196475-62ea-4046-94a2-a8c6db08152d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:53 GMT
+      - Mon, 18 Dec 2023 12:57:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37b6b7c5-5f0f-4901-ac12-eefe8485c316
+      - 16b03ad0-8b51-4aa7-93f5-319edb7928b0
     status: 200 OK
     code: 200
     duration: ""
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T15:59:03.986417Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "700"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:05 GMT
+      - Mon, 18 Dec 2023 13:13:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3216d9b6-38b0-469a-b22e-08de5841689a
+      - bd68e186-cebf-4b36-8c0d-1cac3b879133
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T15:59:03.986417Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "700"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:05 GMT
+      - Mon, 18 Dec 2023 13:13:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 956f4161-e5fa-4224-9915-1996a7c4bd7a
+      - c42bca20-e911-4b87-ad59-a8b532ce07f4
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T15:59:03.986417Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "700"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:05 GMT
+      - Mon, 18 Dec 2023 13:13:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61ea1a94-276a-4b09-87aa-8219b381c132
+      - d6f05a8f-56b7-4c83-9b1e-d5822109197b
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T15:59:03.986417Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "700"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:05 GMT
+      - Mon, 18 Dec 2023 13:13:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,12 +462,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbbeb079-81ce-4928-905a-283e17581701
+      - 2b7a7f54-bb55-4610-86b3-5daed663154e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-private-network","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -478,16 +478,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":null,"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:06 GMT
+      - Mon, 18 Dec 2023 13:13:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2f2e775-6a1a-422e-9ab2-bb23b7e19d20
+      - 90fb5ff9-5424-4b15-8efb-9acc5e7afd5b
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":null,"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:07 GMT
+      - Mon, 18 Dec 2023 13:13:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 820e5ec3-473b-4773-bf41-b461b52b5d63
+      - eccd528f-6a79-4d97-bced-4b042bed7c9f
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":null,"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:37 GMT
+      - Mon, 18 Dec 2023 13:13:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2fce385-d7d4-4f67-baf5-96891bd1c70c
+      - f4c3bdb7-06e8-4e9f-bd0b-05339f49fa58
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":null,"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:00:07 GMT
+      - Mon, 18 Dec 2023 13:14:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d27f6005-ea13-4e16-870c-bded13fbf5a8
+      - e5d7ce88-3045-4065-b482-09e33937c99b
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":null,"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:00:37 GMT
+      - Mon, 18 Dec 2023 13:14:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08247d49-084a-4735-8512-f9b72c7a01a4
+      - e4f39c7c-ee75-4ae3-a5e2-2cffba1ccd5c
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":null,"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:01:07 GMT
+      - Mon, 18 Dec 2023 13:15:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3dfe7d7-136b-4a62-9989-e2dd01607df9
+      - a66beff8-d4da-4ff3-9b03-18d616a3f8c1
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":null,"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "975"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:01:38 GMT
+      - Mon, 18 Dec 2023 13:15:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d45549f4-b239-46b1-a565-435531a035b6
+      - 531f3dec-19b6-4d5b-a7a2-8983156b949a
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":null,"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1239"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:08 GMT
+      - Mon, 18 Dec 2023 13:16:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 139ef031-de93-45ac-8610-e910d5a8bdfe
+      - 95008587-6d65-40e9-924a-f2740123a514
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "991"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:38 GMT
+      - Mon, 18 Dec 2023 13:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f32ff942-f6b5-44f0-a50c-54a147fdb346
+      - 1b361f7e-bd30-4063-85ac-0a59040d0b38
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1879"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:38 GMT
+      - Mon, 18 Dec 2023 13:17:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 559edbf3-4e36-4474-9966-7f0f302324b3
+      - c9b6f7b1-592d-445d-9fb5-12b52edc1515
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1451"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:38 GMT
+      - Mon, 18 Dec 2023 13:17:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30cb0d8d-e5e5-418d-88fc-5565a9eee7b5
+      - c2df51fa-3091-494d-a94a-a4ad74d1b5f0
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T15:59:03.986417Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "700"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:39 GMT
+      - Mon, 18 Dec 2023 13:17:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1c16cfc-9505-44f8-8204-91fb01ceb933
+      - 67f58f3c-9a10-4973-80c6-5f24c6e78f6f
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:39 GMT
+      - Mon, 18 Dec 2023 13:17:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04d0b2b2-9af1-46d3-9712-eba1169f5975
+      - 6b688df7-7e33-4420-b02d-837f503fc0a0
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "1879"
+      - "702"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:39 GMT
+      - Mon, 18 Dec 2023 13:17:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f40ade0-9569-4357-8b30-2b9692f4a7dc
+      - ce01f9a1-9ccb-46cd-8e0c-3b4f7f69650c
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T15:59:03.986417Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "700"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:40 GMT
+      - Mon, 18 Dec 2023 13:17:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 909a1e71-ce4f-48d9-8b50-0873e34e7fee
+      - 7902cacf-4690-42d6-88d5-65af28e30076
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1451"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:40 GMT
+      - Mon, 18 Dec 2023 13:17:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bacb5e6-c5e6-4dcc-bd81-bbe204cac771
+      - 0de6a2e3-e5e2-4f50-9ee5-87c48e0541c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1879"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:40 GMT
+      - Mon, 18 Dec 2023 13:17:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1025,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca3e7b6e-eba5-4601-84f9-067c0e5c4b49
+      - 2522ee1f-2af4-470a-86e3-eb78ef26e509
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    headers:
+      Content-Length:
+      - "702"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 404482cc-4361-470e-8044-666b2f5f97f0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1248"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08bc54ca-867c-4412-8942-4f0c7b8bc7e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1731"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 17d05300-5233-4e8c-b32f-b94ad4db8a6a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:17:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3db4a93-dbcd-4585-91bb-58a05d1ede69
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: PATCH
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.948499Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "715"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:41 GMT
+      - Mon, 18 Dec 2023 13:17:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 454a9f24-62cf-4041-bdb3-8307bfa14c04
+      - 189a1eb0-5ef9-473f-8d3e-d752dc61a560
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.948499Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "715"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:42 GMT
+      - Mon, 18 Dec 2023 13:17:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbe49e0a-c885-4ac4-8e18-bbd378969728
+      - 60a7b276-ff5e-41ff-a486-86b20d6b913b
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,16 +1241,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T16:02:41.945664Z","dhcp_enabled":true,"id":"c02ab383-e20f-402b-9854-849643ad5b40","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:02:41.945664Z","id":"08945ed1-802a-4775-99bc-4a1bdfe7b0fa","subnet":"172.16.8.0/22","updated_at":"2023-11-21T16:02:41.945664Z"},{"created_at":"2023-11-21T16:02:41.945664Z","id":"a40e0e63-fcdb-4f23-b368-0505333a8054","subnet":"fd5c:d510:d730:e445::/64","updated_at":"2023-11-21T16:02:41.945664Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.945664Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"172.16.0.0/22","updated_at":"2023-12-18T13:17:17.306857Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:17:17.306857Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.306857Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "701"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:43 GMT
+      - Mon, 18 Dec 2023 13:17:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1128,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14fd3989-3ebe-4b8f-8ac0-f42666c1a0a9
+      - 23dc37e7-fd63-4626-8689-e7a2fac52bbc
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,19 +1271,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c02ab383-e20f-402b-9854-849643ad5b40
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:02:41.945664Z","dhcp_enabled":true,"id":"c02ab383-e20f-402b-9854-849643ad5b40","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:02:41.945664Z","id":"08945ed1-802a-4775-99bc-4a1bdfe7b0fa","subnet":"172.16.8.0/22","updated_at":"2023-11-21T16:02:41.945664Z"},{"created_at":"2023-11-21T16:02:41.945664Z","id":"a40e0e63-fcdb-4f23-b368-0505333a8054","subnet":"fd5c:d510:d730:e445::/64","updated_at":"2023-11-21T16:02:41.945664Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.945664Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"172.16.0.0/22","updated_at":"2023-12-18T13:17:17.306857Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:17:17.306857Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.306857Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "701"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:43 GMT
+      - Mon, 18 Dec 2023 13:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1161,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 426fe5ea-5c19-4632-ab94-c36847ed23af
+      - 0e2d04b3-0f8c-48cc-bb9e-7d15e469eade
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,19 +1304,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:43 GMT
+      - Mon, 18 Dec 2023 13:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1194,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00661d92-e8bc-4cb3-915b-d98bdeef8353
+      - cb300174-3a37-44a2-ab2b-89290fbdac8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1205,19 +1337,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:43 GMT
+      - Mon, 18 Dec 2023 13:17:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1227,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82962475-d4ef-4834-bcc1-ef86f27158fc
+      - ebe48391-cd20-4702-b380-6cf409c41006
     status: 200 OK
     code: 200
     duration: ""
@@ -1240,19 +1372,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:44 GMT
+      - Mon, 18 Dec 2023 13:17:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1262,7 +1394,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b420259-122f-4d51-81e8-5e459997b9c4
+      - f1955eda-a28e-413c-a4d6-8478d5177611
     status: 200 OK
     code: 200
     duration: ""
@@ -1273,19 +1405,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1451"
+      - "1248"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:44 GMT
+      - Mon, 18 Dec 2023 13:17:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1295,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 391b5649-042f-49d4-9b4e-4810b2db4216
+      - cf99c275-457a-4e30-a5ca-033d6060d3a5
     status: 200 OK
     code: 200
     duration: ""
@@ -1306,7 +1438,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/b720570a-92d0-4404-b241-c5ad79f24b3c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/4442db4c-3b00-44d5-bac8-1194041c9695
     method: DELETE
   response:
     body: ""
@@ -1316,7 +1448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:44 GMT
+      - Mon, 18 Dec 2023 13:17:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1326,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 996be832-0768-4f8f-83e5-5a29d13515dd
+      - 5aac5299-a8db-4aa0-9f77-7afced955086
     status: 204 No Content
     code: 204
     duration: ""
@@ -1337,19 +1469,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"b720570a-92d0-4404-b241-c5ad79f24b3c","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f914abaf-aacf-426f-8489-24a570c2ef6f","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1254"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:44 GMT
+      - Mon, 18 Dec 2023 13:17:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1359,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - beb631ab-6e5e-45a9-a771-8efd76929444
+      - daa2b7be-44d3-4b8f-b6eb-a068b3f61694
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,19 +1502,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1030"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:14 GMT
+      - Mon, 18 Dec 2023 13:17:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1392,12 +1524,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1ef6207-3bd3-4929-9097-6f713005644e
+      - 2f3692ed-125b-417e-b956-214e91df5b39
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24"}}}'
     form: {}
     headers:
       Content-Type:
@@ -1405,10 +1537,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/endpoints
     method: POST
   response:
-    body: '{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
+    body: '{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
     headers:
       Content-Length:
       - "220"
@@ -1417,7 +1549,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:15 GMT
+      - Mon, 18 Dec 2023 13:17:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1427,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93bef4cd-e492-40cc-8b72-6bb1cb9af439
+      - f0d7395b-c4a9-45ba-95e2-6857aefbc36f
     status: 200 OK
     code: 200
     duration: ""
@@ -1438,19 +1570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1460"
+      - "1257"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:15 GMT
+      - Mon, 18 Dec 2023 13:17:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae1e4db6-9896-4c37-9890-4acd6b7f4b84
+      - 1f572417-41f0-4a29-b68e-d44539b2e54e
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,19 +1603,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 13:18:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd8a2a9f-5961-49d0-841a-4cc9ca5477d2
+      - c4f18bfc-2631-49bb-bca1-6240ce40a91e
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,19 +1636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 13:18:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af1b9f4e-cf4c-42f6-a094-85e8210be31a
+      - 80c38ee0-f7a4-42c0-821a-194fb6e2d054
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1453"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 13:18:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4d02061-9220-479f-8139-d4340142d876
+      - 64e4c761-f388-45e9-a484-53b050432f9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1702,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c02ab383-e20f-402b-9854-849643ad5b40
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:02:41.945664Z","dhcp_enabled":true,"id":"c02ab383-e20f-402b-9854-849643ad5b40","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:02:41.945664Z","id":"08945ed1-802a-4775-99bc-4a1bdfe7b0fa","subnet":"172.16.8.0/22","updated_at":"2023-11-21T16:02:41.945664Z"},{"created_at":"2023-11-21T16:02:41.945664Z","id":"a40e0e63-fcdb-4f23-b368-0505333a8054","subnet":"fd5c:d510:d730:e445::/64","updated_at":"2023-11-21T16:02:41.945664Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.945664Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "701"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:46 GMT
+      - Mon, 18 Dec 2023 13:18:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58fa71ef-10e8-46ab-9262-1bafeb29fa20
+      - ecc58a35-4f2a-48bf-a071-9af344415964
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,19 +1735,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.948499Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "715"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:46 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31bc3223-a178-4ab1-9ad2-4f7e47e49685
+      - a3d44594-3946-4ccc-84fd-db0f712d62ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,19 +1768,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"172.16.0.0/22","updated_at":"2023-12-18T13:17:17.306857Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:17:17.306857Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.306857Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "1453"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:46 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25d7b140-b069-4cff-b395-e35d9477cb9c
+      - c85dec9c-712c-4ef0-8881-8c9d51689bcb
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,19 +1801,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1879"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:46 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f78422e-95fb-49e0-af23-a074c369bf9d
+      - 1175d206-3583-46b0-b715-ed5763175ed3
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,19 +1834,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c02ab383-e20f-402b-9854-849643ad5b40
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:02:41.945664Z","dhcp_enabled":true,"id":"c02ab383-e20f-402b-9854-849643ad5b40","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:02:41.945664Z","id":"08945ed1-802a-4775-99bc-4a1bdfe7b0fa","subnet":"172.16.8.0/22","updated_at":"2023-11-21T16:02:41.945664Z"},{"created_at":"2023-11-21T16:02:41.945664Z","id":"a40e0e63-fcdb-4f23-b368-0505333a8054","subnet":"fd5c:d510:d730:e445::/64","updated_at":"2023-11-21T16:02:41.945664Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.945664Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "701"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:47 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a368afb8-8d93-463b-86e2-bc328812cb0a
+      - 87338d27-9793-4741-83de-56974ad17c33
     status: 200 OK
     code: 200
     duration: ""
@@ -1735,19 +1867,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.948499Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "715"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:47 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1757,7 +1889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7ebad01-915c-4dd3-a161-7ae369cd96d7
+      - 52caa35a-3e88-4fa9-8321-3896abcf29bc
     status: 200 OK
     code: 200
     duration: ""
@@ -1768,19 +1900,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "1453"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:47 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1790,7 +1922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85421159-f5cb-4354-86df-f220682fad82
+      - afb0aee8-77b7-4191-aaf6-85d25a4e13d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1801,19 +1933,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"172.16.0.0/22","updated_at":"2023-12-18T13:17:17.306857Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:17:17.306857Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.306857Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "1879"
+      - "700"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:47 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1823,7 +1955,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd81355f-6428-40f0-bd6f-f1b7e0720f75
+      - e88bf229-15e8-4b2e-ae8d-966cf647765d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1250"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd0840b2-ce51-403f-bf13-22a5af988946
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1731"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c3766e4-906f-4569-9783-cd47163270dd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a678160-181e-45ea-9156-e44aa84f3a16
     status: 200 OK
     code: 200
     duration: ""
@@ -1839,7 +2070,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -1848,7 +2079,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:50 GMT
+      - Mon, 18 Dec 2023 13:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1858,7 +2089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea3562a5-496c-49be-b956-9b16acbce57c
+      - 27dc12d0-8b43-4dfc-b1a5-6b377a343e25
     status: 200 OK
     code: 200
     duration: ""
@@ -1869,10 +2100,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/38889f09-cb5d-4932-b98a-5f2e92cb3c79
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/588e6ee2-c516-4f79-99a2-9bd52977f31e
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -1881,7 +2112,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:50 GMT
+      - Mon, 18 Dec 2023 13:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1891,7 +2122,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 262e7e3d-7599-4fca-be6d-35894749e799
+      - e8f520dc-e078-4d73-8171-0a05d5376d3a
     status: 200 OK
     code: 200
     duration: ""
@@ -1907,7 +2138,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
-    body: '{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":null,"id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":null,"id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "356"
@@ -1916,7 +2147,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:51 GMT
+      - Mon, 18 Dec 2023 13:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1926,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5f26140-ce07-4e33-abfc-d33bc5725a39
+      - 69b1263a-3eee-488b-846b-4d23277187e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1937,10 +2168,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/929d4c74-2aff-47ea-a2f1-0b1c54824de4
     method: GET
   response:
-    body: '{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":null,"id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":null,"id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "356"
@@ -1949,7 +2180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:51 GMT
+      - Mon, 18 Dec 2023 13:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1959,12 +2190,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c570f06-990d-4db6-9f06-1b5302c7484b
+      - e798d2f1-a0e0-4058-8e86-1e22e02dfe1c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -1975,7 +2206,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:03:51.550366Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:24.696189Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "938"
@@ -1984,7 +2215,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:51 GMT
+      - Mon, 18 Dec 2023 13:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1994,7 +2225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfd8827e-b453-44ba-b841-ca7f302d4a73
+      - 63553eeb-6da9-4664-8498-e4129bf51c4a
     status: 200 OK
     code: 200
     duration: ""
@@ -2005,10 +2236,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:03:51.610945Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:24.747545Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "941"
@@ -2017,7 +2248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:51 GMT
+      - Mon, 18 Dec 2023 13:18:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2027,7 +2258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5485efad-3216-4511-b6a5-f56afb4dc020
+      - 2f7a17fd-360b-4617-b3cf-8db87a336993
     status: 200 OK
     code: 200
     duration: ""
@@ -2038,10 +2269,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:03:52.302135Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:25.512265Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "938"
@@ -2050,7 +2281,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:56 GMT
+      - Mon, 18 Dec 2023 13:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2060,7 +2291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17f3812-db74-4876-9932-e760e86c9018
+      - 48fecd13-618b-488b-9306-4115a9429c66
     status: 200 OK
     code: 200
     duration: ""
@@ -2071,10 +2302,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:03:52.302135Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:25.512265Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "938"
@@ -2083,7 +2314,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:56 GMT
+      - Mon, 18 Dec 2023 13:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2093,7 +2324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd912a34-c334-4783-9d93-3ef227180de7
+      - 38941cc9-32e2-4ce5-bf5e-983a03ace0b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2104,10 +2335,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:03:52.302135Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:25.512265Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "938"
@@ -2116,7 +2347,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:56 GMT
+      - Mon, 18 Dec 2023 13:18:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2126,12 +2357,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45e1d2f4-8d39-4429-aba0-e765973acee6
+      - 01d32f25-cb52-4291-b6c9-1d442fdeb253
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79"}'
+    body: '{"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"588e6ee2-c516-4f79-99a2-9bd52977f31e"}'
     form: {}
     headers:
       Content-Type:
@@ -2142,7 +2373,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":null,"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"created","updated_at":"2023-11-21T16:03:57.908213Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":null,"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"created","updated_at":"2023-12-18T13:18:30.956720Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "953"
@@ -2151,7 +2382,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:58 GMT
+      - Mon, 18 Dec 2023 13:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2161,7 +2392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82e0c343-f6db-4983-95c8-e55d10341c1d
+      - e5c5134e-0c75-4284-b6d9-7736f1a1a360
     status: 200 OK
     code: 200
     duration: ""
@@ -2172,10 +2403,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":null,"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"created","updated_at":"2023-11-21T16:03:57.908213Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:03:58.114327Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":null,"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"created","updated_at":"2023-12-18T13:18:30.956720Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:31.135726Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1894"
@@ -2184,7 +2415,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:58 GMT
+      - Mon, 18 Dec 2023 13:18:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2194,7 +2425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f78b7b04-e6f5-4270-96eb-19800a191c1d
+      - c350f9e7-c5f3-409d-adde-39d58644c229
     status: 200 OK
     code: 200
     duration: ""
@@ -2205,10 +2436,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":null,"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"created","updated_at":"2023-11-21T16:03:57.908213Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:03:58.114327Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":null,"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"created","updated_at":"2023-12-18T13:18:30.956720Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:31.135726Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1894"
@@ -2217,7 +2448,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:03 GMT
+      - Mon, 18 Dec 2023 13:18:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2227,7 +2458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6830ca4-9741-4252-a986-9f4a963336b6
+      - 2dde3750-e010-4d24-86b7-cca851d4d564
     status: 200 OK
     code: 200
     duration: ""
@@ -2238,10 +2469,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1903"
@@ -2250,7 +2481,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:08 GMT
+      - Mon, 18 Dec 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2260,7 +2491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1934aac-4f17-4801-bd69-c0409f202727
+      - f5d625b4-82b8-4591-85af-b2e607580596
     status: 200 OK
     code: 200
     duration: ""
@@ -2271,10 +2502,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -2283,7 +2514,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:08 GMT
+      - Mon, 18 Dec 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2293,7 +2524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d7a5a25-ca09-4426-9f9b-d0db405d2af5
+      - 2744a29c-c3e2-4e7c-9c78-54d13f8c4e95
     status: 200 OK
     code: 200
     duration: ""
@@ -2304,10 +2535,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -2316,7 +2547,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:08 GMT
+      - Mon, 18 Dec 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2326,7 +2557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 626147e5-5cf8-4613-8ead-572a6a4c525e
+      - b26ec2ba-b66a-4937-875e-716cd717b388
     status: 200 OK
     code: 200
     duration: ""
@@ -2337,10 +2568,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1903"
@@ -2349,7 +2580,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:08 GMT
+      - Mon, 18 Dec 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2359,7 +2590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c30c334c-c632-41fb-a98a-661d6bd07adf
+      - 36cbebcf-43d6-4bc4-afe5-e67d2fbe5004
     status: 200 OK
     code: 200
     duration: ""
@@ -2370,10 +2601,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -2382,7 +2613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:08 GMT
+      - Mon, 18 Dec 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2392,7 +2623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 386e2947-d048-4566-af1a-522d35caa428
+      - a7a33f52-e463-4f39-a8ec-8cc166ac0b08
     status: 200 OK
     code: 200
     duration: ""
@@ -2403,10 +2634,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1903"
@@ -2415,7 +2646,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:08 GMT
+      - Mon, 18 Dec 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2425,7 +2656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 011b3c7e-4ac9-4959-998d-111488abaa32
+      - a9ddbad8-4760-4f85-8898-af4f5c454f74
     status: 200 OK
     code: 200
     duration: ""
@@ -2436,10 +2667,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1903"
@@ -2448,7 +2679,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:08 GMT
+      - Mon, 18 Dec 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2458,12 +2689,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fbf91e6-b2c9-46a7-8a76-6dada640deef
+      - 4254fcb6-a84a-4173-a699-c9979127e963
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: '{"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
@@ -2474,7 +2705,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T16:04:08.915067Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"303cca5c-abd0-44c2-8847-857df8294025","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:04:08.915067Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -2483,7 +2714,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:08 GMT
+      - Mon, 18 Dec 2023 13:18:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2493,7 +2724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a156b539-e6af-4628-836c-d0ff464e13b4
+      - 00f8dbac-320c-4797-9fd3-b1f08f5a72a8
     status: 200 OK
     code: 200
     duration: ""
@@ -2504,10 +2735,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1903"
@@ -2516,7 +2747,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:09 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2526,7 +2757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 728d99b8-8d7a-42c4-95a5-49b6f6a8e6b9
+      - ec7eb7de-6901-492a-9eb1-4c2cb862dcfe
     status: 200 OK
     code: 200
     duration: ""
@@ -2537,10 +2768,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/303cca5c-abd0-44c2-8847-857df8294025
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:04:08.915067Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"303cca5c-abd0-44c2-8847-857df8294025","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:04:08.915067Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -2549,7 +2780,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:09 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2559,7 +2790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a34c3ab-bc60-4a24-a207-4c4e3d58c9c1
+      - 7f3b03f1-6ffc-4de9-996d-ca22adc554ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2570,19 +2801,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:09 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2592,7 +2823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c95150e4-4055-4444-abee-4eb9092e5dc6
+      - 5e890655-11b7-4a50-9808-7b412b7adbba
     status: 200 OK
     code: 200
     duration: ""
@@ -2603,109 +2834,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/588e6ee2-c516-4f79-99a2-9bd52977f31e
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.948499Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
-    headers:
-      Content-Length:
-      - "715"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6e889712-a7fc-4ac5-9192-b868094c72e5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c02ab383-e20f-402b-9854-849643ad5b40
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:02:41.945664Z","dhcp_enabled":true,"id":"c02ab383-e20f-402b-9854-849643ad5b40","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:02:41.945664Z","id":"08945ed1-802a-4775-99bc-4a1bdfe7b0fa","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:57.445049Z"},{"created_at":"2023-11-21T16:02:41.945664Z","id":"a40e0e63-fcdb-4f23-b368-0505333a8054","subnet":"fd5c:d510:d730:e445::/64","updated_at":"2023-11-21T16:03:57.449599Z"}],"tags":[],"updated_at":"2023-11-21T16:04:04.728067Z","vpc_id":"27d130bf-6e34-42f0-8c58-bc13a9fb55ce"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b9a3e72-e76a-4efc-9d4e-80af2aa843df
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72
-    method: GET
-  response:
-    body: '{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "390"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 247e73db-3382-4aef-9c27-bcd6505911f1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/38889f09-cb5d-4932-b98a-5f2e92cb3c79
-    method: GET
-  response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -2714,7 +2846,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2724,7 +2856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71977b26-6658-446a-811e-1286814479f5
+      - 4a42569a-0b27-4779-bea8-263540ac8cb9
     status: 200 OK
     code: 200
     duration: ""
@@ -2735,241 +2867,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/929d4c74-2aff-47ea-a2f1-0b1c54824de4
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1903"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 62b1387d-ebd6-4ac1-980c-0728a6e560fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d9f620c3-99b0-488c-9d39-cfa29fad25ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c21d0d35-39f8-42cf-8490-9505fada1c8e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1903"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a41a5b0f-0769-4f65-a8dd-26775eb55e6a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1879"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8b2f1130-ffc3-4353-afaf-95d26e13e8c0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fc067bb1-6623-4155-b6fc-1cc6dbd4b607
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/303cca5c-abd0-44c2-8847-857df8294025
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-21T16:04:08.915067Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"303cca5c-abd0-44c2-8847-857df8294025","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:04:08.915067Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8d5169f-1857-488f-9034-411aa40c10fc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72
-    method: GET
-  response:
-    body: '{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "390"
@@ -2978,7 +2879,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2988,7 +2889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0040ce68-26fa-4779-ae4a-fcce2f3095f3
+      - 944776d2-bd4a-45c4-93cd-bff5cf90446b
     status: 200 OK
     code: 200
     duration: ""
@@ -2999,19 +2900,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c02ab383-e20f-402b-9854-849643ad5b40
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:02:41.945664Z","dhcp_enabled":true,"id":"c02ab383-e20f-402b-9854-849643ad5b40","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:02:41.945664Z","id":"08945ed1-802a-4775-99bc-4a1bdfe7b0fa","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:57.445049Z"},{"created_at":"2023-11-21T16:02:41.945664Z","id":"a40e0e63-fcdb-4f23-b368-0505333a8054","subnet":"fd5c:d510:d730:e445::/64","updated_at":"2023-11-21T16:03:57.449599Z"}],"tags":[],"updated_at":"2023-11-21T16:04:04.728067Z","vpc_id":"27d130bf-6e34-42f0-8c58-bc13a9fb55ce"}'
+    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:30.405111Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:18:30.410109Z"}],"tags":[],"updated_at":"2023-12-18T13:18:37.444983Z","vpc_id":"4a115924-8c5e-49f8-8294-c0c9297ea9b9"}'
     headers:
       Content-Length:
-      - "702"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3021,7 +2922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59fef91c-2513-490d-bfa2-9daa2e20a144
+      - 27c48c36-8614-4158-a9e4-73bf9568d835
     status: 200 OK
     code: 200
     duration: ""
@@ -3032,10 +2933,307 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/38889f09-cb5d-4932-b98a-5f2e92cb3c79
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    headers:
+      Content-Length:
+      - "717"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ac49f51-44fe-4738-b7db-06d77f479cc0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fda9c4c7-6a93-4e9a-ba15-d677a3d513cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 843c71e1-108a-4d97-89b6-fd996f94deb8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbf4daa7-edae-40cd-8291-bf49e009c792
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1250"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c50ef2c7-3ecb-4b25-a508-b8cd26857d86
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 24982b87-4543-49ae-ace6-c6bd10522696
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1731"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d6879acb-d04b-4afe-b11b-938f1cf9917e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4fa1d270-7018-46d2-bd7e-fa3f65b7d938
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "283"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca17ca07-ddc8-4e05-8d1b-6ad99575d588
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/588e6ee2-c516-4f79-99a2-9bd52977f31e
+    method: GET
+  response:
+    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "568"
@@ -3044,7 +3242,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3054,7 +3252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb46a4aa-886e-4dc4-ba87-fdcd9cfdf6ca
+      - b55ed2b5-1f9f-4712-a575-ce16f348b6b3
     status: 200 OK
     code: 200
     duration: ""
@@ -3065,10 +3263,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/303cca5c-abd0-44c2-8847-857df8294025
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:04:08.915067Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"303cca5c-abd0-44c2-8847-857df8294025","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:04:08.915067Z","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1903"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 311ca298-03f3-40a5-ab7e-fc98bd2732a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -3077,7 +3308,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3087,7 +3318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 458a467f-e414-47d5-9b74-2af17a552ce4
+      - e2101c7a-5555-41c7-b5e8-becf15705e6d
     status: 200 OK
     code: 200
     duration: ""
@@ -3098,19 +3329,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T15:59:03.986417Z","dhcp_enabled":true,"id":"f914abaf-aacf-426f-8489-24a570c2ef6f","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T15:59:03.986417Z","id":"6269a5ac-6568-4394-b84c-ee47364e35d1","subnet":"172.16.0.0/22","updated_at":"2023-11-21T15:59:03.986417Z"},{"created_at":"2023-11-21T15:59:03.986417Z","id":"edfe4950-33eb-4159-b4c6-4659a51b7b06","subnet":"fd5c:d510:d730:566::/64","updated_at":"2023-11-21T15:59:03.986417Z"}],"tags":[],"updated_at":"2023-11-21T16:02:41.948499Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
     headers:
       Content-Length:
-      - "715"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3120,7 +3351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ffa3f56-933f-4145-9ee0-6a869c3e7697
+      - 83d82f52-3356-47d5-bab7-fadcc2188bee
     status: 200 OK
     code: 200
     duration: ""
@@ -3131,19 +3362,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/929d4c74-2aff-47ea-a2f1-0b1c54824de4
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3153,7 +3384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ec6b3b5-fdd9-4dbd-abfb-81db991b6b74
+      - 5dbd1a78-2d47-4269-b636-9a85c1ee06af
     status: 200 OK
     code: 200
     duration: ""
@@ -3164,19 +3395,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:30.405111Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:18:30.410109Z"}],"tags":[],"updated_at":"2023-12-18T13:18:37.444983Z","vpc_id":"4a115924-8c5e-49f8-8294-c0c9297ea9b9"}'
     headers:
       Content-Length:
-      - "966"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3186,7 +3417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e0d852b-21fe-4144-9969-e9fbc88bb9fd
+      - 258a2816-a990-4071-a31e-d0734270b340
     status: 200 OK
     code: 200
     duration: ""
@@ -3197,76 +3428,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1903"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 267c4888-b280-47d3-a59d-233a5e7a7aca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1453"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a9e1a7dc-b0cd-494e-a444-93760e7c0ae5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -3275,7 +3440,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3285,7 +3450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e605ca2-08d0-46f1-ae08-8e2cd404bf5f
+      - 3f138593-4cd5-4acc-871c-076fe114d928
     status: 200 OK
     code: 200
     duration: ""
@@ -3296,19 +3461,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1903"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:11 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3318,7 +3483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17109b70-ed29-41fa-957d-978287e89abd
+      - 13b1e544-c3c7-405f-8f01-d1cb75633d43
     status: 200 OK
     code: 200
     duration: ""
@@ -3329,10 +3494,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/303cca5c-abd0-44c2-8847-857df8294025
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:04:08.915067Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"303cca5c-abd0-44c2-8847-857df8294025","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-11-21T16:04:08.915067Z","zone":"nl-ams-1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1250"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e89aa675-af11-4fbb-9354-02c7e21d1480
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "966"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86116eeb-c9d7-4ce3-8f81-7b9b2206fdd8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1731"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c91568ae-73a2-4545-9e96-e5ef272e360c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b3d27c84-5e5d-4d34-8f05-663dbcfb33e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
+    method: GET
+  response:
+    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "283"
@@ -3341,7 +3638,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3351,7 +3648,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4da0934f-760f-42b0-aa16-23c4c7b07827
+      - 817db8b6-a1d9-48c1-89b7-eae4c0ff3a83
     status: 200 OK
     code: 200
     duration: ""
@@ -3362,10 +3659,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1903"
@@ -3374,7 +3671,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3384,7 +3681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d176f4a-0963-4bfd-afa4-27439a790eb1
+      - 095d9155-a2b0-4ab7-9686-74fbfaf2b402
     status: 200 OK
     code: 200
     duration: ""
@@ -3395,7 +3692,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/303cca5c-abd0-44c2-8847-857df8294025
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
     method: DELETE
   response:
     body: ""
@@ -3405,7 +3702,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3415,7 +3712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ccd8c55-8c2e-4a2f-8458-47ff690cc407
+      - da539ece-5124-4fc3-a564-f652c298b8d3
     status: 204 No Content
     code: 204
     duration: ""
@@ -3426,10 +3723,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "1903"
@@ -3438,7 +3735,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3448,7 +3745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9731d159-fc1b-4f2b-a304-78ac6cd92923
+      - 66f3dfdc-ec76-4df3-9c3e-40314d100a7d
     status: 200 OK
     code: 200
     duration: ""
@@ -3459,10 +3756,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"ready","updated_at":"2023-11-21T16:04:07.245134Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "966"
@@ -3471,7 +3768,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3481,7 +3778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fef492f9-d6dd-4c47-81a9-ab454d0dd297
+      - f95c08c1-0775-464a-bca7-bdd2d0376da4
     status: 200 OK
     code: 200
     duration: ""
@@ -3492,19 +3789,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3514,7 +3811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa220398-5abd-4c18-a1e1-a3e690291e4f
+      - 616d1fe5-5be1-4156-8b43-6de13d51e78e
     status: 200 OK
     code: 200
     duration: ""
@@ -3525,7 +3822,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3535,7 +3832,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3545,7 +3842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3dbadc2-8d03-4bbf-a7f0-26a086548811
+      - 7a492a60-d0b9-4c97-bfe2-38726f9a07c1
     status: 204 No Content
     code: 204
     duration: ""
@@ -3556,10 +3853,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-21T16:03:57.908213Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-21T16:03:50.611576Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:50.611576Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"32c3f230-43ff-42a3-b7da-85396827bfd9","ipam_config":null,"mac_address":"02:00:00:11:FB:DF","private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","status":"detaching","updated_at":"2023-11-21T16:04:12.756478Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"detaching","updated_at":"2023-12-18T13:18:43.989027Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "970"
@@ -3568,7 +3865,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3578,7 +3875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d65723b9-7074-4061-96f4-45a923e93b02
+      - 4e6c4083-cc05-4e08-9843-503c058933a2
     status: 200 OK
     code: 200
     duration: ""
@@ -3589,19 +3886,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3611,7 +3908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 527d886f-19e4-446e-b28f-eef0e1f61059
+      - 6bc09efa-e727-4765-872a-21d48c819a6a
     status: 200 OK
     code: 200
     duration: ""
@@ -3622,7 +3919,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f914abaf-aacf-426f-8489-24a570c2ef6f
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
     method: DELETE
   response:
     body: ""
@@ -3632,7 +3929,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:12 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3642,7 +3939,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ccd6647-de12-4834-917e-9b4aa868fcc2
+      - ed431ca4-28c7-486d-9ee5-f13033a2d996
     status: 204 No Content
     code: 204
     duration: ""
@@ -3655,19 +3952,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:13 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3677,7 +3974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca07b8cc-b913-413d-b201-7941577a14ca
+      - ae8e7c41-e63f-4eb8-851b-cf46c0082fdb
     status: 200 OK
     code: 200
     duration: ""
@@ -3688,19 +3985,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1453"
+      - "1250"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:13 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3710,7 +4007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0592b6a8-df3e-42dd-9075-f1d97063b97c
+      - cf4a7af4-2c12-47bd-b9c9-69b91bb4941e
     status: 200 OK
     code: 200
     duration: ""
@@ -3721,7 +4018,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/48aa9dfc-2625-4350-b089-fb2dd547d871
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/c0f08595-6f0e-47cd-bd51-f73dee67723d
     method: DELETE
   response:
     body: ""
@@ -3731,7 +4028,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:13 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3741,7 +4038,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05d8e0be-a003-4b94-9c6d-8d9e7685ab7d
+      - 82e6e861-c4f6-4f9f-90b3-aedccc36d9a9
     status: 204 No Content
     code: 204
     duration: ""
@@ -3752,19 +4049,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"48aa9dfc-2625-4350-b089-fb2dd547d871","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"c02ab383-e20f-402b-9854-849643ad5b40","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}},{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1459"
+      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:13 GMT
+      - Mon, 18 Dec 2023 13:18:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3774,7 +4071,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89717c03-ddf4-49a8-90b0-5331acfbcbbf
+      - cafb4360-5f56-4436-9f06-bd0dde24b6e5
     status: 200 OK
     code: 200
     duration: ""
@@ -3785,10 +4082,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/32c3f230-43ff-42a3-b7da-85396827bfd9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"32c3f230-43ff-42a3-b7da-85396827bfd9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3797,7 +4094,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:17 GMT
+      - Mon, 18 Dec 2023 13:18:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3807,7 +4104,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41ff23f9-1469-4388-802f-7b18f03a7b72
+      - 07b77482-68a6-4348-bc59-a61aed49e1bd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3818,10 +4115,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "937"
@@ -3830,7 +4127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:17 GMT
+      - Mon, 18 Dec 2023 13:18:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3840,7 +4137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c7e8ece-57ef-4fd8-a0ec-08df3f8808c5
+      - e4f506af-0f11-4c05-9263-7a174bbec31c
     status: 200 OK
     code: 200
     duration: ""
@@ -3851,10 +4148,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/38889f09-cb5d-4932-b98a-5f2e92cb3c79
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/588e6ee2-c516-4f79-99a2-9bd52977f31e
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"38889f09-cb5d-4932-b98a-5f2e92cb3c79","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3863,7 +4160,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:18 GMT
+      - Mon, 18 Dec 2023 13:18:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3873,7 +4170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a01eac0-a86e-447a-907e-12531d998e68
+      - 2d6c37eb-c4d7-4bdb-8927-a0fe2f98d9a2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3884,10 +4181,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-21T16:03:51.550366Z","gateway_networks":[],"id":"d92c06a0-f83c-437b-b222-0507cccfd294","ip":{"address":"51.15.34.204","created_at":"2023-11-21T16:03:51.257080Z","gateway_id":"d92c06a0-f83c-437b-b222-0507cccfd294","id":"b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"204-34-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-21T16:03:51.257080Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-11-21T16:04:07.364565Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
     headers:
       Content-Length:
       - "937"
@@ -3896,7 +4193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:18 GMT
+      - Mon, 18 Dec 2023 13:18:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3906,7 +4203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71279b4e-d851-4d16-9c44-80e0383d320b
+      - 8cadf2b4-d494-475c-9fad-b520b708b763
     status: 200 OK
     code: 200
     duration: ""
@@ -3917,7 +4214,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3927,7 +4224,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:18 GMT
+      - Mon, 18 Dec 2023 13:18:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3937,7 +4234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96377310-9195-4cb7-aa7a-158422012989
+      - 93d5ffae-99a8-4025-b59e-cfa6e7b9828b
     status: 204 No Content
     code: 204
     duration: ""
@@ -3948,10 +4245,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/d92c06a0-f83c-437b-b222-0507cccfd294
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"d92c06a0-f83c-437b-b222-0507cccfd294","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3960,7 +4257,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:18 GMT
+      - Mon, 18 Dec 2023 13:18:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3970,7 +4267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf3b894c-4ad2-4e6c-8a1c-b9b1cfa9c77e
+      - 5ed21c75-b03d-4f39-9aac-5f6c2d1de668
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3981,7 +4278,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/b1498d6a-0a9f-4eb6-b06e-14a9b0a97c72
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/929d4c74-2aff-47ea-a2f1-0b1c54824de4
     method: DELETE
   response:
     body: ""
@@ -3991,7 +4288,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:18 GMT
+      - Mon, 18 Dec 2023 13:18:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4001,7 +4298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e85725c1-9b42-4abf-a6a1-87d05b2e8265
+      - e725890c-900a-48b1-87c9-435b3bfa3bee
     status: 204 No Content
     code: 204
     duration: ""
@@ -4012,19 +4309,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1030"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:43 GMT
+      - Mon, 18 Dec 2023 13:19:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4034,7 +4331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94ff107d-9f1a-4fc1-9ff3-ca66baf6a269
+      - b387d82f-164b-40e9-8ed8-f4b4d008506a
     status: 200 OK
     code: 200
     duration: ""
@@ -4045,19 +4342,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1232"
+      - "1030"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:44 GMT
+      - Mon, 18 Dec 2023 13:19:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4067,7 +4364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 837dde59-a804-40fd-9568-462bd003147f
+      - 8897400a-2291-42d8-b735-ef805d286b3b
     status: 200 OK
     code: 200
     duration: ""
@@ -4078,19 +4375,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1879"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:44 GMT
+      - Mon, 18 Dec 2023 13:19:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4100,7 +4397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eae3dcaf-ae74-411f-955b-9c38f8005d47
+      - 07a52055-d0c3-44fb-bd75-26db5a0f2616
     status: 200 OK
     code: 200
     duration: ""
@@ -4111,19 +4408,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c02ab383-e20f-402b-9854-849643ad5b40
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:02:41.945664Z","dhcp_enabled":true,"id":"c02ab383-e20f-402b-9854-849643ad5b40","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-11-21T16:02:41.945664Z","id":"08945ed1-802a-4775-99bc-4a1bdfe7b0fa","subnet":"192.168.1.0/24","updated_at":"2023-11-21T16:03:57.445049Z"},{"created_at":"2023-11-21T16:02:41.945664Z","id":"a40e0e63-fcdb-4f23-b368-0505333a8054","subnet":"fd5c:d510:d730:e445::/64","updated_at":"2023-11-21T16:03:57.449599Z"}],"tags":[],"updated_at":"2023-11-21T16:04:12.919808Z","vpc_id":"27d130bf-6e34-42f0-8c58-bc13a9fb55ce"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "702"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:44 GMT
+      - Mon, 18 Dec 2023 13:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4133,7 +4430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1852ef78-d1d8-41d6-aee1-075e39283495
+      - 30b14e16-ea77-4fdf-b639-431cc2dcdede
     status: 200 OK
     code: 200
     duration: ""
@@ -4144,19 +4441,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:30.405111Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:18:30.410109Z"}],"tags":[],"updated_at":"2023-12-18T13:18:44.146014Z","vpc_id":"4a115924-8c5e-49f8-8294-c0c9297ea9b9"}'
     headers:
       Content-Length:
-      - "1232"
+      - "701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:44 GMT
+      - Mon, 18 Dec 2023 13:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4166,7 +4463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96f86eef-c26d-4c73-90a6-5011be9a4787
+      - 26fcb7f2-5301-4f1e-a797-89274e7f392a
     status: 200 OK
     code: 200
     duration: ""
@@ -4177,19 +4474,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUR0ekNDQXArZ0F3SUJBZ0lVWFlVTGIyQ2FPZHUwUnNHVFYxTkQ4U3MrRDM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXhNakV4TmpBeE5UbGFGdzB6TXpFeE1UZ3hOakF4TlRsYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM0Q3VDaVdUVmVxVTVmWDRxK2xyMWNIK3ltamdiMUx3NHYzd2UzZy9FQitMUU8xVnpzNXZtdXNWdXIKazZLOThmNXJmZTU0cHVaZ1QwZmNlQjNPVWVTSTZreXhPSkltTHVWbTIrcGZ5VXA2dVFSM1loUHgrb0ViTzVpawpDdHBSS0ZUYkNRUW5iN2ZOMWlhTXFSY21BNkJjZzQyU09kcWpBdTNjMUU0b1dlaWppN1lBNzA3b3gyL3pSdW9OCkJrQVc0R3hDL3o4MlZid0ZKZzY0YkNxcHJuNzVlOHJ3SDFCRWF0em5kdFlCQTBrVTA5bE1DUUYybGtkbVdkWHcKYzliYTJFbzBZcHpTVVNtb1h6cDZrcnRJeDBGQXlZN091Q2JScGNrZzN5RUNZcE1xWmxlejR4Zm1YbCs0d1ptWQpUakxMM3BSZi9OZVBnY0MzRTJ0V01oOTZHVzl0QWdNQkFBR2plekI1TUhjR0ExVWRFUVJ3TUc2Q0RERTVNaTR4Ck5qZ3VNUzQwTW9JT05URXVNVFU0TGpFek1TNHhPVEdDUEhKM0xUUmlPRFUwWmpZMkxUaGxaV1V0TkdJNU1TMDQKWWpJeUxXRTBZakV3WmpkbFpqWXhZeTV5WkdJdWJtd3RZVzF6TG5OamR5NWpiRzkxWkljRU13OWhBb2NFd0tnQgpLb2NFTTU2RHZ6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFacVVPVGREZVlkeFhBWlhUU2dualJOaWZhWG9NClRVQ25naU0xMGZGMmhLMm5rNzd3RU94V0RkV21raUVtZFk5RVo4Y3FvTHZqb0dzUm1jSUpXMTVWMjhlK1VXZ1MKMnkzNDQzbGM2QkpoTkhUU2JkK3Z5UWtlQVdTV08xdzcxU0dZdlRyZGljenZhZjJ0L1MxRlBwR0w3RzZRaCt6UwpHbGU3bVA1aGhieUlNNWQ4RTZBeVUzd0MzaXMwbHdaY0M2RnB2T2xrYXExKzNoNWFDSXV4cThUL1dOWUdLNWQ5Ck9FTkRvcWFrZUx5b0l5c0VWeGVGenFGYzZuT1BXU2t2WUtuWFhrWHRvWkdZWHRLQTcydFVEZWRuR1RwN1AyWisKWXJpNjNsYjk1enRKNTd5Z2ptbkdIYWdrL3Q4SC94Yzdtd1E2QTRTbGVrSGRQd1RXMmdESm54aUx6dz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1879"
+      - "1030"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:44 GMT
+      - Mon, 18 Dec 2023 13:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4199,7 +4496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff27ee55-227e-4fec-b484-fd867e322439
+      - e0ed04e6-81f6-40a2-b54c-f0b015fd9941
     status: 200 OK
     code: 200
     duration: ""
@@ -4210,19 +4507,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1232"
+      - "1731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:45 GMT
+      - Mon, 18 Dec 2023 13:19:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4232,7 +4529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66e25088-a336-49ea-9cd0-c4e99ec5951e
+      - f2699a06-1102-4092-bc9c-d98c4a8cb356
     status: 200 OK
     code: 200
     duration: ""
@@ -4243,7 +4540,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/c02ab383-e20f-402b-9854-849643ad5b40
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:19:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ceccc769-c071-42b4-b456-c8bb05e48fd3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1030"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:19:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b5d1e25f-c7e3-484b-87b5-e3d7282c311f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
     method: DELETE
   response:
     body: ""
@@ -4253,7 +4616,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:45 GMT
+      - Mon, 18 Dec 2023 13:19:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4263,7 +4626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6863d86e-4a15-4336-a5ec-848d2f0cb517
+      - fc511ed1-a454-4de9-8e54-3f6b1146b8c8
     status: 204 No Content
     code: 204
     duration: ""
@@ -4274,19 +4637,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1235"
+      - "1033"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:45 GMT
+      - Mon, 18 Dec 2023 13:19:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4296,7 +4659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f7a3372-5d99-48f6-88d7-919855f8ddc1
+      - d1280e18-2e20-4efb-9cab-c3aaf4fe71cc
     status: 200 OK
     code: 200
     duration: ""
@@ -4307,19 +4670,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:06.521949Z","endpoint":{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887},"endpoints":[{"id":"0f37bffe-527f-4539-95ae-9d2337ce0f26","ip":"51.158.131.191","load_balancer":{},"name":null,"port":25887}],"engine":"PostgreSQL-15","id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1235"
+      - "1033"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:45 GMT
+      - Mon, 18 Dec 2023 13:19:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4329,7 +4692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0c5dcb6-0d6e-43fb-8d28-a8c413462495
+      - f7cc9eb2-c47e-4cee-9737-9dbe78e2b3c8
     status: 200 OK
     code: 200
     duration: ""
@@ -4340,10 +4703,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e0a34b56-b006-48fe-b123-62541f35fcbb","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4352,7 +4715,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:16 GMT
+      - Mon, 18 Dec 2023 13:19:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4362,7 +4725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c428975c-fa01-46e4-97ab-d3e7efb39b14
+      - 63099567-6313-4666-b6ce-715966b265de
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4373,10 +4736,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/4b854f66-8eee-4b91-8b22-a4b10f7ef61c
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"4b854f66-8eee-4b91-8b22-a4b10f7ef61c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e0a34b56-b006-48fe-b123-62541f35fcbb","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4385,7 +4748,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:16 GMT
+      - Mon, 18 Dec 2023 13:19:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4395,7 +4758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9affb023-a1f3-41f7-bca0-a9fbbef5c40b
+      - 4d533841-ffa5-4bf8-93e1-7de732ea69d8
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-settings.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-settings.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:53 GMT
+      - Mon, 18 Dec 2023 12:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 797b5354-7b9c-46d6-8942-aa43a1499c4f
+      - 7edd4d4c-bdc9-43f8-8212-6f9f49554bdf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-instance-settings","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":null,"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:44 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4976c0b0-59a6-40c6-92b9-1529177d868f
+      - cdc0ffad-1920-4123-9a89-fef86e718929
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:44 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbf9ee3c-9b38-4dfe-b736-b978261a7ff9
+      - 7cfbde54-e2ba-4596-992e-ab26ce0cdaa2
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:14 GMT
+      - Mon, 18 Dec 2023 12:57:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83ed43c5-5a61-4ccd-b66d-bd4bcc78c7a5
+      - 0927a255-86a7-4bbd-b7e0-c21102c7ad22
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:45 GMT
+      - Mon, 18 Dec 2023 12:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 741a0696-df74-402e-b72c-e157ab409505
+      - 9c0bb1b9-2721-45b1-8d7a-1173545b3f06
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:15 GMT
+      - Mon, 18 Dec 2023 12:58:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a92e807b-51e2-43ca-982d-1e5103796085
+      - 39c4393a-3ee8-4202-aa85-f02e56d0a52d
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:45 GMT
+      - Mon, 18 Dec 2023 12:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96a34987-ff12-4432-ad39-21372551a4b4
+      - 8de6b1bb-8449-4f94-9b00-05517d50f8c6
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "698"
+      - "882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:15 GMT
+      - Mon, 18 Dec 2023 12:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a1cc1e3-e4a1-478a-abe7-9d0a80225b74
+      - 71c37f05-9d5e-4aa5-99ad-9038c9f3e361
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "962"
+      - "1146"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:45 GMT
+      - Mon, 18 Dec 2023 13:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d347263-dae7-4084-957b-127f9cc1981b
+      - 480a99de-2396-457c-ac1c-7a65a9e853a8
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384},"endpoints":[{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384}],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1169"
+      - "1193"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:16 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,12 +627,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fc04be2-31f2-4157-839b-c90aac2fe8de
+      - 364d3da7-8b67-4dc8-ba84-94eb198667a7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"settings":[{"name":"max_parallel_workers","value":"2"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"work_mem","value":"4"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers_per_gather","value":"2"}]}'
+    body: '{"settings":[{"name":"work_mem","value":"4"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"maintenance_work_mem","value":"150"}]}'
     form: {}
     headers:
       Content-Type:
@@ -640,10 +640,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0/settings
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608/settings
     method: PUT
   response:
-    body: '{"settings":[{"name":"max_parallel_workers","value":"2"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"work_mem","value":"4"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers_per_gather","value":"2"}]}'
+    body: '{"settings":[{"name":"work_mem","value":"4"},{"name":"effective_cache_size","value":"1300"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"maintenance_work_mem","value":"150"}]}'
     headers:
       Content-Length:
       - "279"
@@ -652,7 +652,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:16 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07b9e542-b695-4845-a153-91e41b775f00
+      - 4e3ce671-02eb-4221-bacb-e0cab699c76b
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384},"endpoints":[{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384}],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1175"
+      - "1199"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:16 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01cb5775-f464-4f95-858d-bc5ca22d17be
+      - be5bc227-7d94-46a4-8c0d-f220f243d0ea
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384},"endpoints":[{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384}],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1169"
+      - "1193"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:49 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb56c64a-bec1-4720-b42a-6424ccffe33e
+      - c728d00d-3a30-4cc2-9ecc-b5bf6c11c38b
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUSsrSkYvbmk2SmMzUmhLRENTWFNlSGd6Wi84d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZd05UTXlXaGNOTXpNeE1URTRNVFl3TlRNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9Bc1laMnQzSGtMZ2FJM0VpRFExSER4WVBXcEI4L09tRDAvR1hwTy9ydXhlQW9ROVJGQW1saGwKM3hDSmZrYXdURmxxaXNYVFd5am1nU25oSk1ER3puZ1VKdmZ4ZmU2ZlkxYVlHbTM5VnFEUTdpam82a3NhYk1JdgptNFNSakV5UmpXRjJ6cGpYekJkRy9IanhLMll0TmpKZENSRVFUV0F0TXZWYXRBRERGdjJHY1c2NEhVeGZkNDR3CmtuVHpFWXJuMW8vanFKcS9CQ2tqVTBVWkdkK1l6aDlDczRjVHAxZ3Fod0JpQzM1MlFMSGxRcUYwcnIxd1MxMDYKNWpIamEyZTNuNXI3NDBtM081cjlxUGpVd1l4MkJxRWdjQjlVVjZEdUFiWHc4ZTFPYzAxWkV3NzBKb0lJdGdLcQo5MGZqczBtYnVHYXg5TmI5eDNpZGFpZkV5clV3SWNrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0WVRVNFlURTNZemt0WldVellTMDBOR1JrTFdFd05qVXRNVGxtWWprM05ETmkKTVdRd0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckwzQmh3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQlByYjdWZ2M2MEk2TUtWN3kzNUZCOXpiRUw0VzY1eWFubDQxUjFSL1Y3aUtsSXpEUjNkTGgrClJEK1lqMHlUS2VUSnZrUHFsZDdUb2ZWaklGa0hlRUJvZmFNc3loa0hkdkEvdVdWRGNrVFFITjVSTHlsVDM0aEYKbFdublBOWGZobCtjTjhkeTM0cG92eGh2dlhZanQvelJneVloa1QzMGhWU0ttVTFzbWcyUWhEM2pOdlRrcVdRYgpoYldmMmxPOUE4bXZzQ2s4L0hZOVM4KzlHSVBjMmJ1anJJM1BUcEg0aElNV1huVUxCS3cxNDJzbXIwL2pLZ3lNCnlTQnY5aWgxRURtL1MrMGk0WE9XNWN3OWh2SjdFeUVBbmJCd21RUEZ6OE1JSVlxeDMxeVlHd1VuaGRtSlJ2cVIKMkZmOGdveHJ4enpveFVON0t6aEp5VXVnUTBTSi9pOVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVWWV4eDhWUzRHVnJUN0lweDFqZlF6VzU1czFrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QXdNRFJhRncwek16RXlNVFV4TXpBd01EUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2JhZVNmU1drTjdrY1kxTFFxVTluWnZGVEpJQU9TZUNSMzFxUFJOMlR3Qkd5RjZOYmoKL0FFN2MyWXo0Z1FQR1pPZU5GU09acG5jdDlmbWVNNWVjclhwVElYWEdhbEMvOGdYYU01ZWhYdVR0OUxhOVNZbApVVExNZVlxa3p6ekZnclhwTmhYcjBGWHREQy93eWdyY1FaSCswRXZrakZUbFVZMFlwdXE0cFljajl6QzBiSTM0CmtTWmdoRlJZQUw2bmVqTlgwT2d5RnBXZkRlRDRSN1VNdG9hWGRBWDNWUkhHdzJVaGJURVNKNkpORGI5ZVptNUIKY21OY2d0TzFZUXVkM0JtQ0NTMjVxMEtBZnhQeC9sMGFkYzZFZjBKdU1YR0czallJZVZvRS9jVUlLZ1dlYlVKawpIaFhRNUpTSVdtdWpZTXRxNysyc0dHMFFMU0w1cGMzc0s3WXZBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwNU16SXpZVE5oTWkwek1EUTRMVFJpTldJdE9UUTUKTkMwd1lXWXhOalV5TXpRMk1EZ3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RPVE15TTJFellUSXRNekEwT0MwMFlqVmlMVGswT1RRdE1HRm1NVFkxTWpNME5qQTRMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySTlmaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNWaEJRZmE4WXhCOUREOFJqNkkwdEVHUU9CUjl4aWFwSXloZS9zeFVTby8wYkUwNWN1SmtWQgpWMjVBdDJDUGhTRVFVRGdxUjNQL1YyTFhLTWFPbkk2RW1rMXkyZVpYd1NUcW9QRG1PN0hmMlVidU5PZGJGd0hiCkFuazNKTmlkZWRNcjJlaVlaaTlSakIzL096WmFzY1k0OWp0eExmV05LR3NaT2Q4RXNJc3ZuVW9vVi9Ob2xxUWcKY0tzbXd4MFZqeHdybkpUWHN5OVBhektkVGp4OUdmQXN3YXcrMmFwcjlEQnJHL2s5MFZrS1NqWGh5K3hvZVdjWgo4ZFV1WjVyMk1IazB0SnFqKzVZTVkvaGtPOTlqazBxbnBHYUhFQjV3cUZlamgzdmd0V0ViNUFYUDBEU042R2IrClJsUFhPaUNTTHRWR1hXM3FFRXpOWnZBcDFZRnpnRFBtCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:49 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f880577-d4ec-4bc7-a064-5c7463ea5ef5
+      - 8f63dab0-14e8-4627-95cd-7fbacdeb8e9b
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9323a3a2-3048-4b5b-9494-0af165234608&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384},"endpoints":[{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384}],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1169"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:50 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c37849a-c3e3-481e-a202-eb0729bfccbd
+      - 8f4e0867-9d58-4ad5-aa19-c6d8826e6801
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384},"endpoints":[{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384}],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1169"
+      - "1193"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:50 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67582200-3d01-4171-9158-77d327efa6be
+      - df6046b3-1f9a-4d1d-88ab-5fda5c7c1a24
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVUSsrSkYvbmk2SmMzUmhLRENTWFNlSGd6Wi84d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZd05UTXlXaGNOTXpNeE1URTRNVFl3TlRNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9Bc1laMnQzSGtMZ2FJM0VpRFExSER4WVBXcEI4L09tRDAvR1hwTy9ydXhlQW9ROVJGQW1saGwKM3hDSmZrYXdURmxxaXNYVFd5am1nU25oSk1ER3puZ1VKdmZ4ZmU2ZlkxYVlHbTM5VnFEUTdpam82a3NhYk1JdgptNFNSakV5UmpXRjJ6cGpYekJkRy9IanhLMll0TmpKZENSRVFUV0F0TXZWYXRBRERGdjJHY1c2NEhVeGZkNDR3CmtuVHpFWXJuMW8vanFKcS9CQ2tqVTBVWkdkK1l6aDlDczRjVHAxZ3Fod0JpQzM1MlFMSGxRcUYwcnIxd1MxMDYKNWpIamEyZTNuNXI3NDBtM081cjlxUGpVd1l4MkJxRWdjQjlVVjZEdUFiWHc4ZTFPYzAxWkV3NzBKb0lJdGdLcQo5MGZqczBtYnVHYXg5TmI5eDNpZGFpZkV5clV3SWNrQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0WVRVNFlURTNZemt0WldVellTMDBOR1JrTFdFd05qVXRNVGxtWWprM05ETmkKTVdRd0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1NqckwzQmh3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQlByYjdWZ2M2MEk2TUtWN3kzNUZCOXpiRUw0VzY1eWFubDQxUjFSL1Y3aUtsSXpEUjNkTGgrClJEK1lqMHlUS2VUSnZrUHFsZDdUb2ZWaklGa0hlRUJvZmFNc3loa0hkdkEvdVdWRGNrVFFITjVSTHlsVDM0aEYKbFdublBOWGZobCtjTjhkeTM0cG92eGh2dlhZanQvelJneVloa1QzMGhWU0ttVTFzbWcyUWhEM2pOdlRrcVdRYgpoYldmMmxPOUE4bXZzQ2s4L0hZOVM4KzlHSVBjMmJ1anJJM1BUcEg0aElNV1huVUxCS3cxNDJzbXIwL2pLZ3lNCnlTQnY5aWgxRURtL1MrMGk0WE9XNWN3OWh2SjdFeUVBbmJCd21RUEZ6OE1JSVlxeDMxeVlHd1VuaGRtSlJ2cVIKMkZmOGdveHJ4enpveFVON0t6aEp5VXVnUTBTSi9pOVIKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1843"
+      - "1193"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:51 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a493dc8c-39af-4a77-b408-f7e7d1fc3d51
+      - 914db4ec-3b2a-4e3a-9932-0dc5a0938620
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384},"endpoints":[{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384}],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVWWV4eDhWUzRHVnJUN0lweDFqZlF6VzU1czFrd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QXdNRFJhRncwek16RXlNVFV4TXpBd01EUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2JhZVNmU1drTjdrY1kxTFFxVTluWnZGVEpJQU9TZUNSMzFxUFJOMlR3Qkd5RjZOYmoKL0FFN2MyWXo0Z1FQR1pPZU5GU09acG5jdDlmbWVNNWVjclhwVElYWEdhbEMvOGdYYU01ZWhYdVR0OUxhOVNZbApVVExNZVlxa3p6ekZnclhwTmhYcjBGWHREQy93eWdyY1FaSCswRXZrakZUbFVZMFlwdXE0cFljajl6QzBiSTM0CmtTWmdoRlJZQUw2bmVqTlgwT2d5RnBXZkRlRDRSN1VNdG9hWGRBWDNWUkhHdzJVaGJURVNKNkpORGI5ZVptNUIKY21OY2d0TzFZUXVkM0JtQ0NTMjVxMEtBZnhQeC9sMGFkYzZFZjBKdU1YR0czallJZVZvRS9jVUlLZ1dlYlVKawpIaFhRNUpTSVdtdWpZTXRxNysyc0dHMFFMU0w1cGMzc0s3WXZBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwNU16SXpZVE5oTWkwek1EUTRMVFJpTldJdE9UUTUKTkMwd1lXWXhOalV5TXpRMk1EZ3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RPVE15TTJFellUSXRNekEwT0MwMFlqVmlMVGswT1RRdE1HRm1NVFkxTWpNME5qQTRMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySTlmaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNWaEJRZmE4WXhCOUREOFJqNkkwdEVHUU9CUjl4aWFwSXloZS9zeFVTby8wYkUwNWN1SmtWQgpWMjVBdDJDUGhTRVFVRGdxUjNQL1YyTFhLTWFPbkk2RW1rMXkyZVpYd1NUcW9QRG1PN0hmMlVidU5PZGJGd0hiCkFuazNKTmlkZWRNcjJlaVlaaTlSakIzL096WmFzY1k0OWp0eExmV05LR3NaT2Q4RXNJc3ZuVW9vVi9Ob2xxUWcKY0tzbXd4MFZqeHdybkpUWHN5OVBhektkVGp4OUdmQXN3YXcrMmFwcjlEQnJHL2s5MFZrS1NqWGh5K3hvZVdjWgo4ZFV1WjVyMk1IazB0SnFqKzVZTVkvaGtPOTlqazBxbnBHYUhFQjV3cUZlamgzdmd0V0ViNUFYUDBEU042R2IrClJsUFhPaUNTTHRWR1hXM3FFRXpOWnZBcDFZRnpnRFBtCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1169"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:51 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4afb75c0-0c2d-47bf-807f-5a64ff25cab1
+      - 5da632c9-c4f5-41b0-a5bf-cac71aac90c0
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +904,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9323a3a2-3048-4b5b-9494-0af165234608&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ab46bb1-8403-462d-bd96-8c5cbefc337a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"ready","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1193"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 848091cf-a782-4593-8285-1e4bb9a0d063
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384},"endpoints":[{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384}],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1196"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:52 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77eb4ddb-696c-4500-aca8-0f19bba70a17
+      - b93d431b-a953-4ced-a7b0-0a6cae4bae92
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:02:44.308556Z","endpoint":{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384},"endpoints":[{"id":"ab4130dd-c38d-4a42-b155-a7ac52d23ebe","ip":"51.159.26.205","load_balancer":{},"name":null,"port":4384}],"engine":"PostgreSQL-15","id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.515367Z","endpoint":{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534},"endpoints":[{"id":"01c5c27a-9fe1-4fb9-8d09-02af885ae8b8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":18534}],"engine":"PostgreSQL-15","id":"9323a3a2-3048-4b5b-9494-0af165234608","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-settings","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"200"},{"name":"max_parallel_workers","value":"2"},{"name":"max_parallel_workers_per_gather","value":"2"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":[],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1172"
+      - "1196"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:52 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b751e3f-0d00-4fd5-8e9c-5245b7db2c24
+      - 517eb175-31cf-4e27-b79f-d64512ba077c
     status: 200 OK
     code: 200
     duration: ""
@@ -970,10 +1036,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"9323a3a2-3048-4b5b-9494-0af165234608","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -982,7 +1048,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:22 GMT
+      - Mon, 18 Dec 2023 13:01:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caf46d63-41b0-4ff1-8b1d-b943fbebcfd0
+      - 75d87736-779c-4e2c-9bc2-7648e644c163
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1003,10 +1069,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a58a17c9-ee3a-44dd-a065-19fb9743b1d0
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9323a3a2-3048-4b5b-9494-0af165234608
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a58a17c9-ee3a-44dd-a065-19fb9743b1d0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"9323a3a2-3048-4b5b-9494-0af165234608","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1015,7 +1081,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:22 GMT
+      - Mon, 18 Dec 2023 13:01:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15fd1443-1f9c-4be2-a180-6d1ea1358f5a
+      - 0b0364f1-c0f7-4cbf-abee-fc18844aec7f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-volume.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-volume.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:54 GMT
+      - Mon, 18 Dec 2023 12:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 837989dc-752f-48df-a4f5-8b79d2a75a93
+      - 96cf42f5-2767-4453-9304-130a87686566
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-instance-volume","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "929"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:04 GMT
+      - Mon, 18 Dec 2023 13:07:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36843e4b-fbed-4e34-9e59-66c51eb29c33
+      - 4eeee60d-f57f-49eb-86b5-6f6a5abaa838
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "929"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:04 GMT
+      - Mon, 18 Dec 2023 13:07:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e564e95f-8ef6-4727-849a-a40adc9394bc
+      - 4fb3a66c-1345-4463-bfe1-b415c0dc90c1
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "929"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:35 GMT
+      - Mon, 18 Dec 2023 13:08:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 108fc0e7-5fc7-4693-995d-072b917f8c3d
+      - 5f8e2d2c-61db-44dc-90c6-15af0f56fab0
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "929"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:00:05 GMT
+      - Mon, 18 Dec 2023 13:08:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7d99347-8d54-4cc4-85c1-69c7e1b13d1f
+      - 8d7e2083-1ceb-4203-a607-2550401cda3e
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "929"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:00:35 GMT
+      - Mon, 18 Dec 2023 13:09:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cc11265-4a9f-4d8c-a7ce-7e524d8301e0
+      - c4942237-02a3-4c74-882e-5fc05a90ac2a
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "747"
+      - "929"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:01:05 GMT
+      - Mon, 18 Dec 2023 13:09:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d865d4a-9259-4de3-a7b6-45f0ee12a6db
+      - 1e32372a-e269-4348-a13f-a8d59176c081
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1011"
+      - "929"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:01:35 GMT
+      - Mon, 18 Dec 2023 13:10:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f23e156-55e3-475a-9188-98097a9cd2bf
+      - baa233bf-4650-4946-b47b-b7f185fca414
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1220"
+      - "929"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:05 GMT
+      - Mon, 18 Dec 2023 13:10:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0c45cd1-a8b6-420e-a2d4-371497f7afbf
+      - a592cd82-66f6-4374-86ba-fa74a05f818d
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWFhiZTMreWQrSHFpTUtlazNjWEl3OG9va3M0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1UQTFNQjRYCkRUSXpNVEV5TVRFMk1ERTBNRm9YRFRNek1URXhPREUyTURFME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TVRBMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVhZUhXT0ZNRERPNDlvckJmejlPVlFsL0hzd2Rsdi9zaklEOGFRNUFMeGJLWWdLL243bCsKeTlmR0svRHJNZWlxSmwzU2VKZjZNQmNEa3Y1REFmYVFoUkhsWG5aQzEyTXhYbEFDRlpoL3lZVHRwa3hMd1R0ago3UDlXaVdRanZyRnVORmhaV2FBblF1MTlvQVNrKzkybFhXa3YrZkxtU0hENlFPdGlOdDNQS3QydjBUMnhHd2wxCkFickpkcXlRcTQ3S0JyZGVCb3B4V3R2aUpEZFJzMHZnek5OaHBIeHpRT3dGZlJxd2o1ZHJOeXEwdXdyNVl1ejYKcXlVbTA4RXAzcTNWL3F6cW16SmZKRXgyTWQvRHd2K243NUQvbmRyUDZabWFKMUFpOElmQzZVNU9STC9SVE4wUgpubkd3OE8wR1JiMjluQ1BKL01JbVBQaDVQVWdnQ0FxamtRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqRXdOWUk4Y25jdE56TTVZMkV4WW1ZdE1XUTVOUzAwTVRZeUxUa3lOamd0WldVMFkyRmgKWlRFNFpEWXhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeDZod1F6bm9KcE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ4M0szb1I4SkNuRWxUd1R4SHE3L3FDQkxkTEtRSlhMZ0JlNjBMMXBFeXcrQ1c5aGdsCkRoYzR6SDZFTmVEWEVMdEptLzNubTBTQ2xma1p2cjY5UWJPY0R5Vlh1QUJURUpNblh5Q0ZTSmVOUXJVMVFGVmcKNFNvQ2tGNjczNWtNK2dwdTcwRnVwVDJrL0YrVjU5QjFJRjdRZXhReEVZYlE1VjVQcUZDR0NwVGlQKzE5aWIxZQp3SGZLTVg1cEU0ZStsRnhuaE1FU0pwTzNGTnpScTFGTGZrYUhPUFg1K2Q3OGVscWpOWFFmTkE4R25HV1FJUDZWCmhGTHp5TzJQajcwR2hxRWR5dzUxT3p2WnZRNloyNUhWdXdzN0tZenNvQW1IMTl5NGhkZUlxNXZtM2ZOU2N4OUEKWVRUcDN1RmRFTXJsUHpoSWdnUm5YV20wS2xUS2wwVzNCZDJsCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1847"
+      - "1236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:05 GMT
+      - Mon, 18 Dec 2023 13:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b32b2a62-2fc8-4c1f-b80f-74d8c07a291b
+      - b15d77e2-10f5-4681-9753-392d3514fb53
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1220"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:06 GMT
+      - Mon, 18 Dec 2023 13:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a6e46df-5283-42e8-9782-28a9d5941f4a
+      - 17421352-08c2-460f-9634-8fa779611ea0
     status: 200 OK
     code: 200
     duration: ""
@@ -671,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1220"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:06 GMT
+      - Mon, 18 Dec 2023 13:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0a96f7b-63c8-4e9a-85b3-8d8ce1e2572a
+      - 13bef233-2122-43af-a4f1-84170a040b1f
     status: 200 OK
     code: 200
     duration: ""
@@ -704,19 +704,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWFhiZTMreWQrSHFpTUtlazNjWEl3OG9va3M0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1UQTFNQjRYCkRUSXpNVEV5TVRFMk1ERTBNRm9YRFRNek1URXhPREUyTURFME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TVRBMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVhZUhXT0ZNRERPNDlvckJmejlPVlFsL0hzd2Rsdi9zaklEOGFRNUFMeGJLWWdLL243bCsKeTlmR0svRHJNZWlxSmwzU2VKZjZNQmNEa3Y1REFmYVFoUkhsWG5aQzEyTXhYbEFDRlpoL3lZVHRwa3hMd1R0ago3UDlXaVdRanZyRnVORmhaV2FBblF1MTlvQVNrKzkybFhXa3YrZkxtU0hENlFPdGlOdDNQS3QydjBUMnhHd2wxCkFickpkcXlRcTQ3S0JyZGVCb3B4V3R2aUpEZFJzMHZnek5OaHBIeHpRT3dGZlJxd2o1ZHJOeXEwdXdyNVl1ejYKcXlVbTA4RXAzcTNWL3F6cW16SmZKRXgyTWQvRHd2K243NUQvbmRyUDZabWFKMUFpOElmQzZVNU9STC9SVE4wUgpubkd3OE8wR1JiMjluQ1BKL01JbVBQaDVQVWdnQ0FxamtRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqRXdOWUk4Y25jdE56TTVZMkV4WW1ZdE1XUTVOUzAwTVRZeUxUa3lOamd0WldVMFkyRmgKWlRFNFpEWXhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeDZod1F6bm9KcE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ4M0szb1I4SkNuRWxUd1R4SHE3L3FDQkxkTEtRSlhMZ0JlNjBMMXBFeXcrQ1c5aGdsCkRoYzR6SDZFTmVEWEVMdEptLzNubTBTQ2xma1p2cjY5UWJPY0R5Vlh1QUJURUpNblh5Q0ZTSmVOUXJVMVFGVmcKNFNvQ2tGNjczNWtNK2dwdTcwRnVwVDJrL0YrVjU5QjFJRjdRZXhReEVZYlE1VjVQcUZDR0NwVGlQKzE5aWIxZQp3SGZLTVg1cEU0ZStsRnhuaE1FU0pwTzNGTnpScTFGTGZrYUhPUFg1K2Q3OGVscWpOWFFmTkE4R25HV1FJUDZWCmhGTHp5TzJQajcwR2hxRWR5dzUxT3p2WnZRNloyNUhWdXdzN0tZenNvQW1IMTl5NGhkZUlxNXZtM2ZOU2N4OUEKWVRUcDN1RmRFTXJsUHpoSWdnUm5YV20wS2xUS2wwVzNCZDJsCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1847"
+      - "1236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:06 GMT
+      - Mon, 18 Dec 2023 13:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,7 +726,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f43fcd1b-580b-4bfd-9201-df76c891e0d4
+      - f3a5a310-9c54-4cc9-aa77-f8185af07464
     status: 200 OK
     code: 200
     duration: ""
@@ -737,19 +737,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1220"
+      - "1236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:06 GMT
+      - Mon, 18 Dec 2023 13:11:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -759,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fda95132-6fcd-4b0d-b086-78dd595688fa
+      - fed3c434-f6ce-41bc-ad0a-6bfc4622e61b
     status: 200 OK
     code: 200
     duration: ""
@@ -770,19 +770,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWFhiZTMreWQrSHFpTUtlazNjWEl3OG9va3M0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1UQTFNQjRYCkRUSXpNVEV5TVRFMk1ERTBNRm9YRFRNek1URXhPREUyTURFME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TVRBMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVhZUhXT0ZNRERPNDlvckJmejlPVlFsL0hzd2Rsdi9zaklEOGFRNUFMeGJLWWdLL243bCsKeTlmR0svRHJNZWlxSmwzU2VKZjZNQmNEa3Y1REFmYVFoUkhsWG5aQzEyTXhYbEFDRlpoL3lZVHRwa3hMd1R0ago3UDlXaVdRanZyRnVORmhaV2FBblF1MTlvQVNrKzkybFhXa3YrZkxtU0hENlFPdGlOdDNQS3QydjBUMnhHd2wxCkFickpkcXlRcTQ3S0JyZGVCb3B4V3R2aUpEZFJzMHZnek5OaHBIeHpRT3dGZlJxd2o1ZHJOeXEwdXdyNVl1ejYKcXlVbTA4RXAzcTNWL3F6cW16SmZKRXgyTWQvRHd2K243NUQvbmRyUDZabWFKMUFpOElmQzZVNU9STC9SVE4wUgpubkd3OE8wR1JiMjluQ1BKL01JbVBQaDVQVWdnQ0FxamtRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqRXdOWUk4Y25jdE56TTVZMkV4WW1ZdE1XUTVOUzAwTVRZeUxUa3lOamd0WldVMFkyRmgKWlRFNFpEWXhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeDZod1F6bm9KcE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ4M0szb1I4SkNuRWxUd1R4SHE3L3FDQkxkTEtRSlhMZ0JlNjBMMXBFeXcrQ1c5aGdsCkRoYzR6SDZFTmVEWEVMdEptLzNubTBTQ2xma1p2cjY5UWJPY0R5Vlh1QUJURUpNblh5Q0ZTSmVOUXJVMVFGVmcKNFNvQ2tGNjczNWtNK2dwdTcwRnVwVDJrL0YrVjU5QjFJRjdRZXhReEVZYlE1VjVQcUZDR0NwVGlQKzE5aWIxZQp3SGZLTVg1cEU0ZStsRnhuaE1FU0pwTzNGTnpScTFGTGZrYUhPUFg1K2Q3OGVscWpOWFFmTkE4R25HV1FJUDZWCmhGTHp5TzJQajcwR2hxRWR5dzUxT3p2WnZRNloyNUhWdXdzN0tZenNvQW1IMTl5NGhkZUlxNXZtM2ZOU2N4OUEKWVRUcDN1RmRFTXJsUHpoSWdnUm5YV20wS2xUS2wwVzNCZDJsCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:07 GMT
+      - Mon, 18 Dec 2023 13:11:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -792,7 +792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4585acc6-8935-4533-bcdc-001b5bf848b9
+      - 59143679-095f-4eef-b007-d0d89a466aa4
     status: 200 OK
     code: 200
     duration: ""
@@ -803,19 +803,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1220"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:07 GMT
+      - Mon, 18 Dec 2023 13:11:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -825,7 +825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90644c67-38b9-4598-bc32-9b426cc5cd80
+      - f249e2bb-1004-4e6b-82d7-51fa777af733
     status: 200 OK
     code: 200
     duration: ""
@@ -836,19 +836,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1220"
+      - "1236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:07 GMT
+      - Mon, 18 Dec 2023 13:11:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -858,7 +858,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f358c427-7179-4444-a86a-0230b71be057
+      - b4b0b2fc-c932-431e-8403-dcdda9f453d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 201f76b7-efe3-4922-a208-ac479a6be7b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca53afc7-1c67-4c90-acb8-6a13d885e066
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1236"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b824373c-c4f1-4753-8541-4b09e94c1a80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1236"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4c7cd4b6-a72b-4368-9530-61801667aab6
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61/upgrade
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/upgrade
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:08 GMT
+      - Mon, 18 Dec 2023 13:11:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9f8480c-eb9b-415d-be53-2d0e920937f5
+      - f77528f1-66c8-4db9-89b8-551482e5e83e
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:08 GMT
+      - Mon, 18 Dec 2023 13:11:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae1eab6d-5e4b-42db-a57d-dca89c70a108
+      - 0835afc4-7c08-4d8d-ae35-095c52393779
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:38 GMT
+      - Mon, 18 Dec 2023 13:11:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2812617f-1946-481e-baf6-ffabce04aef6
+      - f6f1b0ca-bef3-4e8c-b410-5b9fbe318f06
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:08 GMT
+      - Mon, 18 Dec 2023 13:12:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abcef04c-a5b8-4ea7-9bfa-6037fe935c39
+      - e30f5b7e-f0a2-4090-8800-c80ffbf9dbad
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:38 GMT
+      - Mon, 18 Dec 2023 13:12:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7473ae70-218f-4eeb-aad0-d7536b918331
+      - 65a954eb-f86f-40ab-8462-b0c1e8a24f35
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:09 GMT
+      - Mon, 18 Dec 2023 13:13:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ce5e2f3-b54f-4f4f-b8e0-b296a1e3b678
+      - bcb828cf-a714-4b51-a321-4def68d3a892
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:39 GMT
+      - Mon, 18 Dec 2023 13:13:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f051877d-c225-4794-be09-1dda1475c45d
+      - 600e397c-e7ed-447b-a946-e3a460b66ecf
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:09 GMT
+      - Mon, 18 Dec 2023 13:14:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e1cc704-8538-43ee-ac7e-2760aeb001f7
+      - 8a250d83-267d-475f-9382-34fde113e3c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:39 GMT
+      - Mon, 18 Dec 2023 13:14:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35b51dc9-a7ea-4f02-8106-a84b17d63686
+      - 9e1794de-3014-48db-8696-f8c61154e30d
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:10 GMT
+      - Mon, 18 Dec 2023 13:15:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c44b7e19-8a10-4eb6-88fb-29b2599299ba
+      - 3ce9267c-93c7-4df8-bd09-d6bfd4b8e495
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:40 GMT
+      - Mon, 18 Dec 2023 13:15:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aba95151-5eec-4972-849b-a2ce4f836775
+      - b48926e7-fe45-466d-a5cc-288394a243b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:10 GMT
+      - Mon, 18 Dec 2023 13:16:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3dd623a-dfbc-4b7f-99e3-a33257773ed9
+      - 98845914-e1e3-4d32-ada8-8175cd95b418
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,19 +1399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:40 GMT
+      - Mon, 18 Dec 2023 13:16:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4995687c-c495-4b2d-be7e-491208e3e3d7
+      - 16a7072a-3c7f-4d38-b8ce-dbc3d2fc993f
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,19 +1432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:11 GMT
+      - Mon, 18 Dec 2023 13:17:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b284d69b-cb56-435e-867e-012878ffb347
+      - f7f16671-4684-4c0d-a9d5-475a7764fa73
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,19 +1465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1220"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:41 GMT
+      - Mon, 18 Dec 2023 13:17:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52ace6f8-6741-4e11-9a24-00ea55cd7f23
+      - 16ea614c-92eb-4f06-8546-f7495acb01ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,19 +1498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1220"
+      - "1236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:41 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1520,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fce512d-44f5-49f7-b5dd-927101efddb1
+      - 568d592d-156a-41c1-91f1-d3f4448fc07a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1236"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 07591093-b42f-44ba-afba-858cf4671858
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61/upgrade
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/upgrade
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1228"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:41 GMT
+      - Mon, 18 Dec 2023 13:18:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfe3e79a-c6c3-4083-8831-e9fcfbe6d3e8
+      - 695eb817-4c40-4207-891c-29af97d914a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1599,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1228"
+      - "1244"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:41 GMT
+      - Mon, 18 Dec 2023 13:18:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caf05761-cbbb-42e2-b91e-77a561de0314
+      - 4a6494c1-fa43-4a59-b54f-1e3d81f9080a
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,19 +1632,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1221"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:12 GMT
+      - Mon, 18 Dec 2023 13:18:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f7734ba-6dd7-4d42-92b3-81bcf19a9582
+      - d2bc148f-0263-4684-8f36-9d6248bffcb7
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1221"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:12 GMT
+      - Mon, 18 Dec 2023 13:18:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caef86ec-9700-4c4b-ae1c-067561bc7701
+      - 2d36e88e-a0e1-4021-92d9-a3cb9f892a59
     status: 200 OK
     code: 200
     duration: ""
@@ -1535,19 +1700,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1221"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:12 GMT
+      - Mon, 18 Dec 2023 13:18:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1557,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ba87b2e-ddfd-48e7-9608-98fe2aea3acd
+      - 8cbc4584-14e5-4d09-8aba-c3b5996317ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,19 +1733,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1221"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:12 GMT
+      - Mon, 18 Dec 2023 13:18:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1590,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e9464b5-0072-4be5-8fd1-92480d525d89
+      - ee48114f-e165-4966-9a1b-8dec6ba2a9ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,19 +1766,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWFhiZTMreWQrSHFpTUtlazNjWEl3OG9va3M0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1UQTFNQjRYCkRUSXpNVEV5TVRFMk1ERTBNRm9YRFRNek1URXhPREUyTURFME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TVRBMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVhZUhXT0ZNRERPNDlvckJmejlPVlFsL0hzd2Rsdi9zaklEOGFRNUFMeGJLWWdLL243bCsKeTlmR0svRHJNZWlxSmwzU2VKZjZNQmNEa3Y1REFmYVFoUkhsWG5aQzEyTXhYbEFDRlpoL3lZVHRwa3hMd1R0ago3UDlXaVdRanZyRnVORmhaV2FBblF1MTlvQVNrKzkybFhXa3YrZkxtU0hENlFPdGlOdDNQS3QydjBUMnhHd2wxCkFickpkcXlRcTQ3S0JyZGVCb3B4V3R2aUpEZFJzMHZnek5OaHBIeHpRT3dGZlJxd2o1ZHJOeXEwdXdyNVl1ejYKcXlVbTA4RXAzcTNWL3F6cW16SmZKRXgyTWQvRHd2K243NUQvbmRyUDZabWFKMUFpOElmQzZVNU9STC9SVE4wUgpubkd3OE8wR1JiMjluQ1BKL01JbVBQaDVQVWdnQ0FxamtRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqRXdOWUk4Y25jdE56TTVZMkV4WW1ZdE1XUTVOUzAwTVRZeUxUa3lOamd0WldVMFkyRmgKWlRFNFpEWXhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeDZod1F6bm9KcE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ4M0szb1I4SkNuRWxUd1R4SHE3L3FDQkxkTEtRSlhMZ0JlNjBMMXBFeXcrQ1c5aGdsCkRoYzR6SDZFTmVEWEVMdEptLzNubTBTQ2xma1p2cjY5UWJPY0R5Vlh1QUJURUpNblh5Q0ZTSmVOUXJVMVFGVmcKNFNvQ2tGNjczNWtNK2dwdTcwRnVwVDJrL0YrVjU5QjFJRjdRZXhReEVZYlE1VjVQcUZDR0NwVGlQKzE5aWIxZQp3SGZLTVg1cEU0ZStsRnhuaE1FU0pwTzNGTnpScTFGTGZrYUhPUFg1K2Q3OGVscWpOWFFmTkE4R25HV1FJUDZWCmhGTHp5TzJQajcwR2hxRWR5dzUxT3p2WnZRNloyNUhWdXdzN0tZenNvQW1IMTl5NGhkZUlxNXZtM2ZOU2N4OUEKWVRUcDN1RmRFTXJsUHpoSWdnUm5YV20wS2xUS2wwVzNCZDJsCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:12 GMT
+      - Mon, 18 Dec 2023 13:18:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1623,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc3f51b9-2242-4f9a-b3e4-230413c923ba
+      - a3e91dd6-5b50-4fe2-b91f-a9782f8bf8ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,19 +1799,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1221"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:13 GMT
+      - Mon, 18 Dec 2023 13:18:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1656,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 117df387-354b-426c-9b4f-73035f44e75e
+      - e07d91b7-cab7-4699-9eb9-0761a91c2611
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,19 +1832,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1221"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:13 GMT
+      - Mon, 18 Dec 2023 13:18:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1689,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab3ef0ca-beb3-45e5-96a0-8a38708c2e82
+      - da53372f-d874-4d1a-9f5b-be29ec18d952
     status: 200 OK
     code: 200
     duration: ""
@@ -1700,19 +1865,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVWFhiZTMreWQrSHFpTUtlazNjWEl3OG9va3M0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TXpBdU1UQTFNQjRYCkRUSXpNVEV5TVRFMk1ERTBNRm9YRFRNek1URXhPREUyTURFME1Gb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNekF1TVRBMU1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTVhZUhXT0ZNRERPNDlvckJmejlPVlFsL0hzd2Rsdi9zaklEOGFRNUFMeGJLWWdLL243bCsKeTlmR0svRHJNZWlxSmwzU2VKZjZNQmNEa3Y1REFmYVFoUkhsWG5aQzEyTXhYbEFDRlpoL3lZVHRwa3hMd1R0ago3UDlXaVdRanZyRnVORmhaV2FBblF1MTlvQVNrKzkybFhXa3YrZkxtU0hENlFPdGlOdDNQS3QydjBUMnhHd2wxCkFickpkcXlRcTQ3S0JyZGVCb3B4V3R2aUpEZFJzMHZnek5OaHBIeHpRT3dGZlJxd2o1ZHJOeXEwdXdyNVl1ejYKcXlVbTA4RXAzcTNWL3F6cW16SmZKRXgyTWQvRHd2K243NUQvbmRyUDZabWFKMUFpOElmQzZVNU9STC9SVE4wUgpubkd3OE8wR1JiMjluQ1BKL01JbVBQaDVQVWdnQ0FxamtRSURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzQxCk1TNHhOVGd1TVRNd0xqRXdOWUk4Y25jdE56TTVZMkV4WW1ZdE1XUTVOUzAwTVRZeUxUa3lOamd0WldVMFkyRmgKWlRFNFpEWXhMbkprWWk1dWJDMWhiWE11YzJOM0xtTnNiM1ZraHdRekQxeDZod1F6bm9KcE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUJ4M0szb1I4SkNuRWxUd1R4SHE3L3FDQkxkTEtRSlhMZ0JlNjBMMXBFeXcrQ1c5aGdsCkRoYzR6SDZFTmVEWEVMdEptLzNubTBTQ2xma1p2cjY5UWJPY0R5Vlh1QUJURUpNblh5Q0ZTSmVOUXJVMVFGVmcKNFNvQ2tGNjczNWtNK2dwdTcwRnVwVDJrL0YrVjU5QjFJRjdRZXhReEVZYlE1VjVQcUZDR0NwVGlQKzE5aWIxZQp3SGZLTVg1cEU0ZStsRnhuaE1FU0pwTzNGTnpScTFGTGZrYUhPUFg1K2Q3OGVscWpOWFFmTkE4R25HV1FJUDZWCmhGTHp5TzJQajcwR2hxRWR5dzUxT3p2WnZRNloyNUhWdXdzN0tZenNvQW1IMTl5NGhkZUlxNXZtM2ZOU2N4OUEKWVRUcDN1RmRFTXJsUHpoSWdnUm5YV20wS2xUS2wwVzNCZDJsCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1847"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:13 GMT
+      - Mon, 18 Dec 2023 13:18:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1722,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9562c2c-81a5-4c10-a893-4dd40649b6df
+      - 8da930cb-3a50-45b7-a34e-8ad0ee89e325
     status: 200 OK
     code: 200
     duration: ""
@@ -1733,19 +1898,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1221"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:14 GMT
+      - Mon, 18 Dec 2023 13:18:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1755,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2604e18-a25a-47c5-8c12-8e36f5aa62e1
+      - 0eb981ef-46e4-4065-acbf-2ad28108b245
     status: 200 OK
     code: 200
     duration: ""
@@ -1766,19 +1931,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9e5220c1-a4ee-4224-a516-47d30563484d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1237"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:18:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77e250aa-bbe5-4e1a-85aa-b42b7497fd76
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:14 GMT
+      - Mon, 18 Dec 2023 13:18:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1788,7 +2019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c826f47c-97d0-44d0-8f0e-3c9a6297a831
+      - b96a3780-1024-4fcd-b2e3-d12ca496f6cf
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,19 +2030,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.392489Z","endpoint":{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942},"endpoints":[{"id":"2f3bb568-b7a3-4880-a56b-da14fa05467f","ip":"51.158.130.105","load_balancer":{},"name":null,"port":7942}],"engine":"PostgreSQL-15","id":"739ca1bf-1d95-4162-9268-ee4caae18d61","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1224"
+      - "1240"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:14 GMT
+      - Mon, 18 Dec 2023 13:18:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1821,7 +2052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d8ce352-0bf4-41d9-89cc-2992322241fd
+      - e6f643d0-299d-40d4-a4cc-f16657e3104d
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,10 +2063,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"739ca1bf-1d95-4162-9268-ee4caae18d61","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1844,7 +2075,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:44 GMT
+      - Mon, 18 Dec 2023 13:19:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1854,7 +2085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc8b8782-e35f-4604-81a3-0bb82bdab435
+      - ea8154d4-efea-41b2-a62b-452bd0d35760
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1865,10 +2096,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/739ca1bf-1d95-4162-9268-ee4caae18d61
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"739ca1bf-1d95-4162-9268-ee4caae18d61","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1877,7 +2108,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:44 GMT
+      - Mon, 18 Dec 2023 13:19:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1887,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c928e8e-ff8c-41c9-a5bd-9e2a996e6f20
+      - d77cb766-fb5c-45c1-a934-79d8ff552fed
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-with-cluster.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-with-cluster.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:52 GMT
+      - Mon, 18 Dec 2023 12:57:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f659d84-635e-44a2-a4c7-4a0734f12661
+      - 1782392e-b0a5-45e4-bd86-0c9286e93112
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-with-cluster","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s8cret","node_type":"db-dev-m","is_ha_cluster":true,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-with-cluster","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s8cret","node_type":"db-dev-m","is_ha_cluster":true,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_instance","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:17 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b98e83b-e5cb-4188-98dc-829dddbbc53a
+      - f3fa7d7c-c780-42de-bc35-2594780b8ed6
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:17 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e330e3c9-92e6-4b08-9593-fc46e83fb134
+      - 052a8295-7456-4d4f-b3a1-f6ccf82a70f8
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:50 GMT
+      - Mon, 18 Dec 2023 12:57:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f2a467a-dff0-4788-95ba-0313a121124d
+      - 41c879ea-20dd-48c0-a049-7d03f2446c7c
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:20 GMT
+      - Mon, 18 Dec 2023 12:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46cdebc8-d38d-42ce-86b9-859b3a1a4e6c
+      - 7fe6ac04-3a2c-4396-b5ad-5145a1d34c62
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:50 GMT
+      - Mon, 18 Dec 2023 12:58:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb285d44-4012-47be-8068-1b67e850efec
+      - e599a279-3990-4106-ac55-615bf555717d
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:20 GMT
+      - Mon, 18 Dec 2023 12:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56b83edf-a2c1-482a-b81f-03e0636059df
+      - 2f1259fc-78b0-4804-a972-7070a53608a7
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "953"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:51 GMT
+      - Mon, 18 Dec 2023 12:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e877e80a-c4f7-4ea5-acd9-29582a017c1a
+      - 9f312e8e-c291-4a51-97b5-f64aa582561e
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1051"
+      - "1217"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:21 GMT
+      - Mon, 18 Dec 2023 13:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fece01cd-ca74-4eb2-b3ac-459ab1cb3d3f
+      - 29517aac-6226-487d-9854-922feb008573
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802},"endpoints":[{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802}],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:51 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68c7c27e-306d-4682-a01c-781784f13b08
+      - ad0cfeae-30f5-4037-8fbe-bbadd6802f99
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802},"endpoints":[{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802}],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:52 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f472596-a00c-40e1-99fe-436560c5ee61
+      - 36c46f17-14dd-431f-a222-0a83437c7c2d
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802},"endpoints":[{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802}],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:52 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa33c1ad-019b-405c-bdb3-08eb0b365ce1
+      - 9c8a5b0f-739f-4979-8b2b-a1391ebf2ebc
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVTUc4TlhaODF4clBmai9JbWt6QUZVNC9jaXA4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBNE1UQmFGdzB6TXpFeE1UZ3hOakE0TVRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNVNC9iTWFybkFKakZXRkVwWFhoVTZ6TmJkdjRRSlhJcEJ3OU9sT29FZFFIaUlGS3RzTStvK2xrb0sKUGt3RVgwVEdKYWg4OHNCSHhlWnQzTUFGbzFlamN2cWlNemZWNlZXeW15ZlVzMkNFNnVTQmJPenUzZFpmS2phZwp1L09jZTVnRElBZjNEUzhFT3lXWDBsb2hwampRU0hMaWRWblpXVDU4dE5RK3p4ell5WUpjMlpzRVBJTkdnZ0UxCnUzOXNxdXhrdmg3bmdBYktNNUNNN0NTNnZZVzF3ZkdTSjdvQm52b2g2K2J1bGx1emx4cnFJNFpLNVM4VFZHaVEKMHNVdzNEaWZnakxxK3lSRjExUm8xNEplNUdmamNhVEtuQmhab0U2TlhzOXNnWUZYb2UwV212eTZjaUJBVklzZwpyQlg0VmpRS2NYWTI1aDlrTEY2Y2Y3L2ZXV3dOQWdNQkFBR2phekJwTUdjR0ExVWRFUVJnTUY2Q0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RabU15T0RjMlltVXRPR00xT0MwME16SmxMVGt5TWpndE0yVmpZakl3TjJNd01XUTEKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS2ZQaHdRekQvMGZod1F6bnd0R01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFKc1V0WTZCU21nb3JPUCtNSFRwdTM4czcvWkZBdEZHU011KzZjbUNyR3Y1R2ZrWXUyCitUMHVtRHg4YlE4WnNvZGNCNkl3aDFTa2Q5YmE5b0hWT2x5S1NsY2RtcnBBS3FTL0ZKamZ0eUtYNHZGeXNURXgKVitNdDZaSWpEcmxrdzVWcXFSeDZwbysxTElUUjdIU0pwbWgxa0VIdkMxbnJqaVV2aURSQkUwU1c0bEc1S1RrbgpwOGs2ZUdiZklzT1pVSzQ0bi9YbUJWRnlWaTkweTlETDlWcXBCMGlmaTdLUytnMzJCYUpTdjdIUXpPUkRXLzhsClNIR2dLUTF0ZmlKQjM4VjBrN21ZUHNUOUZ5RDNveVRkQlp2MVpxaWY2RWtkTVBRYWdyTVpvdzdtbWFhTTZFcFkKRnZaTWtWMG5WRElhb0tmMUtxV1ArdlpYRmNmVEI1NHJWUk1PCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVDakNDQXZLZ0F3SUJBZ0lVRTNwK2NyUDhocVIySll6OHJPT1Z1bkVWNGNNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QXdNRFJhRncwek16RXlNVFV4TXpBd01EUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ1BpaWZWalU1c2xTS0szd0ZtMFpEOUlIL3o4RngzZTZpblB2WVRjTlZMbDhnLzBCcTQKLzBmVk1KZUNscGhBbkZHRFZZQnFlSDBIWlJNdlFCVGZXNk1hZFhSSDV6VVlHQnJDalZpTXdaakZnSnQ5YVFCQwoydG85ZnBHbDdwaENDbWVLdzhSTDRTd3kxOFZ2dG1MZDF6cnJsWU1RMEJucXc2eWJ5ME5NeUcwL0hWNEVTeXBFCjNxTWl3ZGRyV05wL3Z1VGY3Q2dLRWhrSTY2NW84QUpQUUpMSmtoUnBjclRLZ2R6YVdld2VsbFFJNlVoUFZaS0cKM2gzaGhKcU5wK29aNlZ1VFBiWmROVFpXME1MQlQ1cHloMldwTVZxQ08xam5SQmVyejdZNm5nZm1lbW1tQmhscApxeDNHOWVoNzREdno2NTZLVXNZSlVDakM0NHhweHF6NHVqRjFBZ01CQUFHamdjY3dnY1F3Z2NFR0ExVWRFUVNCCnVUQ0J0b0lQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxaFlqUXpZalEwTkMxa1lXWXpMVFEyTVRRdFlUTXgKWkMxbFpqbG1NelUxTnpKaFpERXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RZV0kwTTJJME5EUXRaR0ZtTXkwME5qRTBMV0V6TVdRdFpXWTVaak0xTlRjeVlXUXhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEL3R2aHdRekQ5ZEhod1REbXNYOGh3VERtc1g4TUEwR0NTcUcKU0liM0RRRUJDd1VBQTRJQkFRQnd4QXBRWjNxcEVmbzFqREd1bjFzdFFEUzVYN3BRQUlaY2pWNzVBMU40dElZZwp6VmI5aVBhbWdvNmhtaXlValpBY0lZY2FGRXkwUVA0ZzlpRHhadWk0UU9PM25qSjExbHBGYXVONWorZDB4dFhZClBvNlZTT0RVTUFybk5GRUQvOGlUWVpOaVp1RU13OGNsV0lCV1IyRFhlTFBudCs5bzRNeTRQU3NuWW4xWnNiUncKU1FrU2dUd2pmeXdXLzY5YlZTZ2VRYzZCMEVKYStzZUZuRlEweGdBVE8yZXh1RW1UakYzSmxpdStiMERFdGIzUQp6Z3lUWk0rRnoyTW1ibXpBUXFhb3prT1hoeWlLczB2VWQrNFlzR3hMS1JkMHJqcmZVTDFaSXFwRUwvOWxUYVhHClRoT1pVTXVSbENRcitreWNodEZVc1pCcHFWQjhuNDR6L3VzVFVkNzUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "2027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:52 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6c395a5-6eb2-47f3-8ec9-5f005b3cc911
+      - c29428e2-dcad-4139-ae7e-c4b1eba568b9
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ab43b444-daf3-4614-a31d-ef9f35572ad1&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802},"endpoints":[{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802}],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1256"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:52 GMT
+      - Mon, 18 Dec 2023 13:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 837c7747-eea2-4464-ab40-37f60121d3fb
+      - 245e633a-bb58-4998-82f5-376a485339ea
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802},"endpoints":[{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802}],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:53 GMT
+      - Mon, 18 Dec 2023 13:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49c059c4-2bfc-4f9b-910e-ac3c600b2e39
+      - 8c4cd9ed-8db8-46cf-b0b9-77f591195dc4
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVTUc4TlhaODF4clBmai9JbWt6QUZVNC9jaXA4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBNE1UQmFGdzB6TXpFeE1UZ3hOakE0TVRCYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNVNC9iTWFybkFKakZXRkVwWFhoVTZ6TmJkdjRRSlhJcEJ3OU9sT29FZFFIaUlGS3RzTStvK2xrb0sKUGt3RVgwVEdKYWg4OHNCSHhlWnQzTUFGbzFlamN2cWlNemZWNlZXeW15ZlVzMkNFNnVTQmJPenUzZFpmS2phZwp1L09jZTVnRElBZjNEUzhFT3lXWDBsb2hwampRU0hMaWRWblpXVDU4dE5RK3p4ell5WUpjMlpzRVBJTkdnZ0UxCnUzOXNxdXhrdmg3bmdBYktNNUNNN0NTNnZZVzF3ZkdTSjdvQm52b2g2K2J1bGx1emx4cnFJNFpLNVM4VFZHaVEKMHNVdzNEaWZnakxxK3lSRjExUm8xNEplNUdmamNhVEtuQmhab0U2TlhzOXNnWUZYb2UwV212eTZjaUJBVklzZwpyQlg0VmpRS2NYWTI1aDlrTEY2Y2Y3L2ZXV3dOQWdNQkFBR2phekJwTUdjR0ExVWRFUVJnTUY2Q0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RabU15T0RjMlltVXRPR00xT0MwME16SmxMVGt5TWpndE0yVmpZakl3TjJNd01XUTEKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pyS2ZQaHdRekQvMGZod1F6bnd0R01BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUFKc1V0WTZCU21nb3JPUCtNSFRwdTM4czcvWkZBdEZHU011KzZjbUNyR3Y1R2ZrWXUyCitUMHVtRHg4YlE4WnNvZGNCNkl3aDFTa2Q5YmE5b0hWT2x5S1NsY2RtcnBBS3FTL0ZKamZ0eUtYNHZGeXNURXgKVitNdDZaSWpEcmxrdzVWcXFSeDZwbysxTElUUjdIU0pwbWgxa0VIdkMxbnJqaVV2aURSQkUwU1c0bEc1S1RrbgpwOGs2ZUdiZklzT1pVSzQ0bi9YbUJWRnlWaTkweTlETDlWcXBCMGlmaTdLUytnMzJCYUpTdjdIUXpPUkRXLzhsClNIR2dLUTF0ZmlKQjM4VjBrN21ZUHNUOUZ5RDNveVRkQlp2MVpxaWY2RWtkTVBRYWdyTVpvdzdtbWFhTTZFcFkKRnZaTWtWMG5WRElhb0tmMUtxV1ArdlpYRmNmVEI1NHJWUk1PCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1847"
+      - "1264"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:53 GMT
+      - Mon, 18 Dec 2023 13:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be5b6244-2234-417f-9f17-88d535e63fde
+      - 74bc3bac-f4c4-4d30-a655-5a333377f2e5
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802},"endpoints":[{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802}],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVDakNDQXZLZ0F3SUJBZ0lVRTNwK2NyUDhocVIySll6OHJPT1Z1bkVWNGNNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16QXdNRFJhRncwek16RXlNVFV4TXpBd01EUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ1BpaWZWalU1c2xTS0szd0ZtMFpEOUlIL3o4RngzZTZpblB2WVRjTlZMbDhnLzBCcTQKLzBmVk1KZUNscGhBbkZHRFZZQnFlSDBIWlJNdlFCVGZXNk1hZFhSSDV6VVlHQnJDalZpTXdaakZnSnQ5YVFCQwoydG85ZnBHbDdwaENDbWVLdzhSTDRTd3kxOFZ2dG1MZDF6cnJsWU1RMEJucXc2eWJ5ME5NeUcwL0hWNEVTeXBFCjNxTWl3ZGRyV05wL3Z1VGY3Q2dLRWhrSTY2NW84QUpQUUpMSmtoUnBjclRLZ2R6YVdld2VsbFFJNlVoUFZaS0cKM2gzaGhKcU5wK29aNlZ1VFBiWmROVFpXME1MQlQ1cHloMldwTVZxQ08xam5SQmVyejdZNm5nZm1lbW1tQmhscApxeDNHOWVoNzREdno2NTZLVXNZSlVDakM0NHhweHF6NHVqRjFBZ01CQUFHamdjY3dnY1F3Z2NFR0ExVWRFUVNCCnVUQ0J0b0lQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxaFlqUXpZalEwTkMxa1lXWXpMVFEyTVRRdFlUTXgKWkMxbFpqbG1NelUxTnpKaFpERXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RZV0kwTTJJME5EUXRaR0ZtTXkwME5qRTBMV0V6TVdRdFpXWTVaak0xTlRjeVlXUXhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEL3R2aHdRekQ5ZEhod1REbXNYOGh3VERtc1g4TUEwR0NTcUcKU0liM0RRRUJDd1VBQTRJQkFRQnd4QXBRWjNxcEVmbzFqREd1bjFzdFFEUzVYN3BRQUlaY2pWNzVBMU40dElZZwp6VmI5aVBhbWdvNmhtaXlValpBY0lZY2FGRXkwUVA0ZzlpRHhadWk0UU9PM25qSjExbHBGYXVONWorZDB4dFhZClBvNlZTT0RVTUFybk5GRUQvOGlUWVpOaVp1RU13OGNsV0lCV1IyRFhlTFBudCs5bzRNeTRQU3NuWW4xWnNiUncKU1FrU2dUd2pmeXdXLzY5YlZTZ2VRYzZCMEVKYStzZUZuRlEweGdBVE8yZXh1RW1UakYzSmxpdStiMERFdGIzUQp6Z3lUWk0rRnoyTW1ibXpBUXFhb3prT1hoeWlLczB2VWQrNFlzR3hMS1JkMHJqcmZVTDFaSXFwRUwvOWxUYVhHClRoT1pVTXVSbENRcitreWNodEZVc1pCcHFWQjhuNDR6L3VzVFVkNzUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1256"
+      - "2027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:53 GMT
+      - Mon, 18 Dec 2023 13:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 887221ba-b9ae-4c3e-9f2b-7f603a210848
+      - f8dc2a0d-543f-4989-b08d-c635c753f159
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +871,85 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ab43b444-daf3-4614-a31d-ef9f35572ad1&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:00:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9721b363-3d6b-4951-a550-10ba20a83de0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1264"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:00:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0a5f246-472d-4573-8187-7aea7eef47b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802},"endpoints":[{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802}],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1259"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:54 GMT
+      - Mon, 18 Dec 2023 13:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abfacda3-f94b-4e4e-8cae-998b7d1fc22b
+      - 5acdc347-3ebe-41ee-8693-8d1488448e80
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-11-22T16:05:16.942069Z","retention":7},"created_at":"2023-11-21T16:05:16.942069Z","endpoint":{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802},"endpoints":[{"id":"431f5feb-3538-4fae-b1e4-939c6372c2f0","ip":"51.159.11.70","load_balancer":{},"name":null,"port":7802}],"engine":"PostgreSQL-15","id":"fc2876be-8c58-432e-9228-3ecb207c01d5","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.528275Z","retention":7},"created_at":"2023-12-18T12:57:07.528275Z","endpoint":{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887},"endpoints":[{"id":"69486eb3-dc07-47a8-80ca-f0bb0e8a154a","ip":"195.154.197.252","load_balancer":{},"name":null,"port":23887}],"engine":"PostgreSQL-15","id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","init_settings":[],"is_ha_cluster":true,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-with-cluster","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"2700"},{"name":"maintenance_work_mem","value":"300"},{"name":"max_connections","value":"150"},{"name":"max_parallel_workers","value":"1"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"8"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1259"
+      - "1267"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:54 GMT
+      - Mon, 18 Dec 2023 13:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0100a72-5334-4626-8f86-31ec05fd5628
+      - 1d524bf7-5511-4f30-87ff-16e5561c276c
     status: 200 OK
     code: 200
     duration: ""
@@ -937,10 +1003,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"fc2876be-8c58-432e-9228-3ecb207c01d5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -949,7 +1015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:24 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 749cc03c-bd40-4c87-91dd-7492aef69719
+      - cf0102f8-3bad-4bcf-8ec8-6868eb35f157
     status: 404 Not Found
     code: 404
     duration: ""
@@ -970,10 +1036,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/fc2876be-8c58-432e-9228-3ecb207c01d5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ab43b444-daf3-4614-a31d-ef9f35572ad1
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"fc2876be-8c58-432e-9228-3ecb207c01d5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"ab43b444-daf3-4614-a31d-ef9f35572ad1","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -982,7 +1048,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:24 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4e3074d-6691-4171-9935-ab0bdae477fb
+      - 57e12b6a-27d4-42f2-8bdd-68c2157c1168
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-privilege-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-privilege-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:05 GMT
+      - Mon, 18 Dec 2023 14:13:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df030da9-41bc-4794-b9a5-cf2eb189fc85
+      - de16164e-eaaa-411f-8b6e-574cfdec828e
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:11 GMT
+      - Mon, 18 Dec 2023 14:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4cbf58e6-4b62-46d4-bff9-1e66e2b02dd0
+      - 344f7dbe-f7b0-429c-94ae-b6f0f37a03bc
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:11 GMT
+      - Mon, 18 Dec 2023 14:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3605ce28-b380-40bf-8dbe-bdfb8202eaba
+      - 2f9ee929-88d0-45ce-88a8-020cd3ac0dae
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:41 GMT
+      - Mon, 18 Dec 2023 14:13:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15832cbf-a214-4aa0-9778-36e2838e9ad2
+      - d1e62c26-15c1-4076-b61f-36a766211cf8
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:11 GMT
+      - Mon, 18 Dec 2023 14:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c205d1db-e99a-461d-99bc-40abdc31d129
+      - ddf6f59b-ada6-40ed-b588-37c31be45b37
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:42 GMT
+      - Mon, 18 Dec 2023 14:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae3f6b9e-82c1-496b-a84b-64cff800b940
+      - fbc94de6-b378-4884-af13-ab61c080a3a0
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:12 GMT
+      - Mon, 18 Dec 2023 14:15:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bf37dd4-4d79-421a-98e6-0851b1b47f82
+      - 0637645b-67be-460f-b4da-cc4386c73bdf
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "961"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:15:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6ff837f2-9d76-4091-85c2-24d47af991aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1225"
@@ -551,7 +584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:42 GMT
+      - Mon, 18 Dec 2023 14:16:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d91cd2d-bb4e-44a0-bd6f-443b2238b503
+      - ebd6600d-72a0-4bd9-ad3e-db84c3ecc8f2
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:12 GMT
+      - Mon, 18 Dec 2023 14:16:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4c59e5f-5246-4acf-98ce-12ae0745fc3a
+      - 5fe85884-fb21-4dbe-8058-807bbd6f38ea
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Mon, 18 Dec 2023 14:16:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cdae0f1-51b8-4b74-b84a-59ef55116de5
+      - 5bd7e856-8d62-418d-ac76-05cc22aa260e
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Mon, 18 Dec 2023 14:16:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c092cb40-b2eb-4b33-9be5-b17370b11592
+      - 23460a01-0c2c-4b18-9471-c25858353176
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Mon, 18 Dec 2023 14:16:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb0eac89-8ea4-4b61-a4bf-1904e7323d81
+      - 34aa763c-4287-44e0-95dc-a9b3df6a1208
     status: 200 OK
     code: 200
     duration: ""
@@ -706,7 +739,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVV1lCN3pPMVdWcXhJQUlLUTNERlI2VnZUZndvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5UVTFXaGNOTXpNeE1qRTFNVFF4TlRVMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxsTHZRRWZlazBYQ0d0WG04Nk43L1JnQXlSZU55K1RiSmx1cDcwM1JZNkltZW9QcUZ2UkN2SUgKUVF4cDNjcStPSHN5Y0MxclFtZHlCeGFuTTRPN0lFaTlobnA3d21vNGJQQmdPNWpEelppZUlRcU1IKzA1bVV2ZgpML2dKanJPZFNUbG9qRmFkZjY5VkVYZ0xmMExWcTJoSnUvWnVQbkhuQjBiWXpiVmZIK05vNW5nWlU4Qks2UEdmCmpncytESzZVbjZIaWk4M3U0Zk5RSllPVmJQWk1uMUVMWHRkcWJCMEdGREdsdDhmK3dnUjdVc212N09SQlV4ZVIKdFB5dnUramtWUk9pbExiTDhzTWh3cW90ZlJIcElWL1R5cENLQnViVjJBc1lwUGxVZ3RBY2xlTlUwL1Q1bHVYYgo4THE5b0kxY0c2V2VMTk1lYnozQzJrN1hJbEZPdEVFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MHdNekF5TlRnMFlTMHlNelZpTFRRMVlXVXRZakk1T0MxaFptTTIKWkRNeE5qQTBaV1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMVEF6TURJMU9EUmhMVEl6TldJdE5EVmhaUzFpTWprNExXRm1ZelprTXpFMk1EUmxaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy85WjRjRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVlErWFpudWZKSGVlbE9XWXBzemtra2kzL3VwcElGSHZoTWlFcnQ3Z0dwcVRaV0NsTjFVZUs3M3hWbjJBdlUrSwpQc3RKQ2l0bnNaWXI3ak1jSnZ4a1VPRC9odGRiT0k1T0REanhLTHFBOG1obDFsY2lPSjFiS014MGQ1bU81bUxMCkIzb1VpbzIrWExJaEtjTXZWd3h3b1BaZS9nTWRUNHJxYmdLallQcm12dmRtUTA2YWR1L1hjUjd2N2VkN3dCcVcKRS9TSURzL0tmbUhlYS9IaXEwUkphQk1lcG1DZDVNTy9rT28vazBRNlpWb1ZnVlFjWmFCRU9Xd0ZIeWVUdDg3OApYUlpwK01qNFlZNXQzRVVUbmM5V0RHZW1YcGRtOXFFakFmZnBsNG8zVGlCS3ZzZ2FIbTJoTWtlNWNBc0tNVnVvCmozWTVsVE82d3JUK0IwS0QvbHVtWXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8fa4aeee-eaeb-4e3c-b0ca-8c9e9ff72670
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0302584a-235b-45ae-b298-afc6d31604ee&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -718,7 +784,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Mon, 18 Dec 2023 14:16:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f29f6e2c-a3e9-4d9b-8bc2-1c0147c94b8e
+      - 7881dc5f-a798-43d6-8909-05550463a3de
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Mon, 18 Dec 2023 14:16:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9db7ca2c-6099-4234-ac7d-73e14ef23263
+      - a90bfe99-6f63-4dc6-84cf-a141cc0b1a02
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Mon, 18 Dec 2023 14:16:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36621bac-661e-4f08-99d4-81b266a9c728
+      - 85c6ce8b-11b0-4435-a758-0f18f0181d1d
     status: 200 OK
     code: 200
     duration: ""
@@ -807,7 +873,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users
     method: POST
   response:
     body: '{"is_admin":true,"name":"user_01"}'
@@ -819,7 +885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Mon, 18 Dec 2023 14:16:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +895,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3253dd3-b248-4142-b970-2ecffb6bdca6
+      - 153a0145-3e24-474c-bc5d-cf38642459b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 565d417c-b6f6-45aa-b6c4-1b771e33e91b
     status: 200 OK
     code: 200
     duration: ""
@@ -842,7 +941,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
@@ -854,7 +953,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
+      - Mon, 18 Dec 2023 14:16:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -864,7 +963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db4cb5a5-14a8-40d4-b928-1972a8a222fd
+      - b2ec8d73-1f27-41a5-b0a6-dd7f4dde080a
     status: 200 OK
     code: 200
     duration: ""
@@ -875,73 +974,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eebb8ff9-11d3-4b86-b28a-8db3526cc9ff
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 83c15df3-029e-4efa-a11c-58a1bd76ae8b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -953,7 +986,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
+      - Mon, 18 Dec 2023 14:16:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -963,7 +996,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0598340-7b78-46f4-a2fe-0878df086408
+      - 80cddad1-cd61-4239-bd83-ef83ca6fb478
     status: 200 OK
     code: 200
     duration: ""
@@ -974,10 +1007,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5480161-d4e9-4555-bdaa-65334a1af2f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7631663}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -986,7 +1052,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
+      - Mon, 18 Dec 2023 14:16:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -996,7 +1062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fe3478c-40a4-4149-a4f3-fc9f741cdacd
+      - a23e78e5-b2b7-4eaf-a782-8035ebd1017d
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,19 +1073,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
+      - Mon, 18 Dec 2023 14:16:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1029,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54f9352e-4336-4a61-9c2a-cadba89e34c3
+      - 88aae878-7e9a-45b1-ae9a-bbb745b8256f
     status: 200 OK
     code: 200
     duration: ""
@@ -1042,7 +1108,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"all","user_name":"user_01"}'
@@ -1054,7 +1120,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
+      - Mon, 18 Dec 2023 14:16:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1064,7 +1130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f5af149-c3c9-4921-8cdc-5d26cf42434d
+      - 4bc09897-ae93-4d47-9e27-e54657b80a52
     status: 200 OK
     code: 200
     duration: ""
@@ -1075,19 +1141,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
+      - Mon, 18 Dec 2023 14:16:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1097,7 +1163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10418538-3681-4278-82ff-cf59d570c251
+      - e4595c67-3394-4ee6-b6fc-62d5227de3cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1108,19 +1174,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:14 GMT
+      - Mon, 18 Dec 2023 14:16:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1130,7 +1196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 578f4fa7-dec2-4b7f-aee7-f1c1e5dab746
+      - bd1e8daf-3314-44a4-95e0-57fd7bb5907d
     status: 200 OK
     code: 200
     duration: ""
@@ -1141,7 +1207,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1153,7 +1219,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:15 GMT
+      - Mon, 18 Dec 2023 14:16:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1163,7 +1229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3569d062-eb72-45f7-ace9-4675404e3529
+      - 4072575f-73b6-4a37-a9cf-868c9e9573d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1174,7 +1240,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -1186,7 +1252,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:15 GMT
+      - Mon, 18 Dec 2023 14:16:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1196,7 +1262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f91ba7f-5ec5-4e03-a703-09f0c3efada4
+      - 587f7c9d-6a11-4b2b-9d36-97805df3b02a
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,7 +1273,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -1219,7 +1285,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:15 GMT
+      - Mon, 18 Dec 2023 14:16:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1229,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c573bb0-77d6-48cd-8625-bb2a8379d8cc
+      - ba629d7e-9f29-406d-9a05-682f5b414942
     status: 200 OK
     code: 200
     duration: ""
@@ -1240,19 +1306,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:16 GMT
+      - Mon, 18 Dec 2023 14:16:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1262,7 +1328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf381362-4dc7-403f-828e-01ab186174b9
+      - a8c6e3ea-6bf2-43bb-ad41-d259e29ec4a9
     status: 200 OK
     code: 200
     duration: ""
@@ -1273,19 +1339,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "2011"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:16 GMT
+      - Mon, 18 Dec 2023 14:16:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1295,7 +1361,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a758f11-6056-43f7-898c-6e49d6714420
+      - 30dc3f9a-c982-4a1e-bb96-03a53b154eec
     status: 200 OK
     code: 200
     duration: ""
@@ -1306,7 +1372,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVV1lCN3pPMVdWcXhJQUlLUTNERlI2VnZUZndvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5UVTFXaGNOTXpNeE1qRTFNVFF4TlRVMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxsTHZRRWZlazBYQ0d0WG04Nk43L1JnQXlSZU55K1RiSmx1cDcwM1JZNkltZW9QcUZ2UkN2SUgKUVF4cDNjcStPSHN5Y0MxclFtZHlCeGFuTTRPN0lFaTlobnA3d21vNGJQQmdPNWpEelppZUlRcU1IKzA1bVV2ZgpML2dKanJPZFNUbG9qRmFkZjY5VkVYZ0xmMExWcTJoSnUvWnVQbkhuQjBiWXpiVmZIK05vNW5nWlU4Qks2UEdmCmpncytESzZVbjZIaWk4M3U0Zk5RSllPVmJQWk1uMUVMWHRkcWJCMEdGREdsdDhmK3dnUjdVc212N09SQlV4ZVIKdFB5dnUramtWUk9pbExiTDhzTWh3cW90ZlJIcElWL1R5cENLQnViVjJBc1lwUGxVZ3RBY2xlTlUwL1Q1bHVYYgo4THE5b0kxY0c2V2VMTk1lYnozQzJrN1hJbEZPdEVFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MHdNekF5TlRnMFlTMHlNelZpTFRRMVlXVXRZakk1T0MxaFptTTIKWkRNeE5qQTBaV1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMVEF6TURJMU9EUmhMVEl6TldJdE5EVmhaUzFpTWprNExXRm1ZelprTXpFMk1EUmxaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy85WjRjRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVlErWFpudWZKSGVlbE9XWXBzemtra2kzL3VwcElGSHZoTWlFcnQ3Z0dwcVRaV0NsTjFVZUs3M3hWbjJBdlUrSwpQc3RKQ2l0bnNaWXI3ak1jSnZ4a1VPRC9odGRiT0k1T0REanhLTHFBOG1obDFsY2lPSjFiS014MGQ1bU81bUxMCkIzb1VpbzIrWExJaEtjTXZWd3h3b1BaZS9nTWRUNHJxYmdLallQcm12dmRtUTA2YWR1L1hjUjd2N2VkN3dCcVcKRS9TSURzL0tmbUhlYS9IaXEwUkphQk1lcG1DZDVNTy9rT28vazBRNlpWb1ZnVlFjWmFCRU9Xd0ZIeWVUdDg3OApYUlpwK01qNFlZNXQzRVVUbmM5V0RHZW1YcGRtOXFFakFmZnBsNG8zVGlCS3ZzZ2FIbTJoTWtlNWNBc0tNVnVvCmozWTVsVE82d3JUK0IwS0QvbHVtWXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73df72a0-e475-4590-9f6c-23e5764cd5cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0302584a-235b-45ae-b298-afc6d31604ee&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1318,7 +1417,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:16 GMT
+      - Mon, 18 Dec 2023 14:16:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1328,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f27b9d08-863c-4c48-9abe-d0c0ecc921a3
+      - c5f8f729-9bb4-4d14-bcd8-224808ebfad0
     status: 200 OK
     code: 200
     duration: ""
@@ -1339,19 +1438,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:16 GMT
+      - Mon, 18 Dec 2023 14:16:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1361,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d963fb96-c8dd-4730-bdab-a2d2a1b26aa3
+      - 30bfeb03-e018-426f-91d9-5c14b6b2decc
     status: 200 OK
     code: 200
     duration: ""
@@ -1372,10 +1471,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1384,7 +1483,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:16 GMT
+      - Mon, 18 Dec 2023 14:16:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1394,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fccd573b-fd3b-4e7d-8fa8-996493305d55
+      - c368d39a-c2be-45ba-a4cd-458c57323404
     status: 200 OK
     code: 200
     duration: ""
@@ -1405,7 +1504,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1417,7 +1516,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:16 GMT
+      - Mon, 18 Dec 2023 14:16:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1427,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fab4cd7-0233-453e-b91a-9b02487d5044
+      - 8976c2ca-3225-43c7-84f3-62ff5648ebfe
     status: 200 OK
     code: 200
     duration: ""
@@ -1438,19 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:16 GMT
+      - Mon, 18 Dec 2023 14:16:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8dde19e-c8ca-4aed-906b-d41a22ead808
+      - 5ffbb91a-d785-4003-8f0b-5cc94d9c9798
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,7 +1570,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1483,7 +1582,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:16 GMT
+      - Mon, 18 Dec 2023 14:16:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 511711aa-3aab-45d0-a96a-900bf48d0941
+      - aa64f75c-6596-43eb-ae6b-c829b1a844c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,7 +1603,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -1516,7 +1615,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:17 GMT
+      - Mon, 18 Dec 2023 14:16:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 715db2b1-189c-4eb3-a4af-e1faf1a2894a
+      - d0b39c49-6c53-434f-8633-18348b72cf30
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,19 +1636,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:17 GMT
+      - Mon, 18 Dec 2023 14:16:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73760668-ecd0-4c75-8d64-7ebac109910c
+      - f121ef5a-cd43-4ce5-84a2-189da3255551
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVV1lCN3pPMVdWcXhJQUlLUTNERlI2VnZUZndvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5UVTFXaGNOTXpNeE1qRTFNVFF4TlRVMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxsTHZRRWZlazBYQ0d0WG04Nk43L1JnQXlSZU55K1RiSmx1cDcwM1JZNkltZW9QcUZ2UkN2SUgKUVF4cDNjcStPSHN5Y0MxclFtZHlCeGFuTTRPN0lFaTlobnA3d21vNGJQQmdPNWpEelppZUlRcU1IKzA1bVV2ZgpML2dKanJPZFNUbG9qRmFkZjY5VkVYZ0xmMExWcTJoSnUvWnVQbkhuQjBiWXpiVmZIK05vNW5nWlU4Qks2UEdmCmpncytESzZVbjZIaWk4M3U0Zk5RSllPVmJQWk1uMUVMWHRkcWJCMEdGREdsdDhmK3dnUjdVc212N09SQlV4ZVIKdFB5dnUramtWUk9pbExiTDhzTWh3cW90ZlJIcElWL1R5cENLQnViVjJBc1lwUGxVZ3RBY2xlTlUwL1Q1bHVYYgo4THE5b0kxY0c2V2VMTk1lYnozQzJrN1hJbEZPdEVFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MHdNekF5TlRnMFlTMHlNelZpTFRRMVlXVXRZakk1T0MxaFptTTIKWkRNeE5qQTBaV1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMVEF6TURJMU9EUmhMVEl6TldJdE5EVmhaUzFpTWprNExXRm1ZelprTXpFMk1EUmxaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy85WjRjRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVlErWFpudWZKSGVlbE9XWXBzemtra2kzL3VwcElGSHZoTWlFcnQ3Z0dwcVRaV0NsTjFVZUs3M3hWbjJBdlUrSwpQc3RKQ2l0bnNaWXI3ak1jSnZ4a1VPRC9odGRiT0k1T0REanhLTHFBOG1obDFsY2lPSjFiS014MGQ1bU81bUxMCkIzb1VpbzIrWExJaEtjTXZWd3h3b1BaZS9nTWRUNHJxYmdLallQcm12dmRtUTA2YWR1L1hjUjd2N2VkN3dCcVcKRS9TSURzL0tmbUhlYS9IaXEwUkphQk1lcG1DZDVNTy9rT28vazBRNlpWb1ZnVlFjWmFCRU9Xd0ZIeWVUdDg3OApYUlpwK01qNFlZNXQzRVVUbmM5V0RHZW1YcGRtOXFFakFmZnBsNG8zVGlCS3ZzZ2FIbTJoTWtlNWNBc0tNVnVvCmozWTVsVE82d3JUK0IwS0QvbHVtWXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2011"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:17 GMT
+      - Mon, 18 Dec 2023 14:16:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 786726c6-bd43-4e36-a9ca-66d6b03cec6e
+      - 72a9efb9-0580-4d92-b12c-86bc24e64362
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,7 +1702,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0302584a-235b-45ae-b298-afc6d31604ee&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1615,7 +1714,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:17 GMT
+      - Mon, 18 Dec 2023 14:16:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aae42295-8bfd-432f-a78d-c178968f669b
+      - f73b0237-e1f1-4eed-9ec4-d2fa46d25331
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,10 +1735,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a909dd9-4f55-4edb-900a-952518e5e300
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/databases?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -1648,7 +1780,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:17 GMT
+      - Mon, 18 Dec 2023 14:16:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1e36a56-e960-4a54-9481-366da1146df2
+      - 1d50e91b-c979-4fcb-b267-96cfbea2c0b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,40 +1801,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e53556bb-591f-4dd0-9195-8c643337f82d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1714,7 +1813,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:18 GMT
+      - Mon, 18 Dec 2023 14:16:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1724,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a81b8247-92c1-4b6c-a04a-10c63d121374
+      - ba9c8513-96bf-4266-a0c1-0781398fdc55
     status: 200 OK
     code: 200
     duration: ""
@@ -1735,19 +1834,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:18 GMT
+      - Mon, 18 Dec 2023 14:16:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1757,7 +1856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3514c157-c5d4-4154-bf26-c275aed058fe
+      - 66528e1d-742c-46e2-8db6-c42198d6a0b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1768,7 +1867,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1780,7 +1879,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:18 GMT
+      - Mon, 18 Dec 2023 14:16:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1790,7 +1889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9578a9ad-ebad-4367-baf0-ad91243c0836
+      - 50b20705-898d-410f-baef-598d3cfe9c3b
     status: 200 OK
     code: 200
     duration: ""
@@ -1801,7 +1900,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -1813,7 +1912,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:18 GMT
+      - Mon, 18 Dec 2023 14:16:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1823,7 +1922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bbb88d4-aa67-41e5-b269-7863e1f6e3e1
+      - d95b8f0d-cffa-49ab-93e6-22f8c5cf81ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1834,19 +1933,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:19 GMT
+      - Mon, 18 Dec 2023 14:16:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1856,7 +1955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0fb4c87-61c2-443d-9ea2-b34f42230d10
+      - 098df3c9-8317-4603-bc27-da81a926f48d
     status: 200 OK
     code: 200
     duration: ""
@@ -1869,7 +1968,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"user_02"}'
@@ -1881,7 +1980,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:19 GMT
+      - Mon, 18 Dec 2023 14:16:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1891,7 +1990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24810c75-05ac-4f76-85c9-a2e3fb0d4eb0
+      - 719541c7-c36b-4554-99d8-7c638c7e0150
     status: 200 OK
     code: 200
     duration: ""
@@ -1902,19 +2001,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:19 GMT
+      - Mon, 18 Dec 2023 14:16:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1924,7 +2023,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52577519-aede-4bc0-8792-0667a601a43c
+      - cc13124a-aa01-4f55-b9b0-96ce0c157b72
     status: 200 OK
     code: 200
     duration: ""
@@ -1935,7 +2034,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -1947,7 +2046,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:19 GMT
+      - Mon, 18 Dec 2023 14:16:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1957,7 +2056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14b0394b-40de-4ecb-b3ed-2547ec4503e5
+      - 30683b32-dbeb-421f-81d5-3acd5e299c40
     status: 200 OK
     code: 200
     duration: ""
@@ -1968,19 +2067,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:19 GMT
+      - Mon, 18 Dec 2023 14:16:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1990,7 +2089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd794859-37a4-4438-8838-c645154080b8
+      - d2ae2bab-7fd9-4d6f-86ed-c7f77f74a318
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,7 +2102,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"readwrite","user_name":"user_02"}'
@@ -2015,7 +2114,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:20 GMT
+      - Mon, 18 Dec 2023 14:16:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2025,7 +2124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2584e190-5c28-45e6-9a75-ec8f5613d4bd
+      - 5430f821-7047-4b37-be8c-3c1a95b804ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,19 +2135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:20 GMT
+      - Mon, 18 Dec 2023 14:16:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2058,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e558c1e6-e27b-4706-a560-3ac2ba2ecd8d
+      - 9663e1ee-f2d0-4b18-9df8-4aef303ac1bf
     status: 200 OK
     code: 200
     duration: ""
@@ -2069,19 +2168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:20 GMT
+      - Mon, 18 Dec 2023 14:16:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 810544b4-0326-4853-ab88-40da59f0d37a
+      - 05f80dd7-70af-444a-9b91-7adb6caf3ef1
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,7 +2201,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -2114,7 +2213,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:20 GMT
+      - Mon, 18 Dec 2023 14:16:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2124,7 +2223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb898b19-ed2d-4fce-b29c-ab2e5ef65339
+      - c530442b-0f4d-4796-aa7c-0babccf052d2
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,7 +2234,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -2147,7 +2246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:21 GMT
+      - Mon, 18 Dec 2023 14:16:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2157,7 +2256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9953ed6-d827-4678-b45d-20532430fe75
+      - c42a6a32-b21c-4f58-9faa-f0dc5d145795
     status: 200 OK
     code: 200
     duration: ""
@@ -2168,7 +2267,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -2180,7 +2279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:21 GMT
+      - Mon, 18 Dec 2023 14:16:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2190,7 +2289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5d4b75d-7b4f-4908-bd7d-712d2a7c7f12
+      - 38773a61-0919-4089-9f38-624677a0bd13
     status: 200 OK
     code: 200
     duration: ""
@@ -2201,19 +2300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
+      - Mon, 18 Dec 2023 14:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2223,7 +2322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6c84766-95b7-4ffb-80cc-9310e6dc56af
+      - 1ab1c5c7-2868-4e91-ae89-3462bdee6894
     status: 200 OK
     code: 200
     duration: ""
@@ -2234,19 +2333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVV1lCN3pPMVdWcXhJQUlLUTNERlI2VnZUZndvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5UVTFXaGNOTXpNeE1qRTFNVFF4TlRVMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxsTHZRRWZlazBYQ0d0WG04Nk43L1JnQXlSZU55K1RiSmx1cDcwM1JZNkltZW9QcUZ2UkN2SUgKUVF4cDNjcStPSHN5Y0MxclFtZHlCeGFuTTRPN0lFaTlobnA3d21vNGJQQmdPNWpEelppZUlRcU1IKzA1bVV2ZgpML2dKanJPZFNUbG9qRmFkZjY5VkVYZ0xmMExWcTJoSnUvWnVQbkhuQjBiWXpiVmZIK05vNW5nWlU4Qks2UEdmCmpncytESzZVbjZIaWk4M3U0Zk5RSllPVmJQWk1uMUVMWHRkcWJCMEdGREdsdDhmK3dnUjdVc212N09SQlV4ZVIKdFB5dnUramtWUk9pbExiTDhzTWh3cW90ZlJIcElWL1R5cENLQnViVjJBc1lwUGxVZ3RBY2xlTlUwL1Q1bHVYYgo4THE5b0kxY0c2V2VMTk1lYnozQzJrN1hJbEZPdEVFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MHdNekF5TlRnMFlTMHlNelZpTFRRMVlXVXRZakk1T0MxaFptTTIKWkRNeE5qQTBaV1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMVEF6TURJMU9EUmhMVEl6TldJdE5EVmhaUzFpTWprNExXRm1ZelprTXpFMk1EUmxaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy85WjRjRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVlErWFpudWZKSGVlbE9XWXBzemtra2kzL3VwcElGSHZoTWlFcnQ3Z0dwcVRaV0NsTjFVZUs3M3hWbjJBdlUrSwpQc3RKQ2l0bnNaWXI3ak1jSnZ4a1VPRC9odGRiT0k1T0REanhLTHFBOG1obDFsY2lPSjFiS014MGQ1bU81bUxMCkIzb1VpbzIrWExJaEtjTXZWd3h3b1BaZS9nTWRUNHJxYmdLallQcm12dmRtUTA2YWR1L1hjUjd2N2VkN3dCcVcKRS9TSURzL0tmbUhlYS9IaXEwUkphQk1lcG1DZDVNTy9rT28vazBRNlpWb1ZnVlFjWmFCRU9Xd0ZIeWVUdDg3OApYUlpwK01qNFlZNXQzRVVUbmM5V0RHZW1YcGRtOXFFakFmZnBsNG8zVGlCS3ZzZ2FIbTJoTWtlNWNBc0tNVnVvCmozWTVsVE82d3JUK0IwS0QvbHVtWXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2011"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
+      - Mon, 18 Dec 2023 14:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2256,7 +2355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd980a02-cfcb-41da-aad0-aef51a6bb796
+      - fa00f6c3-2a5e-47ba-8011-3de1ed9fc0ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2267,7 +2366,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0302584a-235b-45ae-b298-afc6d31604ee&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -2279,7 +2378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
+      - Mon, 18 Dec 2023 14:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2289,7 +2388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc6e522a-7ec4-4d22-94bc-58141ad20dfb
+      - e5a1fbfe-dd2a-4cd9-b584-454c22d56bd2
     status: 200 OK
     code: 200
     duration: ""
@@ -2300,10 +2399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -2312,7 +2411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
+      - Mon, 18 Dec 2023 14:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2322,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baae1331-1595-4252-a32c-e01b4c526085
+      - e3d6dde3-828d-4e1e-ac14-2c11145968dd
     status: 200 OK
     code: 200
     duration: ""
@@ -2333,19 +2432,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
+      - Mon, 18 Dec 2023 14:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2355,7 +2454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74b0de51-6789-464e-9265-be79c04497a5
+      - a6f8cd5a-9211-450c-8e3e-34b0e2ecbd63
     status: 200 OK
     code: 200
     duration: ""
@@ -2366,19 +2465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
+      - Mon, 18 Dec 2023 14:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2388,7 +2487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 446fbed1-8158-4e04-abd1-397e73493226
+      - 96edde0c-13e7-4c1d-9f8a-9aef992a89a8
     status: 200 OK
     code: 200
     duration: ""
@@ -2399,40 +2498,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dd347d09-f706-4a16-a0e8-503fe46fd3ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -2444,7 +2510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
+      - Mon, 18 Dec 2023 14:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2454,7 +2520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 463900dc-82f4-4765-a702-d09370e15c66
+      - 788ce755-c4cd-44eb-9ce6-59aaa6724a94
     status: 200 OK
     code: 200
     duration: ""
@@ -2465,106 +2531,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6638f60f-53a4-4112-8963-8884eabfd18e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 357e5574-ebc8-42e0-877a-3e74b7a4d323
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b752a9a7-98cb-480a-a8ab-862c96470301
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -2576,7 +2543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Mon, 18 Dec 2023 14:16:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2586,7 +2553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94b51692-1185-454d-af13-ab2d6def93b1
+      - 0dd51255-9f41-456c-bccc-367e34e69b26
     status: 200 OK
     code: 200
     duration: ""
@@ -2597,7 +2564,139 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 782e5fd4-319f-4640-95c7-20ba17564b68
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af0b2530-e9a8-435f-8dd9-3e6107c13083
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3281bdf5-9246-4dec-b3fd-2b4f1bf4c335
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 267f0abb-9af9-4de6-9720-8a9493f455a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -2609,7 +2708,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2619,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82010a57-5299-41ee-b339-28e26a46f724
+      - 4d2c966c-da4c-47b4-ba1e-a68c974a8612
     status: 200 OK
     code: 200
     duration: ""
@@ -2630,7 +2729,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -2642,7 +2741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2652,7 +2751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dc73a27-67fa-4e47-af6c-20801d745a88
+      - fc9924f5-632d-4d66-b8ed-71636bc50c75
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,19 +2762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2685,7 +2784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0108b022-bfb4-4172-8c1b-5be40a36339e
+      - 1758e16f-e640-4949-b597-733d3c089ded
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,19 +2795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVV1lCN3pPMVdWcXhJQUlLUTNERlI2VnZUZndvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5UVTFXaGNOTXpNeE1qRTFNVFF4TlRVMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxsTHZRRWZlazBYQ0d0WG04Nk43L1JnQXlSZU55K1RiSmx1cDcwM1JZNkltZW9QcUZ2UkN2SUgKUVF4cDNjcStPSHN5Y0MxclFtZHlCeGFuTTRPN0lFaTlobnA3d21vNGJQQmdPNWpEelppZUlRcU1IKzA1bVV2ZgpML2dKanJPZFNUbG9qRmFkZjY5VkVYZ0xmMExWcTJoSnUvWnVQbkhuQjBiWXpiVmZIK05vNW5nWlU4Qks2UEdmCmpncytESzZVbjZIaWk4M3U0Zk5RSllPVmJQWk1uMUVMWHRkcWJCMEdGREdsdDhmK3dnUjdVc212N09SQlV4ZVIKdFB5dnUramtWUk9pbExiTDhzTWh3cW90ZlJIcElWL1R5cENLQnViVjJBc1lwUGxVZ3RBY2xlTlUwL1Q1bHVYYgo4THE5b0kxY0c2V2VMTk1lYnozQzJrN1hJbEZPdEVFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MHdNekF5TlRnMFlTMHlNelZpTFRRMVlXVXRZakk1T0MxaFptTTIKWkRNeE5qQTBaV1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMVEF6TURJMU9EUmhMVEl6TldJdE5EVmhaUzFpTWprNExXRm1ZelprTXpFMk1EUmxaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy85WjRjRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVlErWFpudWZKSGVlbE9XWXBzemtra2kzL3VwcElGSHZoTWlFcnQ3Z0dwcVRaV0NsTjFVZUs3M3hWbjJBdlUrSwpQc3RKQ2l0bnNaWXI3ak1jSnZ4a1VPRC9odGRiT0k1T0REanhLTHFBOG1obDFsY2lPSjFiS014MGQ1bU81bUxMCkIzb1VpbzIrWExJaEtjTXZWd3h3b1BaZS9nTWRUNHJxYmdLallQcm12dmRtUTA2YWR1L1hjUjd2N2VkN3dCcVcKRS9TSURzL0tmbUhlYS9IaXEwUkphQk1lcG1DZDVNTy9rT28vazBRNlpWb1ZnVlFjWmFCRU9Xd0ZIeWVUdDg3OApYUlpwK01qNFlZNXQzRVVUbmM5V0RHZW1YcGRtOXFFakFmZnBsNG8zVGlCS3ZzZ2FIbTJoTWtlNWNBc0tNVnVvCmozWTVsVE82d3JUK0IwS0QvbHVtWXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2011"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2718,7 +2817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4694cbe-083a-4c4d-8cd2-b9083cd0b1a4
+      - a3da08f2-63c7-45ef-8c26-1aed3a14909e
     status: 200 OK
     code: 200
     duration: ""
@@ -2729,7 +2828,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0302584a-235b-45ae-b298-afc6d31604ee&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -2741,7 +2840,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2751,7 +2850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b887eee3-1514-40fa-adf6-21d688d6d1f6
+      - 763097ce-8dd2-4d06-bebd-0ad0c972f6ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2762,43 +2861,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6b9cb167-14b5-4b4e-9d7b-7b3ab1ae495a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -2807,7 +2873,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2817,7 +2883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a044e319-c027-4e61-a5b7-5cadedfdee3a
+      - 25f92282-188b-49ef-8480-9646340697ba
     status: 200 OK
     code: 200
     duration: ""
@@ -2828,19 +2894,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2850,7 +2916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19018e48-d752-4496-b558-18163b20bb7a
+      - 2919d5b6-2f47-4a03-be03-675c41923cfa
     status: 200 OK
     code: 200
     duration: ""
@@ -2861,19 +2927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "62"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:24 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2883,7 +2949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd6a0f78-e01d-4d90-8dc2-84c1923c9064
+      - ffa29f7d-5de4-4bfe-a837-e34e738b3fc0
     status: 200 OK
     code: 200
     duration: ""
@@ -2894,106 +2960,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 822dbbf1-2278-4ef9-80df-3ee4be6596f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9deb466a-2d8a-49c6-84f3-1b296a611fcb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5896cdc3-3e55-4bef-9e48-ad8a8209d62d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -3005,7 +2972,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:24 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3015,7 +2982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 035f06fd-efa0-4782-93b9-75e12cbf1581
+      - 6d78e687-9a3f-40d6-b65c-d99e1e51188a
     status: 200 OK
     code: 200
     duration: ""
@@ -3026,7 +2993,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -3038,7 +3005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:24 GMT
+      - Mon, 18 Dec 2023 14:16:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3048,7 +3015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - faa6c19b-91f0-4895-9c05-194f15a877ce
+      - 1a2ef393-a4a1-44ca-91bd-f49ad7909c9c
     status: 200 OK
     code: 200
     duration: ""
@@ -3059,19 +3026,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "103"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:24 GMT
+      - Mon, 18 Dec 2023 14:16:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3081,7 +3048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49df048c-c8d3-4b7c-bf1e-cff2d972fc6a
+      - 704ba76c-c659-4d4a-8226-f288ee7e2634
     status: 200 OK
     code: 200
     duration: ""
@@ -3092,7 +3059,106 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2fcd3a52-5332-414f-9b9f-e2398517154c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0ebfeac7-959a-4171-a550-a6788717db45
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a45e9cdc-076d-49cd-aa6f-9a3e3c08d4dc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -3104,7 +3170,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:24 GMT
+      - Mon, 18 Dec 2023 14:16:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3114,7 +3180,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c5cb781-0edb-492c-acc5-5ce8cf24fd56
+      - 2a784141-c5f0-4728-8356-cf0891fe208f
     status: 200 OK
     code: 200
     duration: ""
@@ -3125,19 +3191,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1270"
+      - "103"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:25 GMT
+      - Mon, 18 Dec 2023 14:16:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3147,7 +3213,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3549c41f-d10f-4015-bc90-fe6342e5318d
+      - a203215e-d124-48d9-b024-fa3ae0812e6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3ade193-ef09-456c-85a2-61960688c7a5
     status: 200 OK
     code: 200
     duration: ""
@@ -3160,7 +3259,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"user_03"}'
@@ -3172,7 +3271,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:25 GMT
+      - Mon, 18 Dec 2023 14:16:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3182,7 +3281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d605cf4a-71fd-4d72-beef-794e3048f77d
+      - e8f0838b-2dee-43ed-b8e7-283deaf84359
     status: 200 OK
     code: 200
     duration: ""
@@ -3193,19 +3292,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:25 GMT
+      - Mon, 18 Dec 2023 14:16:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3215,7 +3314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03a86cab-a559-443f-ba9c-efeda99a5bd4
+      - 0cded01a-2140-4931-b011-1f7449c4b190
     status: 200 OK
     code: 200
     duration: ""
@@ -3226,7 +3325,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
@@ -3238,7 +3337,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:25 GMT
+      - Mon, 18 Dec 2023 14:16:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3248,7 +3347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f256247-35bd-46fb-add9-e93203e1491a
+      - 33432b56-46b1-4d74-a3eb-18ec2bfd452b
     status: 200 OK
     code: 200
     duration: ""
@@ -3259,19 +3358,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:25 GMT
+      - Mon, 18 Dec 2023 14:16:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3281,7 +3380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2c11be7-ada5-4b43-8cce-6b3c3271af37
+      - 65d372ff-6625-4312-b490-58f424b25817
     status: 200 OK
     code: 200
     duration: ""
@@ -3294,7 +3393,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
@@ -3306,7 +3405,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:25 GMT
+      - Mon, 18 Dec 2023 14:16:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3316,7 +3415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 519bbc89-df90-4443-9030-94f71843cc2a
+      - cfcf126c-e4e4-44f6-9bb5-369b73092ef4
     status: 200 OK
     code: 200
     duration: ""
@@ -3327,19 +3426,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:26 GMT
+      - Mon, 18 Dec 2023 14:16:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3349,7 +3448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 725d12cd-3492-4ea7-b1ce-57b1e97e3d11
+      - e7f2a8a0-03aa-4a4e-90c2-37b7670281a0
     status: 200 OK
     code: 200
     duration: ""
@@ -3360,19 +3459,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:26 GMT
+      - Mon, 18 Dec 2023 14:16:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3382,7 +3481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fde5a2c2-966e-4342-94ac-7d79f6d47d3e
+      - a4cef86d-65ce-4091-b7b0-69e71da26287
     status: 200 OK
     code: 200
     duration: ""
@@ -3393,7 +3492,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
@@ -3405,7 +3504,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:30 GMT
+      - Mon, 18 Dec 2023 14:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3415,7 +3514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c2a9e56-ef42-4f5a-8d20-862d2b4bdef6
+      - 2b013321-a3a6-472a-9b2c-f7ff971975a3
     status: 200 OK
     code: 200
     duration: ""
@@ -3426,7 +3525,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
@@ -3438,7 +3537,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:31 GMT
+      - Mon, 18 Dec 2023 14:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3448,7 +3547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1542db7-d805-4e71-bb8b-221c06e4d493
+      - f3cb9916-9ff6-4694-9f2c-a8b128e61826
     status: 200 OK
     code: 200
     duration: ""
@@ -3459,7 +3558,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
@@ -3471,7 +3570,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:31 GMT
+      - Mon, 18 Dec 2023 14:16:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3481,7 +3580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bcbcfb9-1db5-47c1-baac-191a9ab5e958
+      - 765c5f2a-0ffa-4f51-b648-e93e0eeb3849
     status: 200 OK
     code: 200
     duration: ""
@@ -3492,19 +3591,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:33 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3514,7 +3613,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a130b679-5661-4785-a845-93653fbe1318
+      - fc90e862-d3cf-4ad0-931e-87e2420b2270
     status: 200 OK
     code: 200
     duration: ""
@@ -3525,19 +3624,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVV1lCN3pPMVdWcXhJQUlLUTNERlI2VnZUZndvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVRJdU9UY3dIaGNOCk1qTXhNakU0TVRReE5UVTFXaGNOTXpNeE1qRTFNVFF4TlRVMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhNaTQ1TnpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxsTHZRRWZlazBYQ0d0WG04Nk43L1JnQXlSZU55K1RiSmx1cDcwM1JZNkltZW9QcUZ2UkN2SUgKUVF4cDNjcStPSHN5Y0MxclFtZHlCeGFuTTRPN0lFaTlobnA3d21vNGJQQmdPNWpEelppZUlRcU1IKzA1bVV2ZgpML2dKanJPZFNUbG9qRmFkZjY5VkVYZ0xmMExWcTJoSnUvWnVQbkhuQjBiWXpiVmZIK05vNW5nWlU4Qks2UEdmCmpncytESzZVbjZIaWk4M3U0Zk5RSllPVmJQWk1uMUVMWHRkcWJCMEdGREdsdDhmK3dnUjdVc212N09SQlV4ZVIKdFB5dnUramtWUk9pbExiTDhzTWh3cW90ZlJIcElWL1R5cENLQnViVjJBc1lwUGxVZ3RBY2xlTlUwL1Q1bHVYYgo4THE5b0kxY0c2V2VMTk1lYnozQzJrN1hJbEZPdEVFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXlMamszZ2p4eWR5MHdNekF5TlRnMFlTMHlNelZpTFRRMVlXVXRZakk1T0MxaFptTTIKWkRNeE5qQTBaV1V1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1USXVPVGVDUEhKMwpMVEF6TURJMU9EUmhMVEl6TldJdE5EVmhaUzFpTWprNExXRm1ZelprTXpFMk1EUmxaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy85WjRjRU01OXdZWWNFTTU5d1lUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVlErWFpudWZKSGVlbE9XWXBzemtra2kzL3VwcElGSHZoTWlFcnQ3Z0dwcVRaV0NsTjFVZUs3M3hWbjJBdlUrSwpQc3RKQ2l0bnNaWXI3ak1jSnZ4a1VPRC9odGRiT0k1T0REanhLTHFBOG1obDFsY2lPSjFiS014MGQ1bU81bUxMCkIzb1VpbzIrWExJaEtjTXZWd3h3b1BaZS9nTWRUNHJxYmdLallQcm12dmRtUTA2YWR1L1hjUjd2N2VkN3dCcVcKRS9TSURzL0tmbUhlYS9IaXEwUkphQk1lcG1DZDVNTy9rT28vazBRNlpWb1ZnVlFjWmFCRU9Xd0ZIeWVUdDg3OApYUlpwK01qNFlZNXQzRVVUbmM5V0RHZW1YcGRtOXFFakFmZnBsNG8zVGlCS3ZzZ2FIbTJoTWtlNWNBc0tNVnVvCmozWTVsVE82d3JUK0IwS0QvbHVtWXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2011"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:33 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3547,7 +3646,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0fcff35-0aa4-4959-aedb-26cd5bbe399b
+      - 79c73330-4c81-4eeb-90b5-3e0c5073009b
     status: 200 OK
     code: 200
     duration: ""
@@ -3558,7 +3657,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0302584a-235b-45ae-b298-afc6d31604ee&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -3570,7 +3669,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:33 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3580,7 +3679,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c060c43-8021-4f90-9fcf-beb1a937cef7
+      - e048ffc8-4f25-41cd-acd2-24db7f6d91a1
     status: 200 OK
     code: 200
     duration: ""
@@ -3591,10 +3690,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/databases?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
+    body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7656239}],"total_count":1}'
     headers:
       Content-Length:
       - "102"
@@ -3603,7 +3702,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3613,7 +3712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0934be26-74b5-46ac-9065-5c05ba2a4466
+      - f8e0a072-61a4-4906-8445-3dbfb8b17825
     status: 200 OK
     code: 200
     duration: ""
@@ -3624,19 +3723,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3646,7 +3745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a461e4b-7018-4d8f-8bfa-093159e74995
+      - bcba0263-15e0-4050-b1a9-f2411a950de2
     status: 200 OK
     code: 200
     duration: ""
@@ -3657,19 +3756,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3679,7 +3778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1270545d-a293-400f-80b2-39cd6bc36e22
+      - 2ad1c9fe-e48a-4b59-a794-9481c4a4534f
     status: 200 OK
     code: 200
     duration: ""
@@ -3690,19 +3789,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3712,7 +3811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9039898-e9b9-4d57-a971-7e52db95f0e8
+      - 32a16b17-2f52-4bbd-b03f-99fc59dddb6d
     status: 200 OK
     code: 200
     duration: ""
@@ -3723,40 +3822,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6026352c-ac10-4b52-9680-07084955dc59
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
@@ -3768,7 +3834,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3778,7 +3844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be049a40-f412-4eb4-89a2-d7ea0e325488
+      - e13522a0-254d-4bf9-bb5b-cee82b6e6034
     status: 200 OK
     code: 200
     duration: ""
@@ -3789,7 +3855,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -3801,7 +3867,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3811,7 +3877,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac5e07de-1de7-4c1a-b887-697ed295b9b0
+      - 4b883dce-8c15-49f1-ac47-2d03b7408610
     status: 200 OK
     code: 200
     duration: ""
@@ -3822,172 +3888,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 91b891fe-a572-4b37-8155-b859a8382d61
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8a6d280c-a1bb-4cc8-befc-a40fb8e99013
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f8805239-f595-41be-9d72-e1aa82961f3f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0d7f6ba3-a85a-4ac4-b608-f7bb344de25e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e067ca6a-695f-4bdb-9af9-ba5f46a6cc57
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -3999,7 +3900,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4009,7 +3910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b61879f-b3c2-47d5-a3c1-db26c2b0275e
+      - 94991df6-0d6f-4af8-8fb8-6d970636b36b
     status: 200 OK
     code: 200
     duration: ""
@@ -4020,7 +3921,205 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf7f46ea-978f-4cb7-b6f8-a18dcb885c05
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:54 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4991d355-0480-44c5-bc09-9028aae2c398
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec04c2fc-0c29-4119-b10d-da5101bab8f0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 37597a00-5e65-43d8-969d-f5b8bbda21b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11136cc5-2450-47a6-9629-291a29b19a98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c07e68d7-4a43-4edd-96c6-061bd78c0079
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -4032,7 +4131,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4042,7 +4141,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fc1a2db-1b98-4bc2-934c-00770aa2d761
+      - 6cce3163-33ad-4dca-bdfd-48c7922171c9
     status: 200 OK
     code: 200
     duration: ""
@@ -4053,7 +4152,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -4065,7 +4164,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4075,7 +4174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 530cfec5-fbba-4cdc-95ee-c69d6dd9a547
+      - 07595716-32bf-4bf5-b482-43650baf5205
     status: 200 OK
     code: 200
     duration: ""
@@ -4086,7 +4185,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
@@ -4098,7 +4197,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:34 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4108,7 +4207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3aaa5592-6378-4188-b730-d12cef87f129
+      - ebaa476a-a84f-47a6-bcfb-adcfcedb74c0
     status: 200 OK
     code: 200
     duration: ""
@@ -4119,19 +4218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4141,7 +4240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca256fc6-446e-4ee7-ac10-323dc7db962e
+      - b22d53cc-b909-4642-aeea-ebb7d3520e96
     status: 200 OK
     code: 200
     duration: ""
@@ -4152,19 +4251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4174,7 +4273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66a503b8-3ef3-4a33-8705-1971e01146f5
+      - 91c10f04-81d9-44d0-8f1c-2389db0f0ca9
     status: 200 OK
     code: 200
     duration: ""
@@ -4185,19 +4284,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4207,7 +4306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f431ba14-03c5-419d-abaf-514d551f4ad9
+      - 0f1e83c5-acec-4f31-bac6-6d01ff82feae
     status: 200 OK
     code: 200
     duration: ""
@@ -4218,73 +4317,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 27fd5eed-4e3c-4cf1-a643-6a7edef4d274
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 37b0874a-6e3c-4c5f-97de-e45df9537b4f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -4296,7 +4329,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4306,7 +4339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efc11343-98aa-4b88-85eb-7aeb90456037
+      - c8a2527b-093d-4eac-a8e2-211021e94dbb
     status: 200 OK
     code: 200
     duration: ""
@@ -4317,7 +4350,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -4329,7 +4362,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4339,7 +4372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bad8f942-f0fb-4513-a4dc-42e49e4bd5d2
+      - 7dcc4b86-3729-488d-9ffc-787d6969c95f
     status: 200 OK
     code: 200
     duration: ""
@@ -4350,7 +4383,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
@@ -4362,7 +4395,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4372,7 +4405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66f79bc0-3b89-4751-89b6-565ca06944a8
+      - 4b90a7e9-a084-4df1-9846-67702b4da5b1
     status: 200 OK
     code: 200
     duration: ""
@@ -4383,7 +4416,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a7f5355c-ce68-40ee-b2fc-ec0426f9ad7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -4395,7 +4461,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:35 GMT
+      - Mon, 18 Dec 2023 14:16:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4405,7 +4471,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a787c0f-d565-4264-82ef-9a1e68027ee0
+      - b549a8c3-fde5-4e7f-8e27-86a8ddc350e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b8fb4a81-23a7-4cab-9cfc-f14974b06f28
     status: 200 OK
     code: 200
     duration: ""
@@ -4418,7 +4517,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_01"}'
@@ -4430,7 +4529,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4440,7 +4539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97f72559-ad9d-4995-b5b9-b4b6e3299441
+      - bcf94aed-fb44-46fa-9700-3a716499c0a8
     status: 200 OK
     code: 200
     duration: ""
@@ -4453,7 +4552,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges
     method: PUT
   response:
     body: '{"message":"Tuple concurrently updated"}'
@@ -4465,7 +4564,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4475,7 +4574,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fd9b646-b411-478d-aa74-1419194f72ca
+      - 7a9fdc34-7fee-4b6e-a6d8-f1ffb0518f4d
     status: 409 Conflict
     code: 409
     duration: ""
@@ -4488,306 +4587,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
-    method: PUT
-  response:
-    body: '{"message":"Tuple concurrently updated"}'
-    headers:
-      Content-Length:
-      - "40"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2a69b87f-f120-4b2c-a60e-37ad2497d0a7
-    status: 409 Conflict
-    code: 409
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 78de4fff-afc4-4444-8045-ab1cff279c09
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 88032ad2-8b09-474e-add5-b2b1de481acc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0756d523-fd7b-45f5-a061-dc1eb88542c5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1270"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5fd0c679-b915-47dc-a048-1f750b9020d2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users/user_01
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b24239aa-1562-40c7-95e0-d1ec44aafb3a
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f5fa4e7a-495b-436e-9dc3-fc3278a0099c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - caa852e9-df6e-4ec8-ba85-ed5e8191a747
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_02","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
-    method: PUT
-  response:
-    body: '{"message":"Tuple concurrently updated"}'
-    headers:
-      Content-Length:
-      - "40"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb3ebf88-6ac8-42ca-bf1a-648fe1e85ce8
-    status: 409 Conflict
-    code: 409
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_03","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
@@ -4799,7 +4599,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:37 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4809,7 +4609,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9484695-59c0-4426-8ce3-a2940d204858
+      - 4f5ddea3-70cc-47b3-8262-7f04e6d792b2
     status: 200 OK
     code: 200
     duration: ""
@@ -4820,19 +4620,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:37 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4842,7 +4642,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e294bf93-2ea2-4027-aeb0-dd7f08f1c9ee
+      - c091f3f6-c710-4700-9979-b71b0171d731
     status: 200 OK
     code: 200
     duration: ""
@@ -4853,19 +4653,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:37 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4875,7 +4675,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a02b303-716a-49a3-a4ba-1eea15424c5e
+      - d1862102-0087-464d-93c5-3d8a0bdca33a
     status: 200 OK
     code: 200
     duration: ""
@@ -4886,19 +4686,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:37 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4908,7 +4708,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ec02b3a-4a34-4a73-971a-2c0545b43e52
+      - a88e7292-a841-464d-b94e-c90b813d58dd
     status: 200 OK
     code: 200
     duration: ""
@@ -4919,7 +4719,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users/user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f05cb22e-3df4-49cb-828d-61ca79226acd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1268"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 71532c96-c0d5-4391-8f53-7a02f21bf32e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users/user_03
     method: DELETE
   response:
     body: ""
@@ -4929,7 +4795,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:37 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4939,7 +4805,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0efe644f-7ccc-48e4-bd6f-b86cd2263b45
+      - b3de9db5-068e-472b-b294-c98bfa517672
     status: 204 No Content
     code: 204
     duration: ""
@@ -4950,7 +4816,38 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users/user_01
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:16:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fe678741-4ae3-4993-8a02-f18f967db228
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -4962,7 +4859,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:38 GMT
+      - Mon, 18 Dec 2023 14:16:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4972,7 +4869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91bb0896-dd6f-4661-858d-705c7b72278a
+      - 30d4ca79-5ed8-46f7-90d0-9c35dc0d47d0
     status: 200 OK
     code: 200
     duration: ""
@@ -4985,7 +4882,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_02"}'
@@ -4997,7 +4894,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:38 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5007,7 +4904,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baac30ef-9734-4c6d-885d-0ebd518d351a
+      - f837e86a-5c51-46e5-b9ff-cc909626e744
     status: 200 OK
     code: 200
     duration: ""
@@ -5018,19 +4915,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:38 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5040,7 +4937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d50162d-691a-4343-8ba9-429ab7cc010f
+      - 093eb27b-147f-4b80-a54b-61bb8b451781
     status: 200 OK
     code: 200
     duration: ""
@@ -5051,19 +4948,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:39 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5073,7 +4970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3893535f-0f73-4f4f-aae5-b69fd0406526
+      - 63b1a5d3-a539-4618-8662-feaa38ef12c6
     status: 200 OK
     code: 200
     duration: ""
@@ -5084,19 +4981,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:39 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5106,7 +5003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87ba7c39-13a7-4729-8e48-28f7d4ecc719
+      - 3f53d0c5-eea3-4a68-8a2a-cb284a530e40
     status: 200 OK
     code: 200
     duration: ""
@@ -5117,7 +5014,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users/user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/users/user_02
     method: DELETE
   response:
     body: ""
@@ -5127,7 +5024,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:39 GMT
+      - Mon, 18 Dec 2023 14:16:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5137,7 +5034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f388724f-1e26-47c8-9cf0-a1f68aa382b0
+      - 9a90f30f-ca52-4151-8f21-c1c1ac80051d
     status: 204 No Content
     code: 204
     duration: ""
@@ -5148,7 +5045,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee/databases/foo
     method: DELETE
   response:
     body: ""
@@ -5158,7 +5055,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:39 GMT
+      - Mon, 18 Dec 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5168,7 +5065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00bcb2f4-df1d-4f6b-8fc3-2c571c84d269
+      - 80dd4e1c-56fe-4286-a115-05cdc9ca7a69
     status: 204 No Content
     code: 204
     duration: ""
@@ -5179,19 +5076,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:39 GMT
+      - Mon, 18 Dec 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5201,7 +5098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d96a41b0-0ba2-4508-af0d-3ddd447b8f69
+      - 1b333d4e-38e1-4b7e-bc16-26f2c19e0da8
     status: 200 OK
     code: 200
     duration: ""
@@ -5212,19 +5109,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1270"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:39 GMT
+      - Mon, 18 Dec 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5234,7 +5131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ce222e5-074e-4aff-928d-d3be08092768
+      - bde1aa88-57e1-4065-8b62-654f249e4e86
     status: 200 OK
     code: 200
     duration: ""
@@ -5245,19 +5142,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1273"
+      - "1271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:40 GMT
+      - Mon, 18 Dec 2023 14:16:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5267,7 +5164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 950d32dc-ec38-4171-8e3f-d91f85bc2c57
+      - 0a05ac3b-d405-42ae-93fa-004bd985b3d3
     status: 200 OK
     code: 200
     duration: ""
@@ -5278,19 +5175,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:13:01.993227Z","retention":7},"created_at":"2023-12-18T14:13:01.993227Z","endpoint":{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342},"endpoints":[{"id":"dcbdc92c-b0a9-4e30-b046-30f051cba8d5","ip":"51.159.112.97","load_balancer":{},"name":null,"port":12342}],"engine":"PostgreSQL-15","id":"0302584a-235b-45ae-b298-afc6d31604ee","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1273"
+      - "1271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:40 GMT
+      - Mon, 18 Dec 2023 14:16:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5300,7 +5197,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 990bbfd1-838a-45f2-b479-5b9d1d29b0fc
+      - 59d6668b-2250-4894-ae76-a0471a234329
     status: 200 OK
     code: 200
     duration: ""
@@ -5311,10 +5208,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0302584a-235b-45ae-b298-afc6d31604ee","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -5323,7 +5220,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:10 GMT
+      - Mon, 18 Dec 2023 14:17:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5333,7 +5230,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd3ac55e-8dfb-481a-84e9-029cac5db57f
+      - 7be6b6f7-efc0-48d7-aeca-d076818ab1ca
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5344,10 +5241,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0302584a-235b-45ae-b298-afc6d31604ee
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0302584a-235b-45ae-b298-afc6d31604ee","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -5356,7 +5253,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:10 GMT
+      - Mon, 18 Dec 2023 14:17:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5366,7 +5263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fba59710-c615-44ab-bd7f-35de70e4a957
+      - 4a1db3d0-a473-4e83-88b7-7aef4200aed7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-privilege-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-privilege-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:44 GMT
+      - Mon, 18 Dec 2023 12:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fa352f1-27f4-49f1-a166-537ee3107ade
+      - df030da9-41bc-4794-b9a5-cf2eb189fc85
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbPrivilege_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"TestAccScalewayRdbPrivilege_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:44 GMT
+      - Mon, 18 Dec 2023 13:09:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfc57458-7fce-4238-84c7-16fc22ee8ccc
+      - 4cbf58e6-4b62-46d4-bff9-1e66e2b02dd0
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:44 GMT
+      - Mon, 18 Dec 2023 13:09:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0b724e9-b81c-45c6-afca-89e6fba6a07b
+      - 3605ce28-b380-40bf-8dbe-bdfb8202eaba
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:50:15 GMT
+      - Mon, 18 Dec 2023 13:09:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 769296fd-7b5b-4cb5-bc10-588dcdfc3002
+      - 15832cbf-a214-4aa0-9778-36e2838e9ad2
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:50:45 GMT
+      - Mon, 18 Dec 2023 13:10:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af9e051e-684b-446f-b13b-058b57d95c39
+      - c205d1db-e99a-461d-99bc-40abdc31d129
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:51:20 GMT
+      - Mon, 18 Dec 2023 13:10:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eeb978ba-5f51-4182-99ae-93ae38a05577
+      - ae3f6b9e-82c1-496b-a84b-64cff800b940
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "961"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:51:50 GMT
+      - Mon, 18 Dec 2023 13:11:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba885765-093b-44ba-a0fd-0d2c523f29a6
+      - 9bf37dd4-4d79-421a-98e6-0851b1b47f82
     status: 200 OK
     code: 200
     duration: ""
@@ -539,43 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "961"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:52:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b7b43402-6328-470d-8aef-702e6bf72086
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1225"
@@ -584,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:52:55 GMT
+      - Mon, 18 Dec 2023 13:11:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f44961d-b273-4599-95d1-665f999baad7
+      - 4d91cd2d-bb4e-44a0-bd6f-443b2238b503
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:25 GMT
+      - Mon, 18 Dec 2023 13:12:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bac56cc-a6a0-4167-bc53-1ec33c3f2617
+      - a4c59e5f-5246-4acf-98ce-12ae0745fc3a
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:26 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6402b06d-3c4b-44a5-a171-2ed398369d3f
+      - 0cdae0f1-51b8-4b74-b84a-59ef55116de5
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:26 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7f331e0-6973-4a1e-9e7f-ff05d37b1343
+      - c092cb40-b2eb-4b33-9be5-b17370b11592
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:26 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bb74cb0-7d51-41dd-b050-364f61c84ae3
+      - cb0eac89-8ea4-4b61-a4bf-1904e7323d81
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVGs1dHg0V29NdHdBTWRXbktEdXZFdnRNbGhBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TURrMU1qUTVXaGNOTXpNeE1qRTFNRGsxTWpRNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9VR2poZFduWFZWazFEVDVmQ2NQeUdIR1FwVmU0bDcvNmpoZXJXclB1UzdRblJXZ2xTdmJXVFYKNFRmWjFaL09ncXpKT2FCQnBDREtoZXg0QURMQ1VUZXBaVDNPZVlSR3ZpcHBWZTlGRE1uOExENVhaRXNoTTlpMwoxaHFIV2U4MGRUakwvSzlOaDM0N253dE9jRWhnVjBZakhEQnVxUXh6K0pwdjU1K29EMGo2YVFJZVFtZ1ZjRWJaCkFBZDFlTVBEREZMOGJDeW0yVGhIaVRyZEFTQTNXQjR0TERmdVJIS1p0M3M3MzFJSmF5Q2lNVWY1bGlNWTNBYlMKSGUxMHlHR0FDc0ZXYTEzWDhxTGJxSzhadDdZZ2cxelNJMXFzS3ZWaUVnZXNidCtNSDJVdENaYTNTem1Xb0NNZgozNzNBZ2J5cXdkVGNpS0Ixa3QzclBPc1RYaGhCWjBjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDNZbUZsTXpWaU55MWtORE0zTFRReU9Ua3RPRGMyWVMweU56WmgKT0RaaVpHTTJNVGN1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGRpWVdVek5XSTNMV1EwTXpjdE5ESTVPUzA0TnpaaExUSTNObUU0Tm1Ka1l6WXhOeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlpWG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZkxVOUVhbUlqOVpTZzNIOW5OZHdjckVBb0RCNHpJUmtyVGM3eWtUUVppNndzNW5zeUhpOUZXa2N1Mi9XcVVmSApicEk5T0VVMlZQK2dnWGxaOGI5b29jQlhTUW9GbHdOU0FoTWROTzRwbit0eS85dldERkZPNk1DVjJQTHhzZzV3CnBwb2k2SS9HdTVVWVlCTWx4dHBKR25CS2pmQUVmMFRROU91UzM1M1Q2b3ZrVW5iRjVPbXpQaGdHdFhwd1oxM3UKYXlscXJ3dkM2OFBZaFZBaXovWFNBUGNPcm1CNHp3aHF4UmdZTGJKa04xaUptQlpZSUQrcHFSUFF3TjlSaXlFTQpWcWVIdHYwQ0IzV0l5SlIvcm9Vak0wd2EyeDFKWTFEeWxTaWcyc3RZUlljSkh4ZG1wdzFtNG8wbGd5WWhrSVR4CmRES3duTW5PWkltWlAvRWNpL0U3Z1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2007"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:26 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14fe7dee-f1fc-48d8-ba67-012038f35dda
+      - f29f6e2c-a3e9-4d9b-8bc2-1c0147c94b8e
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:26 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ca48210-1bbf-4977-9101-2a9f89eecaf1
+      - 9db7ca2c-6099-4234-ac7d-73e14ef23263
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:26 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9384922d-5224-4043-a3ac-c53fc564c77b
+      - 36621bac-661e-4f08-99d4-81b266a9c728
     status: 200 OK
     code: 200
     duration: ""
@@ -840,7 +807,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users
     method: POST
   response:
     body: '{"is_admin":true,"name":"user_01"}'
@@ -852,7 +819,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:27 GMT
+      - Mon, 18 Dec 2023 13:12:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e85a359-6101-4417-b3f2-2ece34c40365
+      - a3253dd3-b248-4142-b970-2ecffb6bdca6
     status: 200 OK
     code: 200
     duration: ""
@@ -875,7 +842,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/databases
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases
     method: POST
   response:
     body: '{"managed":true,"name":"foo","owner":"","size":0}'
@@ -887,7 +854,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:27 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -897,7 +864,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adf9b861-7f24-4caa-a2d4-6670d877e674
+      - db4cb5a5-14a8-40d4-b928-1972a8a222fd
     status: 200 OK
     code: 200
     duration: ""
@@ -908,19 +875,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:27 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -930,7 +897,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fbb4138-27a7-433a-b60b-6773826e389b
+      - eebb8ff9-11d3-4b86-b28a-8db3526cc9ff
     status: 200 OK
     code: 200
     duration: ""
@@ -941,19 +908,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:27 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -963,7 +930,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbbe50e6-79d8-4075-8421-be3ec4444254
+      - 83c15df3-029e-4efa-a11c-58a1bd76ae8b
     status: 200 OK
     code: 200
     duration: ""
@@ -974,7 +941,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -986,7 +953,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:27 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -996,7 +963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b02b1807-1ec2-418c-82e6-65ffc447d2ae
+      - f0598340-7b78-46f4-a2fe-0878df086408
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,7 +974,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7705391}],"total_count":1}'
@@ -1019,7 +986,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:27 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1029,7 +996,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a70eafe8-fe8b-4635-822c-4b238a5795bd
+      - 6fe3478c-40a4-4149-a4f3-fc9f741cdacd
     status: 200 OK
     code: 200
     duration: ""
@@ -1040,19 +1007,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:27 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1062,7 +1029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e22b8635-9cb8-429f-8c49-a5a4cf04a585
+      - 54f9352e-4336-4a61-9c2a-cadba89e34c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1075,7 +1042,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"all","user_name":"user_01"}'
@@ -1087,7 +1054,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:28 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1097,7 +1064,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f96c104-5ff0-4b68-b0d8-fb643b875f53
+      - 2f5af149-c3c9-4921-8cdc-5d26cf42434d
     status: 200 OK
     code: 200
     duration: ""
@@ -1108,19 +1075,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:28 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1130,7 +1097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41b9d8f3-f3f9-409c-9ac9-3cbad356518f
+      - 10418538-3681-4278-82ff-cf59d570c251
     status: 200 OK
     code: 200
     duration: ""
@@ -1141,19 +1108,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:28 GMT
+      - Mon, 18 Dec 2023 13:12:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1163,7 +1130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 909fe274-2970-4a4f-9e75-cc0ace06e612
+      - 578f4fa7-dec2-4b7f-aee7-f1c1e5dab746
     status: 200 OK
     code: 200
     duration: ""
@@ -1174,139 +1141,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9e4ce6bc-9185-4d28-b11d-47347cfa3e6e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "97"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1857e60d-3cf0-4aa8-95ea-c31fbab2980c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "97"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab953e22-714e-4082-b787-3e07930f15b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8035d70a-4acb-4580-a98c-49a09719cead
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1318,7 +1153,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:29 GMT
+      - Mon, 18 Dec 2023 13:12:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1328,7 +1163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 219f4ebb-e9ac-4e3c-980d-5a6452802839
+      - 3569d062-eb72-45f7-ace9-4675404e3529
     status: 200 OK
     code: 200
     duration: ""
@@ -1339,19 +1174,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVGs1dHg0V29NdHdBTWRXbktEdXZFdnRNbGhBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TURrMU1qUTVXaGNOTXpNeE1qRTFNRGsxTWpRNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9VR2poZFduWFZWazFEVDVmQ2NQeUdIR1FwVmU0bDcvNmpoZXJXclB1UzdRblJXZ2xTdmJXVFYKNFRmWjFaL09ncXpKT2FCQnBDREtoZXg0QURMQ1VUZXBaVDNPZVlSR3ZpcHBWZTlGRE1uOExENVhaRXNoTTlpMwoxaHFIV2U4MGRUakwvSzlOaDM0N253dE9jRWhnVjBZakhEQnVxUXh6K0pwdjU1K29EMGo2YVFJZVFtZ1ZjRWJaCkFBZDFlTVBEREZMOGJDeW0yVGhIaVRyZEFTQTNXQjR0TERmdVJIS1p0M3M3MzFJSmF5Q2lNVWY1bGlNWTNBYlMKSGUxMHlHR0FDc0ZXYTEzWDhxTGJxSzhadDdZZ2cxelNJMXFzS3ZWaUVnZXNidCtNSDJVdENaYTNTem1Xb0NNZgozNzNBZ2J5cXdkVGNpS0Ixa3QzclBPc1RYaGhCWjBjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDNZbUZsTXpWaU55MWtORE0zTFRReU9Ua3RPRGMyWVMweU56WmgKT0RaaVpHTTJNVGN1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGRpWVdVek5XSTNMV1EwTXpjdE5ESTVPUzA0TnpaaExUSTNObUU0Tm1Ka1l6WXhOeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlpWG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZkxVOUVhbUlqOVpTZzNIOW5OZHdjckVBb0RCNHpJUmtyVGM3eWtUUVppNndzNW5zeUhpOUZXa2N1Mi9XcVVmSApicEk5T0VVMlZQK2dnWGxaOGI5b29jQlhTUW9GbHdOU0FoTWROTzRwbit0eS85dldERkZPNk1DVjJQTHhzZzV3CnBwb2k2SS9HdTVVWVlCTWx4dHBKR25CS2pmQUVmMFRROU91UzM1M1Q2b3ZrVW5iRjVPbXpQaGdHdFhwd1oxM3UKYXlscXJ3dkM2OFBZaFZBaXovWFNBUGNPcm1CNHp3aHF4UmdZTGJKa04xaUptQlpZSUQrcHFSUFF3TjlSaXlFTQpWcWVIdHYwQ0IzV0l5SlIvcm9Vak0wd2EyeDFKWTFEeWxTaWcyc3RZUlljSkh4ZG1wdzFtNG8wbGd5WWhrSVR4CmRES3duTW5PWkltWlAvRWNpL0U3Z1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "2007"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:29 GMT
+      - Mon, 18 Dec 2023 13:12:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1361,7 +1196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6331a17-dde9-4d47-b77e-a0115db20ffd
+      - 4f91ba7f-5ec5-4e03-a703-09f0c3efada4
     status: 200 OK
     code: 200
     duration: ""
@@ -1372,7 +1207,172 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    method: GET
+  response:
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "97"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0c573bb0-77d6-48cd-8625-bb2a8379d8cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf381362-4dc7-403f-828e-01ab186174b9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5a758f11-6056-43f7-898c-6e49d6714420
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f27b9d08-863c-4c48-9abe-d0c0ecc921a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:16 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d963fb96-c8dd-4730-bdab-a2d2a1b26aa3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
@@ -1384,7 +1384,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:30 GMT
+      - Mon, 18 Dec 2023 13:12:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1394,7 +1394,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff8d91e5-e7fe-4ef9-90b5-c5a245875424
+      - fccd573b-fd3b-4e7d-8fa8-996493305d55
     status: 200 OK
     code: 200
     duration: ""
@@ -1405,40 +1405,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c0fbb8c6-7661-4713-b813-6513ae8e26d1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1450,7 +1417,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:30 GMT
+      - Mon, 18 Dec 2023 13:12:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1460,7 +1427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8787030b-e592-41b9-a4fb-41b6c17f0495
+      - 9fab4cd7-0233-453e-b91a-9b02487d5044
     status: 200 OK
     code: 200
     duration: ""
@@ -1471,19 +1438,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:37 GMT
+      - Mon, 18 Dec 2023 13:12:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1493,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef05cd09-8005-4e4e-921d-c759d58c045a
+      - e8dde19e-c8ca-4aed-906b-d41a22ead808
     status: 200 OK
     code: 200
     duration: ""
@@ -1504,7 +1471,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1516,7 +1483,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:37 GMT
+      - Mon, 18 Dec 2023 13:12:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1526,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83cc964b-f325-4d59-af49-f9b265da680a
+      - 511711aa-3aab-45d0-a96a-900bf48d0941
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,7 +1504,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -1549,7 +1516,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:38 GMT
+      - Mon, 18 Dec 2023 13:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1559,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d3c0d00-ea90-4021-9ac3-2d9ba0781dca
+      - 715db2b1-189c-4eb3-a4af-e1faf1a2894a
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,19 +1537,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:38 GMT
+      - Mon, 18 Dec 2023 13:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1592,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac3371a5-f80a-4adc-afe9-5ee34d18fc84
+      - 73760668-ecd0-4c75-8d64-7ebac109910c
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,19 +1570,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVGs1dHg0V29NdHdBTWRXbktEdXZFdnRNbGhBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TURrMU1qUTVXaGNOTXpNeE1qRTFNRGsxTWpRNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9VR2poZFduWFZWazFEVDVmQ2NQeUdIR1FwVmU0bDcvNmpoZXJXclB1UzdRblJXZ2xTdmJXVFYKNFRmWjFaL09ncXpKT2FCQnBDREtoZXg0QURMQ1VUZXBaVDNPZVlSR3ZpcHBWZTlGRE1uOExENVhaRXNoTTlpMwoxaHFIV2U4MGRUakwvSzlOaDM0N253dE9jRWhnVjBZakhEQnVxUXh6K0pwdjU1K29EMGo2YVFJZVFtZ1ZjRWJaCkFBZDFlTVBEREZMOGJDeW0yVGhIaVRyZEFTQTNXQjR0TERmdVJIS1p0M3M3MzFJSmF5Q2lNVWY1bGlNWTNBYlMKSGUxMHlHR0FDc0ZXYTEzWDhxTGJxSzhadDdZZ2cxelNJMXFzS3ZWaUVnZXNidCtNSDJVdENaYTNTem1Xb0NNZgozNzNBZ2J5cXdkVGNpS0Ixa3QzclBPc1RYaGhCWjBjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDNZbUZsTXpWaU55MWtORE0zTFRReU9Ua3RPRGMyWVMweU56WmgKT0RaaVpHTTJNVGN1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGRpWVdVek5XSTNMV1EwTXpjdE5ESTVPUzA0TnpaaExUSTNObUU0Tm1Ka1l6WXhOeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlpWG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZkxVOUVhbUlqOVpTZzNIOW5OZHdjckVBb0RCNHpJUmtyVGM3eWtUUVppNndzNW5zeUhpOUZXa2N1Mi9XcVVmSApicEk5T0VVMlZQK2dnWGxaOGI5b29jQlhTUW9GbHdOU0FoTWROTzRwbit0eS85dldERkZPNk1DVjJQTHhzZzV3CnBwb2k2SS9HdTVVWVlCTWx4dHBKR25CS2pmQUVmMFRROU91UzM1M1Q2b3ZrVW5iRjVPbXpQaGdHdFhwd1oxM3UKYXlscXJ3dkM2OFBZaFZBaXovWFNBUGNPcm1CNHp3aHF4UmdZTGJKa04xaUptQlpZSUQrcHFSUFF3TjlSaXlFTQpWcWVIdHYwQ0IzV0l5SlIvcm9Vak0wd2EyeDFKWTFEeWxTaWcyc3RZUlljSkh4ZG1wdzFtNG8wbGd5WWhrSVR4CmRES3duTW5PWkltWlAvRWNpL0U3Z1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2007"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:38 GMT
+      - Mon, 18 Dec 2023 13:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1625,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 980cb242-b4d7-4780-a8c0-b0de3c37d6d5
+      - 786726c6-bd43-4e36-a9ca-66d6b03cec6e
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,7 +1603,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aae42295-8bfd-432f-a78d-c178968f669b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
@@ -1648,7 +1648,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:38 GMT
+      - Mon, 18 Dec 2023 13:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1658,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c062bdc-a8d5-4889-9e01-d6204abc4792
+      - f1e36a56-e960-4a54-9481-366da1146df2
     status: 200 OK
     code: 200
     duration: ""
@@ -1669,19 +1669,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:38 GMT
+      - Mon, 18 Dec 2023 13:12:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1691,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 868c24f0-1229-4a02-8573-8b8811206824
+      - e53556bb-591f-4dd0-9195-8c643337f82d
     status: 200 OK
     code: 200
     duration: ""
@@ -1702,73 +1702,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb13b994-4d1a-4b55-855e-9c4347210ef0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 69fa3781-5e81-4ef3-8e2d-99541830fd9f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -1780,7 +1714,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:39 GMT
+      - Mon, 18 Dec 2023 13:12:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1790,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69a97183-5727-4010-bcb2-1f1bc5ac21e4
+      - a81b8247-92c1-4b6c-a04a-10c63d121374
     status: 200 OK
     code: 200
     duration: ""
@@ -1801,7 +1735,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3514c157-c5d4-4154-bf26-c275aed058fe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9578a9ad-ebad-4367-baf0-ad91243c0836
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -1813,7 +1813,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:39 GMT
+      - Mon, 18 Dec 2023 13:12:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1823,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ea30bda-ecb1-4d5f-9930-02187f03a9ce
+      - 6bbb88d4-aa67-41e5-b269-7863e1f6e3e1
     status: 200 OK
     code: 200
     duration: ""
@@ -1834,19 +1834,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:39 GMT
+      - Mon, 18 Dec 2023 13:12:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1856,7 +1856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d01028ba-5af8-4b59-8594-bc970f68fc05
+      - e0fb4c87-61c2-443d-9ea2-b34f42230d10
     status: 200 OK
     code: 200
     duration: ""
@@ -1869,7 +1869,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"user_02"}'
@@ -1881,7 +1881,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:39 GMT
+      - Mon, 18 Dec 2023 13:12:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1891,7 +1891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 255dc047-fa21-4fc9-bfd8-3fa2f4b63e5a
+      - 24810c75-05ac-4f76-85c9-a2e3fb0d4eb0
     status: 200 OK
     code: 200
     duration: ""
@@ -1902,19 +1902,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:40 GMT
+      - Mon, 18 Dec 2023 13:12:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1924,7 +1924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6cadfd94-0c56-4040-9407-9eac6c8cc95f
+      - 52577519-aede-4bc0-8792-0667a601a43c
     status: 200 OK
     code: 200
     duration: ""
@@ -1935,7 +1935,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -1947,7 +1947,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:40 GMT
+      - Mon, 18 Dec 2023 13:12:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1957,7 +1957,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d28e382-709c-47b5-9ee3-5ca01c97fe54
+      - 14b0394b-40de-4ecb-b3ed-2547ec4503e5
     status: 200 OK
     code: 200
     duration: ""
@@ -1968,19 +1968,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:40 GMT
+      - Mon, 18 Dec 2023 13:12:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1990,7 +1990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25d8dc6c-d015-4427-81bc-cf88326853f3
+      - bd794859-37a4-4438-8838-c645154080b8
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,7 +2003,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"readwrite","user_name":"user_02"}'
@@ -2015,7 +2015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:40 GMT
+      - Mon, 18 Dec 2023 13:12:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2025,7 +2025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b83d8bd-be27-4cec-8567-2978074fda6f
+      - 2584e190-5c28-45e6-9a75-ec8f5613d4bd
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,19 +2036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:40 GMT
+      - Mon, 18 Dec 2023 13:12:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2058,7 +2058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76ce8469-5a03-4743-96e4-c64feae22d75
+      - e558c1e6-e27b-4706-a560-3ac2ba2ecd8d
     status: 200 OK
     code: 200
     duration: ""
@@ -2069,19 +2069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:40 GMT
+      - Mon, 18 Dec 2023 13:12:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2091,7 +2091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4721aeae-5aa9-4f3a-b4ca-8dca0e0002dc
+      - 810544b4-0326-4853-ab88-40da59f0d37a
     status: 200 OK
     code: 200
     duration: ""
@@ -2102,7 +2102,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -2114,7 +2114,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:40 GMT
+      - Mon, 18 Dec 2023 13:12:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2124,7 +2124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d32b192-b950-421c-afb6-ca3fcb54bfe8
+      - bb898b19-ed2d-4fce-b29c-ab2e5ef65339
     status: 200 OK
     code: 200
     duration: ""
@@ -2135,7 +2135,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -2147,7 +2147,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:41 GMT
+      - Mon, 18 Dec 2023 13:12:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2157,7 +2157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a603a4b3-2e85-4c66-a0da-efcf72a6a92d
+      - c9953ed6-d827-4678-b45d-20532430fe75
     status: 200 OK
     code: 200
     duration: ""
@@ -2168,7 +2168,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -2180,7 +2180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:41 GMT
+      - Mon, 18 Dec 2023 13:12:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2190,7 +2190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38d5bebb-9054-401e-b39e-ecfd7f7ef689
+      - d5d4b75d-7b4f-4908-bd7d-712d2a7c7f12
     status: 200 OK
     code: 200
     duration: ""
@@ -2201,19 +2201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:41 GMT
+      - Mon, 18 Dec 2023 13:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2223,7 +2223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c052c3d6-9cc4-4898-a205-e77adc5d32f4
+      - f6c84766-95b7-4ffb-80cc-9310e6dc56af
     status: 200 OK
     code: 200
     duration: ""
@@ -2234,19 +2234,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVGs1dHg0V29NdHdBTWRXbktEdXZFdnRNbGhBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TURrMU1qUTVXaGNOTXpNeE1qRTFNRGsxTWpRNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9VR2poZFduWFZWazFEVDVmQ2NQeUdIR1FwVmU0bDcvNmpoZXJXclB1UzdRblJXZ2xTdmJXVFYKNFRmWjFaL09ncXpKT2FCQnBDREtoZXg0QURMQ1VUZXBaVDNPZVlSR3ZpcHBWZTlGRE1uOExENVhaRXNoTTlpMwoxaHFIV2U4MGRUakwvSzlOaDM0N253dE9jRWhnVjBZakhEQnVxUXh6K0pwdjU1K29EMGo2YVFJZVFtZ1ZjRWJaCkFBZDFlTVBEREZMOGJDeW0yVGhIaVRyZEFTQTNXQjR0TERmdVJIS1p0M3M3MzFJSmF5Q2lNVWY1bGlNWTNBYlMKSGUxMHlHR0FDc0ZXYTEzWDhxTGJxSzhadDdZZ2cxelNJMXFzS3ZWaUVnZXNidCtNSDJVdENaYTNTem1Xb0NNZgozNzNBZ2J5cXdkVGNpS0Ixa3QzclBPc1RYaGhCWjBjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDNZbUZsTXpWaU55MWtORE0zTFRReU9Ua3RPRGMyWVMweU56WmgKT0RaaVpHTTJNVGN1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGRpWVdVek5XSTNMV1EwTXpjdE5ESTVPUzA0TnpaaExUSTNObUU0Tm1Ka1l6WXhOeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlpWG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZkxVOUVhbUlqOVpTZzNIOW5OZHdjckVBb0RCNHpJUmtyVGM3eWtUUVppNndzNW5zeUhpOUZXa2N1Mi9XcVVmSApicEk5T0VVMlZQK2dnWGxaOGI5b29jQlhTUW9GbHdOU0FoTWROTzRwbit0eS85dldERkZPNk1DVjJQTHhzZzV3CnBwb2k2SS9HdTVVWVlCTWx4dHBKR25CS2pmQUVmMFRROU91UzM1M1Q2b3ZrVW5iRjVPbXpQaGdHdFhwd1oxM3UKYXlscXJ3dkM2OFBZaFZBaXovWFNBUGNPcm1CNHp3aHF4UmdZTGJKa04xaUptQlpZSUQrcHFSUFF3TjlSaXlFTQpWcWVIdHYwQ0IzV0l5SlIvcm9Vak0wd2EyeDFKWTFEeWxTaWcyc3RZUlljSkh4ZG1wdzFtNG8wbGd5WWhrSVR4CmRES3duTW5PWkltWlAvRWNpL0U3Z1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2007"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:41 GMT
+      - Mon, 18 Dec 2023 13:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2256,7 +2256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 464a6a51-4894-4e23-b746-efb803111fc8
+      - cd980a02-cfcb-41da-aad0-aef51a6bb796
     status: 200 OK
     code: 200
     duration: ""
@@ -2267,19 +2267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1268"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:41 GMT
+      - Mon, 18 Dec 2023 13:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2289,7 +2289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a791f3a7-c9ef-46f3-b456-f29ce8674ec5
+      - cc6e522a-7ec4-4d22-94bc-58141ad20dfb
     status: 200 OK
     code: 200
     duration: ""
@@ -2300,40 +2300,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1259c33d-0c2f-44af-b338-caf8c816464a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
@@ -2345,7 +2312,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:41 GMT
+      - Mon, 18 Dec 2023 13:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2355,7 +2322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44af7df6-67e4-4aa5-8505-0dc4b61c597e
+      - baae1331-1595-4252-a32c-e01b4c526085
     status: 200 OK
     code: 200
     duration: ""
@@ -2366,7 +2333,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74b0de51-6789-464e-9265-be79c04497a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 446fbed1-8158-4e04-abd1-397e73493226
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -2378,7 +2411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
+      - Mon, 18 Dec 2023 13:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2388,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfe01f2e-0f90-4e53-bd3b-0d295ce244cb
+      - dd347d09-f706-4a16-a0e8-503fe46fd3ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2399,7 +2432,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -2411,7 +2444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
+      - Mon, 18 Dec 2023 13:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2421,7 +2454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ba4e8f3-35c5-447e-824f-8b7f6a902c6f
+      - 463900dc-82f4-4765-a702-d09370e15c66
     status: 200 OK
     code: 200
     duration: ""
@@ -2432,19 +2465,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
+      - Mon, 18 Dec 2023 13:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2454,7 +2487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3b1e49e-4d62-434f-8152-3e7f5b40ce12
+      - 6638f60f-53a4-4112-8963-8884eabfd18e
     status: 200 OK
     code: 200
     duration: ""
@@ -2465,19 +2498,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
+      - Mon, 18 Dec 2023 13:12:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2487,7 +2520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 034dfc34-9e70-45cc-9e04-c47bb12c17bd
+      - 357e5574-ebc8-42e0-877a-3e74b7a4d323
     status: 200 OK
     code: 200
     duration: ""
@@ -2498,7 +2531,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b752a9a7-98cb-480a-a8ab-862c96470301
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -2510,7 +2576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2520,7 +2586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c22dd93-9f59-4d00-a4f7-67672f223441
+      - 94b51692-1185-454d-af13-ab2d6def93b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2531,73 +2597,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 79ec21dd-c344-4482-afe5-177c45391ee9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "97"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b0c07bc8-4b50-47ec-a309-8a58d8cdac57
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -2609,7 +2609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2619,7 +2619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15f4213b-440f-436d-ad9f-1d91fbce6b26
+      - 82010a57-5299-41ee-b339-28e26a46f724
     status: 200 OK
     code: 200
     duration: ""
@@ -2630,19 +2630,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1268"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:42 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2652,7 +2652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1e90f6a-e673-4aa0-83ce-f3b77405a8a8
+      - 6dc73a27-67fa-4e47-af6c-20801d745a88
     status: 200 OK
     code: 200
     duration: ""
@@ -2663,19 +2663,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVGs1dHg0V29NdHdBTWRXbktEdXZFdnRNbGhBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TURrMU1qUTVXaGNOTXpNeE1qRTFNRGsxTWpRNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9VR2poZFduWFZWazFEVDVmQ2NQeUdIR1FwVmU0bDcvNmpoZXJXclB1UzdRblJXZ2xTdmJXVFYKNFRmWjFaL09ncXpKT2FCQnBDREtoZXg0QURMQ1VUZXBaVDNPZVlSR3ZpcHBWZTlGRE1uOExENVhaRXNoTTlpMwoxaHFIV2U4MGRUakwvSzlOaDM0N253dE9jRWhnVjBZakhEQnVxUXh6K0pwdjU1K29EMGo2YVFJZVFtZ1ZjRWJaCkFBZDFlTVBEREZMOGJDeW0yVGhIaVRyZEFTQTNXQjR0TERmdVJIS1p0M3M3MzFJSmF5Q2lNVWY1bGlNWTNBYlMKSGUxMHlHR0FDc0ZXYTEzWDhxTGJxSzhadDdZZ2cxelNJMXFzS3ZWaUVnZXNidCtNSDJVdENaYTNTem1Xb0NNZgozNzNBZ2J5cXdkVGNpS0Ixa3QzclBPc1RYaGhCWjBjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDNZbUZsTXpWaU55MWtORE0zTFRReU9Ua3RPRGMyWVMweU56WmgKT0RaaVpHTTJNVGN1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGRpWVdVek5XSTNMV1EwTXpjdE5ESTVPUzA0TnpaaExUSTNObUU0Tm1Ka1l6WXhOeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlpWG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZkxVOUVhbUlqOVpTZzNIOW5OZHdjckVBb0RCNHpJUmtyVGM3eWtUUVppNndzNW5zeUhpOUZXa2N1Mi9XcVVmSApicEk5T0VVMlZQK2dnWGxaOGI5b29jQlhTUW9GbHdOU0FoTWROTzRwbit0eS85dldERkZPNk1DVjJQTHhzZzV3CnBwb2k2SS9HdTVVWVlCTWx4dHBKR25CS2pmQUVmMFRROU91UzM1M1Q2b3ZrVW5iRjVPbXpQaGdHdFhwd1oxM3UKYXlscXJ3dkM2OFBZaFZBaXovWFNBUGNPcm1CNHp3aHF4UmdZTGJKa04xaUptQlpZSUQrcHFSUFF3TjlSaXlFTQpWcWVIdHYwQ0IzV0l5SlIvcm9Vak0wd2EyeDFKWTFEeWxTaWcyc3RZUlljSkh4ZG1wdzFtNG8wbGd5WWhrSVR4CmRES3duTW5PWkltWlAvRWNpL0U3Z1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2007"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2685,7 +2685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3da97a47-70ee-4181-b499-57620fea3723
+      - 0108b022-bfb4-4172-8c1b-5be40a36339e
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,19 +2696,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1268"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2718,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cc418c4-c9a9-496a-b474-15c7d5254824
+      - a4694cbe-083a-4c4d-8cd2-b9083cd0b1a4
     status: 200 OK
     code: 200
     duration: ""
@@ -2729,19 +2729,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1268"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2751,7 +2751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86e31b77-ec23-46cf-bcd6-2f6da569cf55
+      - b887eee3-1514-40fa-adf6-21d688d6d1f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2762,7 +2762,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6b9cb167-14b5-4b4e-9d7b-7b3ab1ae495a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
@@ -2774,7 +2807,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2784,7 +2817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c61af0e0-77a6-4770-bf05-f28d66508690
+      - a044e319-c027-4e61-a5b7-5cadedfdee3a
     status: 200 OK
     code: 200
     duration: ""
@@ -2795,7 +2828,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 19018e48-d752-4496-b558-18163b20bb7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -2807,7 +2873,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2817,7 +2883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d374cd1a-f33d-413c-869e-41b0bab2a3a4
+      - cd6a0f78-e01d-4d90-8dc2-84c1923c9064
     status: 200 OK
     code: 200
     duration: ""
@@ -2828,7 +2894,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -2840,7 +2906,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2850,7 +2916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf59f736-b401-4008-965f-4de0506c13a8
+      - 822dbbf1-2278-4ef9-80df-3ee4be6596f0
     status: 200 OK
     code: 200
     duration: ""
@@ -2861,19 +2927,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2883,7 +2949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f19468a-9e6d-4aa5-84cc-c3696c7aa877
+      - 9deb466a-2d8a-49c6-84f3-1b296a611fcb
     status: 200 OK
     code: 200
     duration: ""
@@ -2894,19 +2960,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2916,7 +2982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 052b314a-df8f-4c55-bfaf-28100f0a5e01
+      - 5896cdc3-3e55-4bef-9e48-ad8a8209d62d
     status: 200 OK
     code: 200
     duration: ""
@@ -2927,7 +2993,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -2939,7 +3005,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2949,7 +3015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5397bf3e-eff1-41db-8b78-7bdd5a9d6ca6
+      - 035f06fd-efa0-4782-93b9-75e12cbf1581
     status: 200 OK
     code: 200
     duration: ""
@@ -2960,7 +3026,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -2972,7 +3038,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2982,7 +3048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9214179-cee8-4a15-a7d8-a63b5f6b9a1a
+      - faa6c19b-91f0-4895-9c05-194f15a877ce
     status: 200 OK
     code: 200
     duration: ""
@@ -2993,40 +3059,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
-    method: GET
-  response:
-    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "97"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 20f87e03-170d-4a43-be41-4eaa9b9ee20e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -3038,7 +3071,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:43 GMT
+      - Mon, 18 Dec 2023 13:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3048,7 +3081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d5fbc5f-4780-41b6-9c37-979a62266abf
+      - 49df048c-c8d3-4b7c-bf1e-cff2d972fc6a
     status: 200 OK
     code: 200
     duration: ""
@@ -3059,19 +3092,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1268"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:44 GMT
+      - Mon, 18 Dec 2023 13:12:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3081,7 +3114,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d8757c9-9e72-4ccd-a853-4ec8f3a344d6
+      - 4c5cb781-0edb-492c-acc5-5ce8cf24fd56
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:25 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3549c41f-d10f-4015-bc90-fe6342e5318d
     status: 200 OK
     code: 200
     duration: ""
@@ -3094,7 +3160,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"user_03"}'
@@ -3106,7 +3172,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:44 GMT
+      - Mon, 18 Dec 2023 13:12:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3116,7 +3182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21464321-0ea0-4754-a3c6-cefe2d0b4caa
+      - d605cf4a-71fd-4d72-beef-794e3048f77d
     status: 200 OK
     code: 200
     duration: ""
@@ -3127,19 +3193,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:44 GMT
+      - Mon, 18 Dec 2023 13:12:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3149,7 +3215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec0bad2a-a4e5-4582-8d86-368d8cd5c816
+      - 03a86cab-a559-443f-ba9c-efeda99a5bd4
     status: 200 OK
     code: 200
     duration: ""
@@ -3160,7 +3226,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
@@ -3172,7 +3238,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:44 GMT
+      - Mon, 18 Dec 2023 13:12:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3182,7 +3248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45a715fb-36f6-4a67-a70a-de9ad0b86271
+      - 3f256247-35bd-46fb-add9-e93203e1491a
     status: 200 OK
     code: 200
     duration: ""
@@ -3193,19 +3259,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:44 GMT
+      - Mon, 18 Dec 2023 13:12:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3215,7 +3281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a1d9a1a-3266-4238-9790-d650348a7de7
+      - e2c11be7-ada5-4b43-8cce-6b3c3271af37
     status: 200 OK
     code: 200
     duration: ""
@@ -3228,7 +3294,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
@@ -3240,7 +3306,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:44 GMT
+      - Mon, 18 Dec 2023 13:12:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3250,7 +3316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8374afcd-04b4-4058-9307-900410b70c36
+      - 519bbc89-df90-4443-9030-94f71843cc2a
     status: 200 OK
     code: 200
     duration: ""
@@ -3261,19 +3327,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:45 GMT
+      - Mon, 18 Dec 2023 13:12:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3283,7 +3349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f705e14-217e-4365-a8c5-5cb83d86147d
+      - 725d12cd-3492-4ea7-b1ce-57b1e97e3d11
     status: 200 OK
     code: 200
     duration: ""
@@ -3294,19 +3360,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:45 GMT
+      - Mon, 18 Dec 2023 13:12:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3316,7 +3382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81d284ea-1b2b-4961-81c3-01e26500a334
+      - fde5a2c2-966e-4342-94ac-7d79f6d47d3e
     status: 200 OK
     code: 200
     duration: ""
@@ -3327,7 +3393,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
@@ -3339,7 +3405,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:45 GMT
+      - Mon, 18 Dec 2023 13:12:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3349,7 +3415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87a97937-eeda-46b1-97cc-da55411c51f9
+      - 0c2a9e56-ef42-4f5a-8d20-862d2b4bdef6
     status: 200 OK
     code: 200
     duration: ""
@@ -3360,7 +3426,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
@@ -3372,7 +3438,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:45 GMT
+      - Mon, 18 Dec 2023 13:12:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3382,7 +3448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86541929-2fd3-443e-a83e-8b0f6d5f4c09
+      - b1542db7-d805-4e71-bb8b-221c06e4d493
     status: 200 OK
     code: 200
     duration: ""
@@ -3393,7 +3459,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
@@ -3405,7 +3471,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:45 GMT
+      - Mon, 18 Dec 2023 13:12:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3415,7 +3481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64ea53c3-1b21-4872-a5be-bc7960c8864a
+      - 8bcbcfb9-1db5-47c1-baac-191a9ab5e958
     status: 200 OK
     code: 200
     duration: ""
@@ -3426,19 +3492,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3448,7 +3514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65e7fe50-16e2-4f45-902b-a8a74c18864d
+      - a130b679-5661-4785-a845-93653fbe1318
     status: 200 OK
     code: 200
     duration: ""
@@ -3459,19 +3525,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVGs1dHg0V29NdHdBTWRXbktEdXZFdnRNbGhBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TURrMU1qUTVXaGNOTXpNeE1qRTFNRGsxTWpRNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9VR2poZFduWFZWazFEVDVmQ2NQeUdIR1FwVmU0bDcvNmpoZXJXclB1UzdRblJXZ2xTdmJXVFYKNFRmWjFaL09ncXpKT2FCQnBDREtoZXg0QURMQ1VUZXBaVDNPZVlSR3ZpcHBWZTlGRE1uOExENVhaRXNoTTlpMwoxaHFIV2U4MGRUakwvSzlOaDM0N253dE9jRWhnVjBZakhEQnVxUXh6K0pwdjU1K29EMGo2YVFJZVFtZ1ZjRWJaCkFBZDFlTVBEREZMOGJDeW0yVGhIaVRyZEFTQTNXQjR0TERmdVJIS1p0M3M3MzFJSmF5Q2lNVWY1bGlNWTNBYlMKSGUxMHlHR0FDc0ZXYTEzWDhxTGJxSzhadDdZZ2cxelNJMXFzS3ZWaUVnZXNidCtNSDJVdENaYTNTem1Xb0NNZgozNzNBZ2J5cXdkVGNpS0Ixa3QzclBPc1RYaGhCWjBjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDNZbUZsTXpWaU55MWtORE0zTFRReU9Ua3RPRGMyWVMweU56WmgKT0RaaVpHTTJNVGN1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGRpWVdVek5XSTNMV1EwTXpjdE5ESTVPUzA0TnpaaExUSTNObUU0Tm1Ka1l6WXhOeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlpWG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKZkxVOUVhbUlqOVpTZzNIOW5OZHdjckVBb0RCNHpJUmtyVGM3eWtUUVppNndzNW5zeUhpOUZXa2N1Mi9XcVVmSApicEk5T0VVMlZQK2dnWGxaOGI5b29jQlhTUW9GbHdOU0FoTWROTzRwbit0eS85dldERkZPNk1DVjJQTHhzZzV3CnBwb2k2SS9HdTVVWVlCTWx4dHBKR25CS2pmQUVmMFRROU91UzM1M1Q2b3ZrVW5iRjVPbXpQaGdHdFhwd1oxM3UKYXlscXJ3dkM2OFBZaFZBaXovWFNBUGNPcm1CNHp3aHF4UmdZTGJKa04xaUptQlpZSUQrcHFSUFF3TjlSaXlFTQpWcWVIdHYwQ0IzV0l5SlIvcm9Vak0wd2EyeDFKWTFEeWxTaWcyc3RZUlljSkh4ZG1wdzFtNG8wbGd5WWhrSVR4CmRES3duTW5PWkltWlAvRWNpL0U3Z1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYkV3aVpYUk84YkRmVmpHV0xqQTZPZVJna3Fnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TmpndU1UY3pNQjRYCkRUSXpNVEl4T0RFek1URTBOVm9YRFRNek1USXhOVEV6TVRFME5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOamd1TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRnV2pQTktEV0hhZk53dUZEV0tyR1hCbVNaTFlKTi9SOGR2a1BDNEtvVE1SSVVvR2QyN2QKZ2lJdjRsUXVOdC9ld2V5MTRzZGZEOSt2U3plaTBhdmh4NFNkTXE4Y0JiTEcwWWV0RFM4MW12RWs2elBCRzNCTApmWXUzeU9qYXM2MVVWOFNwNTBNdVp2T1ZzWXZTbUxGVmlaNzZ2UFM4bXRlSkR4ak5CODVUUjluY2luQUhFVUZtCkVWVERibTMyT1ZpcWw4U25EL0lwcjV6a01KM0F2NlVOL3liZG9iQVFEdkZvR1RFOHlXbjJMdEN3alpsUzBWRHUKcFVFOU80LzBKdGtrUlBUMmhVdnZsYldsY2R4U0Z0UDhDb0lyaFk4eFpTa08zb2VNZGdsam9DeG5sWVFEb3FSRwo0c2UrckNQQlE5bzRFTGFrOXVFUkFSNVVkUG9Ya2tjWSt3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOamd1TVRjemdqeHlkeTFrTUdSbU5tTmxaQzB5TW1aa0xUUm1aVFF0WVdGbU1TMWoKT1dSaU1UazVNemswTmpFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOamd1TVRjegpnanh5ZHkxa01HUm1ObU5sWkMweU1tWmtMVFJtWlRRdFlXRm1NUzFqT1dSaU1UazVNemswTmpFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUDBkR0hCTU9hUksySEJNT2FSSzB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFMNFFuL0lJSDVLaW1rU1dMTlRRN0o2a1BOMWkyYXlnUUZnbjhzcUk5MVhubGVqWjlCcGNFTUJMWkh3OAo1bkE5TkQ2R0ViTm4xLzhkV2Z5bU5oSHQya05IMXk3V0ZKK1JHMHQ4Z3g3VDJzRkVvaGI0NXllbDhkbldyTXhpCnc5bHFaKzVEZ1dCTXBMZFdFM20rbzdCT3kzdUttWVViNmdJamdWNmlEbEFEY1NRakkzZU5MOGExaGN3SU1MMmEKR216RTBKbXBUaDAvZEg3amlsWWhNVWx5SjNCRjBzdFBNZ0FRVXF3MHo0eGN5ZGRVRXhTYTVGSmJRWHYyenM5bwpETnd1UVYzc09Wa3RGcTVtZ3NjSHRSQjRVSmVRVmxWdWd1Mjg1VWlETGlhcytVNjdua0hOZTFRbFhXakUrS0g2CmwvREpFb1RSZTZURzVHcnY2NlJ4aFNkVnpXRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2007"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3481,7 +3547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41481cb4-2dde-4fc1-a675-11470bf0ca43
+      - e0fcff35-0aa4-4959-aedb-26cd5bbe399b
     status: 200 OK
     code: 200
     duration: ""
@@ -3492,19 +3558,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d0df6ced-22fd-4fe4-aaf1-c9db19939461&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1268"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3514,7 +3580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f59bb9a2-f1ef-426c-9ba2-0090b171bd2b
+      - 3c060c43-8021-4f90-9fcf-beb1a937cef7
     status: 200 OK
     code: 200
     duration: ""
@@ -3525,40 +3591,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9cff510b-f5a5-4f14-8046-8a9d4bfb8554
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/databases?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"databases":[{"managed":true,"name":"foo","owner":"_rdb_superadmin","size":7729967}],"total_count":1}'
@@ -3570,7 +3603,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3580,7 +3613,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01ff1617-d155-464f-a3a3-b91f72d6c829
+      - 0934be26-74b5-46ac-9065-5c05ba2a4466
     status: 200 OK
     code: 200
     duration: ""
@@ -3591,19 +3624,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3613,7 +3646,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 825aed72-dbc2-4787-a367-a5d504ed2c06
+      - 7a461e4b-7018-4d8f-8bfa-093159e74995
     status: 200 OK
     code: 200
     duration: ""
@@ -3624,19 +3657,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "63"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3646,7 +3679,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5df7945c-c539-4d64-9c20-edce13067293
+      - 1270545d-a293-400f-80b2-39cd6bc36e22
     status: 200 OK
     code: 200
     duration: ""
@@ -3657,19 +3690,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "63"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3679,7 +3712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9415986-74e2-48a3-baaa-a14f980e65e2
+      - a9039898-e9b9-4d57-a971-7e52db95f0e8
     status: 200 OK
     code: 200
     duration: ""
@@ -3690,172 +3723,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1bc902d3-46c0-4b0e-b844-ef3c4d06d8d5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 41a95197-06a9-42bc-b891-a6e0a345ab17
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2d91c52f-f64b-475d-9601-ec35d3df523a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd91aa0d-8a18-4c6e-a928-01a27dc4e8e4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_03&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c961ec77-0c94-4764-9479-5868691f6601
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
@@ -3867,7 +3735,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3877,7 +3745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e30287c-f907-408f-a6af-00cd8759415b
+      - 6026352c-ac10-4b52-9680-07084955dc59
     status: 200 OK
     code: 200
     duration: ""
@@ -3888,7 +3756,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - be049a40-f412-4eb4-89a2-d7ea0e325488
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -3900,7 +3801,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:46 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3910,7 +3811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 576a5763-2eb2-42ba-b0cb-1d50f3b6356c
+      - ac5e07de-1de7-4c1a-b887-697ed295b9b0
     status: 200 OK
     code: 200
     duration: ""
@@ -3921,19 +3822,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "98"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3943,7 +3844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a69250d9-5afa-425b-84ed-2bd8cb2ca6a8
+      - 91b891fe-a572-4b37-8155-b859a8382d61
     status: 200 OK
     code: 200
     duration: ""
@@ -3954,7 +3855,172 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a6d280c-a1bb-4cc8-befc-a40fb8e99013
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f8805239-f595-41be-9d72-e1aa82961f3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0d7f6ba3-a85a-4ac4-b608-f7bb344de25e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e067ca6a-695f-4bdb-9af9-ba5f46a6cc57
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b61879f-b3c2-47d5-a3c1-db26c2b0275e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_02
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"readwrite","user_name":"user_02"}],"total_count":1}'
@@ -3966,7 +4032,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -3976,7 +4042,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d21b295f-3a56-4c44-bea5-f0a4e2741485
+      - 3fc1a2db-1b98-4bc2-934c-00770aa2d761
     status: 200 OK
     code: 200
     duration: ""
@@ -3987,7 +4053,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_01
     method: GET
   response:
     body: '{"privileges":[{"database_name":"foo","permission":"all","user_name":"user_01"}],"total_count":1}'
@@ -3999,7 +4065,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4009,7 +4075,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cfb69e6-adbe-4023-a46a-46cadc610861
+      - 530cfec5-fbba-4cdc-95ee-c69d6dd9a547
     status: 200 OK
     code: 200
     duration: ""
@@ -4020,19 +4086,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges?database_name=foo&order_by=user_name_asc&user_name=user_03
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"privileges":[{"database_name":"foo","permission":"none","user_name":"user_03"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1268"
+      - "98"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4042,7 +4108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01af19c4-325b-411f-824e-153aa1008fdd
+      - 3aaa5592-6378-4188-b730-d12cef87f129
     status: 200 OK
     code: 200
     duration: ""
@@ -4053,19 +4119,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4075,7 +4141,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - deb3d0a6-7ca0-4ade-adc5-f4ad6183a81b
+      - ca256fc6-446e-4ee7-ac10-323dc7db962e
     status: 200 OK
     code: 200
     duration: ""
@@ -4086,19 +4152,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4108,7 +4174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f4ebabe-544c-4ef7-84a8-3e9dc6676180
+      - 66a503b8-3ef3-4a33-8705-1971e01146f5
     status: 200 OK
     code: 200
     duration: ""
@@ -4119,19 +4185,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "63"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4141,7 +4207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 589d09fb-8aeb-4130-858a-eb080a647b09
+      - f431ba14-03c5-419d-abaf-514d551f4ad9
     status: 200 OK
     code: 200
     duration: ""
@@ -4152,73 +4218,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0c7d84c3-608e-4204-a350-50cf83d16c41
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 955cd221-4eec-407f-9226-7731f78710cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_03&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
@@ -4230,7 +4230,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4240,7 +4240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0939de6-1e82-4851-9625-d415aec4f591
+      - 27fd5eed-4e3c-4cf1-a643-6a7edef4d274
     status: 200 OK
     code: 200
     duration: ""
@@ -4251,40 +4251,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3b1ebaa6-d7c4-4e00-82d8-3612092f57fb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
@@ -4296,7 +4263,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:47 GMT
+      - Mon, 18 Dec 2023 13:12:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4306,32 +4273,30 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7918cb3-8d96-4805-b3a4-c1cd990f6a05
+      - 37b0874a-6e3c-4c5f-97de-e45df9537b4f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"database_name":"foo","user_name":"user_03","permission":"none"}'
+    body: ""
     form: {}
     headers:
-      Content-Type:
-      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges
-    method: PUT
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    method: GET
   response:
-    body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
     headers:
       Content-Length:
-      - "65"
+      - "62"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:48 GMT
+      - Mon, 18 Dec 2023 13:12:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4341,7 +4306,106 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19f44e1c-e064-4cc1-8977-2a1ec07b44e3
+      - efc11343-98aa-4b88-85eb-7aeb90456037
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bad8f942-f0fb-4513-a4dc-42e49e4bd5d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 66f79bc0-3b89-4751-89b6-565ca06944a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_01&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
+    headers:
+      Content-Length:
+      - "62"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:35 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4a787c0f-d565-4264-82ef-9a1e68027ee0
     status: 200 OK
     code: 200
     duration: ""
@@ -4354,306 +4418,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges
-    method: PUT
-  response:
-    body: '{"message":"Tuple concurrently updated"}'
-    headers:
-      Content-Length:
-      - "40"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 96ae7117-7b58-49d4-8597-cb4a4e021243
-    status: 409 Conflict
-    code: 409
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_02","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges
-    method: PUT
-  response:
-    body: '{"message":"Tuple concurrently updated"}'
-    headers:
-      Content-Length:
-      - "40"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 12e21a4f-1289-4c9c-bc47-03a3d4f25a47
-    status: 409 Conflict
-    code: 409
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 57a44b51-6cd2-476f-8f12-9a34ac59fe07
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4dabf4df-d52c-4d90-8b63-c72d2797babc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 12c628d3-1133-4f8c-ad68-28503ee994b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e192a58a-2206-4321-8e9c-b6860ab4f281
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users/user_03
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4e0664b6-6a1a-4053-bb5b-d467a1386896
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_01&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"user_01"}]}'
-    headers:
-      Content-Length:
-      - "62"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0a197081-8994-440f-9fe9-05e2f30e31f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users?name=user_02&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
-    headers:
-      Content-Length:
-      - "63"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b54b82b8-9064-43f9-a1d1-93f828f220cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"database_name":"foo","user_name":"user_01","permission":"none"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_01"}'
@@ -4665,7 +4430,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:53 GMT
+      - Mon, 18 Dec 2023 13:12:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4675,106 +4440,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e600be66-4e76-4d00-b0ef-fb2fa5e85e7d
+      - 97f72559-ad9d-4995-b5b9-b4b6e3299441
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 75d755f8-a3a2-4825-919a-ceefacb0830d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1268"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b82eeba4-e160-479d-909c-a713825ce181
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users/user_01
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b560c987-20b2-4342-9f3d-8e8011eb106f
-    status: 204 No Content
-    code: 204
     duration: ""
 - request:
     body: '{"database_name":"foo","user_name":"user_02","permission":"none"}'
@@ -4785,7 +4453,539 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/privileges
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    method: PUT
+  response:
+    body: '{"message":"Tuple concurrently updated"}'
+    headers:
+      Content-Length:
+      - "40"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7fd9b646-b411-478d-aa74-1419194f72ca
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: '{"database_name":"foo","user_name":"user_03","permission":"none"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    method: PUT
+  response:
+    body: '{"message":"Tuple concurrently updated"}'
+    headers:
+      Content-Length:
+      - "40"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2a69b87f-f120-4b2c-a60e-37ad2497d0a7
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 78de4fff-afc4-4444-8045-ab1cff279c09
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 88032ad2-8b09-474e-add5-b2b1de481acc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0756d523-fd7b-45f5-a061-dc1eb88542c5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5fd0c679-b915-47dc-a048-1f750b9020d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users/user_01
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b24239aa-1562-40c7-95e0-d1ec44aafb3a
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5fa4e7a-495b-436e-9dc3-fc3278a0099c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_03&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_03"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - caa852e9-df6e-4ec8-ba85-ed5e8191a747
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"database_name":"foo","user_name":"user_02","permission":"none"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    method: PUT
+  response:
+    body: '{"message":"Tuple concurrently updated"}'
+    headers:
+      Content-Length:
+      - "40"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb3ebf88-6ac8-42ca-bf1a-648fe1e85ce8
+    status: 409 Conflict
+    code: 409
+    duration: ""
+- request:
+    body: '{"database_name":"foo","user_name":"user_03","permission":"none"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
+    method: PUT
+  response:
+    body: '{"database_name":"foo","permission":"none","user_name":"user_03"}'
+    headers:
+      Content-Length:
+      - "65"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c9484695-59c0-4426-8ce3-a2940d204858
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e294bf93-2ea2-4027-aeb0-dd7f08f1c9ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a02b303-716a-49a3-a4ba-1eea15424c5e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1270"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ec02b3a-4a34-4a73-971a-2c0545b43e52
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users/user_03
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:37 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0efe644f-7ccc-48e4-bd6f-b86cd2263b45
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users?name=user_02&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"user_02"}]}'
+    headers:
+      Content-Length:
+      - "63"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:12:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 91bb0896-dd6f-4661-858d-705c7b72278a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"database_name":"foo","user_name":"user_02","permission":"none"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/privileges
     method: PUT
   response:
     body: '{"database_name":"foo","permission":"none","user_name":"user_02"}'
@@ -4797,7 +4997,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:54 GMT
+      - Mon, 18 Dec 2023 13:12:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4807,7 +5007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3513cbd4-bb9b-499a-9bbf-1d0384e53090
+      - baac30ef-9734-4c6d-885d-0ebd518d351a
     status: 200 OK
     code: 200
     duration: ""
@@ -4818,19 +5018,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:54 GMT
+      - Mon, 18 Dec 2023 13:12:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4840,7 +5040,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f57bb1da-73dd-474a-b6db-6aa5e73f039d
+      - 7d50162d-691a-4343-8ba9-429ab7cc010f
     status: 200 OK
     code: 200
     duration: ""
@@ -4851,19 +5051,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:54 GMT
+      - Mon, 18 Dec 2023 13:12:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4873,7 +5073,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffbf2fbd-663c-4d03-a183-6750346381e8
+      - 3893535f-0f73-4f4f-aae5-b69fd0406526
     status: 200 OK
     code: 200
     duration: ""
@@ -4884,19 +5084,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:54 GMT
+      - Mon, 18 Dec 2023 13:12:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4906,7 +5106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2517eda-ff36-499b-8d95-eba2bc1e3c3d
+      - 87ba7c39-13a7-4729-8e48-28f7d4ecc719
     status: 200 OK
     code: 200
     duration: ""
@@ -4917,7 +5117,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/users/user_02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/users/user_02
     method: DELETE
   response:
     body: ""
@@ -4927,7 +5127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:54 GMT
+      - Mon, 18 Dec 2023 13:12:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4937,7 +5137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 631952ae-49cd-465c-9832-7fc84c843df6
+      - f388724f-1e26-47c8-9cf0-a1f68aa382b0
     status: 204 No Content
     code: 204
     duration: ""
@@ -4948,7 +5148,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617/databases/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461/databases/foo
     method: DELETE
   response:
     body: ""
@@ -4958,7 +5158,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:55 GMT
+      - Mon, 18 Dec 2023 13:12:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -4968,7 +5168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 818e743c-3204-40a3-a16f-915c1881a965
+      - 00bcb2f4-df1d-4f6b-8fc3-2c571c84d269
     status: 204 No Content
     code: 204
     duration: ""
@@ -4979,19 +5179,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:55 GMT
+      - Mon, 18 Dec 2023 13:12:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5001,7 +5201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15ec45aa-9737-4724-b51f-d5d3e3fc511c
+      - d96a41b0-0ba2-4508-af0d-3ddd447b8f69
     status: 200 OK
     code: 200
     duration: ""
@@ -5012,19 +5212,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1270"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:55 GMT
+      - Mon, 18 Dec 2023 13:12:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5034,7 +5234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b98cbdc-da88-4d90-a86f-b6b1628d1143
+      - 0ce222e5-074e-4aff-928d-d3be08092768
     status: 200 OK
     code: 200
     duration: ""
@@ -5045,19 +5245,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:56 GMT
+      - Mon, 18 Dec 2023 13:12:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5067,7 +5267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6cc6f97-85f1-4139-9162-b248bc2c3f1d
+      - 950d32dc-ec38-4171-8e3f-d91f85bc2c57
     status: 200 OK
     code: 200
     duration: ""
@@ -5078,19 +5278,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:44.658183Z","retention":7},"created_at":"2023-12-18T09:49:44.658183Z","endpoint":{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601},"endpoints":[{"id":"6e407f7d-d295-4799-9903-897aebd20b48","ip":"51.159.74.238","load_balancer":{},"name":null,"port":15601}],"engine":"PostgreSQL-15","id":"7bae35b7-d437-4299-876a-276a86bdc617","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T13:09:11.274797Z","retention":7},"created_at":"2023-12-18T13:09:11.274797Z","endpoint":{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485},"endpoints":[{"id":"09077e31-689e-48e0-be6c-0989988eb6aa","ip":"195.154.68.173","load_balancer":{},"name":null,"port":16485}],"engine":"PostgreSQL-15","id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbPrivilege_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1271"
+      - "1273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:56 GMT
+      - Mon, 18 Dec 2023 13:12:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5100,7 +5300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f966712-ca4e-4700-a60f-d2aa9d885ce5
+      - 990bbfd1-838a-45f2-b479-5b9d1d29b0fc
     status: 200 OK
     code: 200
     duration: ""
@@ -5111,10 +5311,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"7bae35b7-d437-4299-876a-276a86bdc617","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -5123,7 +5323,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:54:26 GMT
+      - Mon, 18 Dec 2023 13:13:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5133,7 +5333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4e91007-8b99-455b-88be-98cedf63fb4a
+      - bd3ac55e-8dfb-481a-84e9-029cac5db57f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5144,10 +5344,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7bae35b7-d437-4299-876a-276a86bdc617
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/d0df6ced-22fd-4fe4-aaf1-c9db19939461
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"7bae35b7-d437-4299-876a-276a86bdc617","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"d0df6ced-22fd-4fe4-aaf1-c9db19939461","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -5156,7 +5356,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:54:26 GMT
+      - Mon, 18 Dec 2023 13:13:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -5166,7 +5366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 998b58fc-093c-4982-89c2-7d8aaab62826
+      - fba59710-c615-44ab-bd7f-35de70e4a957
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:58:59 GMT
+      - Mon, 18 Dec 2023 12:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99c9372c-ed5e-4530-a55a-702e35a74217
+      - 64f2914b-9001-450a-a80d-a13672cea42c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "927"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:04 GMT
+      - Mon, 18 Dec 2023 13:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73e2ce0a-afd5-40a2-9aa2-c782dd0c2f3a
+      - 0f457480-26c0-43a8-b0a2-4ae1be405b6d
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "927"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:05 GMT
+      - Mon, 18 Dec 2023 13:08:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94be4d97-1a97-415e-84f9-66baaf8412ce
+      - e482bc35-2672-4faf-9f81-a61408f77f49
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "927"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:35 GMT
+      - Mon, 18 Dec 2023 13:08:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51c87539-46f8-446e-98ff-5e94b7589eb2
+      - d4b1229e-f80f-4874-b52b-b72851664b65
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "927"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:00:05 GMT
+      - Mon, 18 Dec 2023 13:09:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33dba6a3-c0dc-46e0-8d87-f788e4ca9749
+      - dd31201c-2022-4deb-a1a3-11ac0981e5c5
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "927"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:00:35 GMT
+      - Mon, 18 Dec 2023 13:09:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8845fad-ce4a-47fe-b937-40bf000f0e4a
+      - 1da1cb7d-3566-4e64-a6e9-b70c601f7cb8
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "927"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:01:05 GMT
+      - Mon, 18 Dec 2023 13:10:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa4cdfe3-4db2-47ef-b5aa-4dbcb5746c78
+      - 5e7d1f05-ce57-431d-9e98-aa7bedb559ac
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "761"
+      - "927"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:01:35 GMT
+      - Mon, 18 Dec 2023 13:10:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81abec73-f14a-42f4-9765-5d7e7486ea63
+      - 5c947716-fdd2-469e-a173-cfc42ae331fa
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1025"
+      - "1191"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:05 GMT
+      - Mon, 18 Dec 2023 13:11:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 335f0fd5-76b0-4747-96a3-052939950e8b
+      - f9f505e6-310b-40b5-8e4f-5b7dbc22e763
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433},"endpoints":[{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433}],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1236"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:35 GMT
+      - Mon, 18 Dec 2023 13:11:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d9d8afb-b27d-45b2-8412-b48578477597
+      - b2097e6b-3427-4084-baed-0ead5b6099c5
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +638,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVUlNHaWRBRHRaNGR5bGFHRVNQYzJweVFhYVlZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpBdU1qQXpNQjRYCkRUSXpNVEV5TVRFMk1ERTFOVm9YRFRNek1URXhPREUyTURFMU5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekF1TWpBek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXgwVUNrUEk2YmZQZmdWckRFcGpwaGZoYXZOYVJicW1uZ2lmck11RXNQcnAyTjZLeWIvUHAKc3RnUUpXY1MrdjV2QXJlM1c0dlZLaE5na2djcWhwTGsvRlhTQzhHRHdlZ0l5akJYUHloWlc1d1dqVW5ra3QxMgo5VVV2SVdwQkp6bzB6SFJOQkRha3JXTi9UYzIxMVhac0NxSjdMUXFFVnZ1akFNMjN1aURuMkRqYXVxNDF4MmMrCmtSaVVtcmhXSDNLWFRkeXZZVmVCUjZlTzRVdlIyMVVGRzkvenBRWEJBLzJobVRseUF3bjRHWlovSWo3UFdMYWQKdENDU2paQ2F2TXVmWXNxVUs0UCt0NzdKbmRRc2VPWnhubTM2YzZjUjZpbndjWkV1VXM2NUswVUZkd2Jpa2I3NwpUdXYwNXdReXhNUStKUE1VWENrUStkRnE0MTNkVjJjMFV3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzR4Ck9UVXVNVFUwTGpjd0xqSXdNNEk4Y25jdE16azFaREF6WWpRdFlqWTJNUzAwWlRVeUxXRTFOV010TVRRMk5UQXgKT1RkbVlqUTVMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFlod1REbWtiTE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUN6U052bjJmVTFwUDRLamM5eCtNVDFzTlZ6TDlna3FBSGc1WnRydzNZRitxa3UxTXF3CjZvME1NVkM0bVJlWUxVM3B0aFNTaWU1YkNJV0FZcTMyS1h5OWFOL0dXcWkwUWQ3Si9EUng4b0ZTa2ovbjA5NDYKOXd1c3dZQWVTNEdkcjdMZXp5SU56Z2lxaUNWeGZ2NGdQbkdjUjF3V244Y0dXL1FsUVhnR0JzUXZ3b3VDbW5hTAo0bFBRREkra3hlWEExdXNKeEt3UENPQ1pLUjRiaVRjOGhSL25sYVJ6cUwvVjRPT0dseENIelhsVkVleHNJZE1OCmlZc0F5RHNEQTVvNGFseVZFZFVBbUNFRWR4Qm5jUXF1QkxKWDR2Z2lRYVY0SEVBNk9MRWVvd1NlV0wyalBxa2MKZWhGaEVnbi9UcWc5aXFjNXhtUjNVT2UrTFduMVh3ZjlQK1RqCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQTJsRGNBcDJVbGl2K0lkQU1YeXptSm1XNHVVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1URXpXaGNOTXpNeE1qRTFNVE14TVRFeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU01SGxDNzBKVU1VY016TXNqdG84Ymk4aXZJazNBTUhld2RrM25zK2YySjYvVnVEZGFPTHhGNEQKU1AzeUJXVUlPUHd6T1YzT0U2blhHWHVzV3JXMGpBaFZkejZVQWFtYXY0MHQ2UmY3eC9uRHVQamc3Q0ZZaG1EcgpseWVYYlBrUXhhL0hBVjBKNGI2UXdHajYxOHJoNXpxUFBDVW9yOERhU2lsU3pSNWR2UHo2dzNTamkxaDdFM1NVCjFWVEZkanBLVDZGblhUTFNJazdBNFArVXgrSFBTaDlEVmpQbWQ0WXVPUWdWSUVRNTY3UHU1NmFBSnZxREtOZXYKTzQ4aHh5RGhNRkh5Tk04OVNYMUhuZ0JpMmkyUnRCN0FVYjFHWEF0aklMVmFLUVNzSVkrTlA0bFd0ZFFXdnN2TQpVQk03aGVuSGF0ejZMK29pWjJJUHN2MWlYUmx0MCtNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHhOakV6TTJaa1lTMDVOemszTFRReE1tVXRZV1V5WWkweVlUZ3kKWm1RMVpEQmlaRFl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEUyTVRNelptUmhMVGszT1RjdE5ERXlaUzFoWlRKaUxUSmhPREptWkRWa01HSmtOaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnloSG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKUjc4YjE4bGxtbnFPZ2xpOWM2MGI2RURmLzV5blQ0ekhONHZpNnRIUjRxeEpZc2gzenRjRFcwaVNQTUxaMnJsVgpocXJMZGp3SzI4bHVNZnpJLzJicTc5MzFxYjF4bW5MZnV2OVFxV3p0RHVjNlNnbC9kUE9SN0hsL1IyZWd4bStpCkRZK2d1L096Wm1TVWlRMzRPR2thVVRVMXV2Sm55QlFpL29INzNzb2VyS0NFenc0dVJmb0s5SndrT2x3LzlZU0cKMy9FZThZUFlabnhHUk1OOHBkc3NYcjNadEIyZDBwc1lUYXRaZi9Bek1UdnlHaDcxMmJESUVEWnRYZzJaQkNjQQpJb3BUd0pjRmo4eTFaRkpiSTdmaS9mbnNZWHNvWHhaUko4Mkc4T3VJS2xuc2ZPYnhTbXZ4TnJyeWpWSDRJNmk2CjBxeTA3TGo1Mlk4VWU4elNLLzh4K3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1847"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:36 GMT
+      - Mon, 18 Dec 2023 13:11:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,12 +660,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 795bc139-5f4a-4e87-a6e6-ca76d63d2d31
+      - 272903af-c1b6-462d-93bd-6ef64992982d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"395d03b4-b661-4e52-a55c-14650197fb49","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=16133fda-9797-412e-ae2b-2a82fd5d0bd6&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 24f87249-6ac7-4c42-83b4-099398183426
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -676,7 +709,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "119"
@@ -685,7 +718,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:36 GMT
+      - Mon, 18 Dec 2023 13:11:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 403ca51c-9769-4386-8849-3a74a629ecb7
+      - 673d9b20-eb80-4a11-a45c-700a16bbbec5
     status: 200 OK
     code: 200
     duration: ""
@@ -706,10 +739,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "119"
@@ -718,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:02:36 GMT
+      - Mon, 18 Dec 2023 13:11:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f56990d6-352e-4f6d-a753-7b5f26d9ca89
+      - c6cd481e-225a-47dc-98fe-86adbac962f2
     status: 200 OK
     code: 200
     duration: ""
@@ -739,10 +772,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "119"
@@ -751,7 +784,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:06 GMT
+      - Mon, 18 Dec 2023 13:12:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1727c623-5013-47ae-95db-09dde0de7a82
+      - 75537097-217f-4a22-b27e-b21fb143245e
     status: 200 OK
     code: 200
     duration: ""
@@ -772,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "228"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:03:36 GMT
+      - Mon, 18 Dec 2023 13:13:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82a4745b-6b1e-4330-9f4e-0aa655e485c6
+      - 15985a6d-6b74-4ca0-81b9-079d9c37e98f
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +838,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "228"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:06 GMT
+      - Mon, 18 Dec 2023 13:13:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b63f71fb-e64d-4c50-a736-7f38f50881b7
+      - 29867d47-6568-4186-b0ea-da458cb9549a
     status: 200 OK
     code: 200
     duration: ""
@@ -838,19 +871,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "228"
+      - "229"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:04:37 GMT
+      - Mon, 18 Dec 2023 13:14:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67433870-5709-4964-aa76-b40b127e61bc
+      - 465283ae-defc-441f-b391-ffa4522f4975
     status: 200 OK
     code: 200
     duration: ""
@@ -871,19 +904,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "228"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:10 GMT
+      - Mon, 18 Dec 2023 13:14:31 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11dcd1b2-cee8-4cec-977c-3ea124012c72
+      - df0fcf69-d6de-425f-ad32-fb3c2609870c
     status: 200 OK
     code: 200
     duration: ""
@@ -904,19 +937,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "221"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:40 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fdd1a4a-420d-4332-9356-aca8e2d6033d
+      - c4e85cb0-e262-42f6-aff0-c5de1c4717ca
     status: 200 OK
     code: 200
     duration: ""
@@ -937,19 +970,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "221"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:40 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98d1858a-cb85-43e6-9e97-a2ffa07e2460
+      - fd2a62b9-4c01-4740-b36c-e93e510bdd4d
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1003,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "221"
+      - "1456"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:40 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94d76c23-6b31-430c-a154-e0bb6b3edd99
+      - 7a95d9ea-7483-4a7a-9bb0-0e687c7a7596
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,19 +1036,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433},"endpoints":[{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433}],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQTJsRGNBcDJVbGl2K0lkQU1YeXptSm1XNHVVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRNeE1URXpXaGNOTXpNeE1qRTFNVE14TVRFeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU01SGxDNzBKVU1VY016TXNqdG84Ymk4aXZJazNBTUhld2RrM25zK2YySjYvVnVEZGFPTHhGNEQKU1AzeUJXVUlPUHd6T1YzT0U2blhHWHVzV3JXMGpBaFZkejZVQWFtYXY0MHQ2UmY3eC9uRHVQamc3Q0ZZaG1EcgpseWVYYlBrUXhhL0hBVjBKNGI2UXdHajYxOHJoNXpxUFBDVW9yOERhU2lsU3pSNWR2UHo2dzNTamkxaDdFM1NVCjFWVEZkanBLVDZGblhUTFNJazdBNFArVXgrSFBTaDlEVmpQbWQ0WXVPUWdWSUVRNTY3UHU1NmFBSnZxREtOZXYKTzQ4aHh5RGhNRkh5Tk04OVNYMUhuZ0JpMmkyUnRCN0FVYjFHWEF0aklMVmFLUVNzSVkrTlA0bFd0ZFFXdnN2TQpVQk03aGVuSGF0ejZMK29pWjJJUHN2MWlYUmx0MCtNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MHhOakV6TTJaa1lTMDVOemszTFRReE1tVXRZV1V5WWkweVlUZ3kKWm1RMVpEQmlaRFl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVEUyTVRNelptUmhMVGszT1RjdE5ERXlaUzFoWlRKaUxUSmhPREptWkRWa01HSmtOaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnloSG9jRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKUjc4YjE4bGxtbnFPZ2xpOWM2MGI2RURmLzV5blQ0ekhONHZpNnRIUjRxeEpZc2gzenRjRFcwaVNQTUxaMnJsVgpocXJMZGp3SzI4bHVNZnpJLzJicTc5MzFxYjF4bW5MZnV2OVFxV3p0RHVjNlNnbC9kUE9SN0hsL1IyZWd4bStpCkRZK2d1L096Wm1TVWlRMzRPR2thVVRVMXV2Sm55QlFpL29INzNzb2VyS0NFenc0dVJmb0s5SndrT2x3LzlZU0cKMy9FZThZUFlabnhHUk1OOHBkc3NYcjNadEIyZDBwc1lUYXRaZi9Bek1UdnlHaDcxMmJESUVEWnRYZzJaQkNjQQpJb3BUd0pjRmo4eTFaRkpiSTdmaS9mbnNZWHNvWHhaUko4Mkc4T3VJS2xuc2ZPYnhTbXZ4TnJyeWpWSDRJNmk2CjBxeTA3TGo1Mlk4VWU4elNLLzh4K3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1457"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:41 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dd8c160-34fd-4ebc-92f3-3d4ce2501ae7
+      - 54cb702f-5137-4627-b19b-166e7080febc
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,19 +1069,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=16133fda-9797-412e-ae2b-2a82fd5d0bd6&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwekNDQW8rZ0F3SUJBZ0lVUlNHaWRBRHRaNGR5bGFHRVNQYzJweVFhYVlZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpBdU1qQXpNQjRYCkRUSXpNVEV5TVRFMk1ERTFOVm9YRFRNek1URXhPREUyTURFMU5Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekF1TWpBek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXgwVUNrUEk2YmZQZmdWckRFcGpwaGZoYXZOYVJicW1uZ2lmck11RXNQcnAyTjZLeWIvUHAKc3RnUUpXY1MrdjV2QXJlM1c0dlZLaE5na2djcWhwTGsvRlhTQzhHRHdlZ0l5akJYUHloWlc1d1dqVW5ra3QxMgo5VVV2SVdwQkp6bzB6SFJOQkRha3JXTi9UYzIxMVhac0NxSjdMUXFFVnZ1akFNMjN1aURuMkRqYXVxNDF4MmMrCmtSaVVtcmhXSDNLWFRkeXZZVmVCUjZlTzRVdlIyMVVGRzkvenBRWEJBLzJobVRseUF3bjRHWlovSWo3UFdMYWQKdENDU2paQ2F2TXVmWXNxVUs0UCt0NzdKbmRRc2VPWnhubTM2YzZjUjZpbndjWkV1VXM2NUswVUZkd2Jpa2I3NwpUdXYwNXdReXhNUStKUE1VWENrUStkRnE0MTNkVjJjMFV3SURBUUFCbzJjd1pUQmpCZ05WSFJFRVhEQmFnZzR4Ck9UVXVNVFUwTGpjd0xqSXdNNEk4Y25jdE16azFaREF6WWpRdFlqWTJNUzAwWlRVeUxXRTFOV010TVRRMk5UQXgKT1RkbVlqUTVMbkprWWk1bWNpMXdZWEl1YzJOM0xtTnNiM1ZraHdRem5uMFlod1REbWtiTE1BMEdDU3FHU0liMwpEUUVCQ3dVQUE0SUJBUUN6U052bjJmVTFwUDRLamM5eCtNVDFzTlZ6TDlna3FBSGc1WnRydzNZRitxa3UxTXF3CjZvME1NVkM0bVJlWUxVM3B0aFNTaWU1YkNJV0FZcTMyS1h5OWFOL0dXcWkwUWQ3Si9EUng4b0ZTa2ovbjA5NDYKOXd1c3dZQWVTNEdkcjdMZXp5SU56Z2lxaUNWeGZ2NGdQbkdjUjF3V244Y0dXL1FsUVhnR0JzUXZ3b3VDbW5hTAo0bFBRREkra3hlWEExdXNKeEt3UENPQ1pLUjRiaVRjOGhSL25sYVJ6cUwvVjRPT0dseENIelhsVkVleHNJZE1OCmlZc0F5RHNEQTVvNGFseVZFZFVBbUNFRWR4Qm5jUXF1QkxKWDR2Z2lRYVY0SEVBNk9MRWVvd1NlV0wyalBxa2MKZWhGaEVnbi9UcWc5aXFjNXhtUjNVT2UrTFduMVh3ZjlQK1RqCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1847"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:41 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa858220-aaf2-46a5-a68a-93efe82179ce
+      - 1b2a4042-5d7e-40b0-ac61-98055dbed910
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1102,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "221"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:41 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b06992d-33d3-4196-817c-fa4b7f3612ce
+      - 7a97342e-f366-4ab7-8328-37fa377d59cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,19 +1135,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "221"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:41 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e9bf12c-7956-4aae-8ec7-363fcde6242f
+      - c8dc4e01-9cea-49e7-b90f-801aa460b835
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,19 +1168,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: DELETE
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "224"
+      - "225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:42 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae6b541e-e076-49da-bec0-285f705a911d
+      - 2dc77500-f5b8-4fac-8e85-d9b04327962e
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"8fa2d58d-0021-4377-90ad-cf95d4b840cf","ip":"51.158.75.167","name":null,"port":5432}],"id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"828e5d8b-bf02-4ae9-807b-60e17a9d8f7e","ip":"212.47.228.116","name":null,"port":5432}],"id":"4f866de1-f376-435b-baa6-81040de176db","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "224"
+      - "225"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:05:42 GMT
+      - Mon, 18 Dec 2023 13:14:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01d663d3-6bbd-4667-b5eb-21fb5470bc09
+      - 14060486-1b93-4b95-80e9-9cfa07aec618
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,10 +1234,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"4f866de1-f376-435b-baa6-81040de176db","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1213,7 +1246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:12 GMT
+      - Mon, 18 Dec 2023 13:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ebe39f2-e347-4b09-b4f5-89426361e811
+      - 90d6b320-fe64-4203-8e0f-dc8f45194d00
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1234,19 +1267,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433},"endpoints":[{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433}],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1236"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:12 GMT
+      - Mon, 18 Dec 2023 13:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16acaabe-14d4-413d-a57c-dfb5f7ad4c6c
+      - 8c7b10a3-3f85-4197-b1e4-cafb5ad538fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,19 +1300,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433},"endpoints":[{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433}],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1239"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:12 GMT
+      - Mon, 18 Dec 2023 13:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e231931-6d8e-4201-ae44-08473d70fbd4
+      - 8b3d57e6-2603-45e3-9efc-db6a0dc9d35b
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T15:59:04.766366Z","endpoint":{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433},"endpoints":[{"id":"224715d8-6f78-40b7-a3ab-a84e6e8c412e","ip":"195.154.70.203","load_balancer":{},"name":null,"port":21433}],"engine":"PostgreSQL-15","id":"395d03b4-b661-4e52-a55c-14650197fb49","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:08:19.983732Z","endpoint":{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463},"endpoints":[{"id":"c75845b2-6102-400e-baa1-5d484b4712e6","ip":"51.159.74.238","load_balancer":{},"name":null,"port":18463}],"engine":"PostgreSQL-15","id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1239"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:13 GMT
+      - Mon, 18 Dec 2023 13:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5865509-7c1d-447a-a35f-8ac46e8fca5e
+      - ed7002f0-6788-4b3c-9f8e-b877f189b677
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,10 +1366,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"395d03b4-b661-4e52-a55c-14650197fb49","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1345,7 +1378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:43 GMT
+      - Mon, 18 Dec 2023 13:15:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6163d154-e442-41f0-b314-25595763a952
+      - d32cb228-7aca-4523-b592-7d7eb0526fa1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1366,10 +1399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/395d03b4-b661-4e52-a55c-14650197fb49
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/16133fda-9797-412e-ae2b-2a82fd5d0bd6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"395d03b4-b661-4e52-a55c-14650197fb49","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"16133fda-9797-412e-ae2b-2a82fd5d0bd6","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1378,7 +1411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:43 GMT
+      - Mon, 18 Dec 2023 13:15:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87908789-dbf6-4119-9137-b5eb81611f55
+      - b096818e-e9c7-4d5a-80c2-e780b7e55781
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1399,10 +1432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/5ad754e8-8df5-4fe6-9a86-b9add0e154ee
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4f866de1-f376-435b-baa6-81040de176db
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"5ad754e8-8df5-4fe6-9a86-b9add0e154ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"4f866de1-f376-435b-baa6-81040de176db","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1411,7 +1444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:43 GMT
+      - Mon, 18 Dec 2023 13:15:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dec8ca03-5c83-4e77-87aa-7e830653809e
+      - 74d8d4a8-65a2-46b7-8f95-9077bee5fa53
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
@@ -2,6 +2,74 @@
 version: 1
 interactions:
 - request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
+    method: POST
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1049"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 12:57:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73c7ac09-41df-451a-a059-e62d32903083
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1049"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 12:57:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9a0a349e-cc09-46ad-866f-01c15e647e5f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
     body: '{"name":"test-rdb-rr-different-zone","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
@@ -13,16 +81,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T16:06:44.271272Z","dhcp_enabled":true,"id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:44.271272Z","id":"003dc11c-e4a9-407f-945d-9aab38854e43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:06:44.271272Z"},{"created_at":"2023-11-21T16:06:44.271272Z","id":"e57e47f8-f7cb-4ae2-b094-bef4fa2fc556","subnet":"fd5f:519c:6d46:bc52::/64","updated_at":"2023-11-21T16:06:44.271272Z"}],"tags":[],"updated_at":"2023-11-21T16:06:44.271272Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T12:57:07.303744Z","dhcp_enabled":true,"id":"f3f55a63-bae6-4771-a8a9-be93065b26de","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.303744Z","id":"907d2411-6135-4ac6-9dcd-d211a4730ad9","subnet":"172.16.120.0/22","updated_at":"2023-12-18T12:57:07.303744Z"},{"created_at":"2023-12-18T12:57:07.303744Z","id":"1c9c864a-73a6-4329-8b8b-f53ef43463ec","subnet":"fd5f:519c:6d46:3996::/64","updated_at":"2023-12-18T12:57:07.303744Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.303744Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "709"
+      - "711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:44 GMT
+      - Mon, 18 Dec 2023 12:57:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -32,42 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b064fca-e425-424c-a364-f335dd1e50da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
-    method: POST
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "883"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:06:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 763a2ddd-c73e-43da-8f8a-8ec3989e5219
+      - d3506831-3e2d-472c-b9b0-09c57159f7ef
     status: 200 OK
     code: 200
     duration: ""
@@ -78,19 +111,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecb21b56-5db6-4e29-b6b3-a76a13537982
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3f55a63-bae6-4771-a8a9-be93065b26de
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:06:44.271272Z","dhcp_enabled":true,"id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:44.271272Z","id":"003dc11c-e4a9-407f-945d-9aab38854e43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:06:44.271272Z"},{"created_at":"2023-11-21T16:06:44.271272Z","id":"e57e47f8-f7cb-4ae2-b094-bef4fa2fc556","subnet":"fd5f:519c:6d46:bc52::/64","updated_at":"2023-11-21T16:06:44.271272Z"}],"tags":[],"updated_at":"2023-11-21T16:06:44.271272Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T12:57:07.303744Z","dhcp_enabled":true,"id":"f3f55a63-bae6-4771-a8a9-be93065b26de","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.303744Z","id":"907d2411-6135-4ac6-9dcd-d211a4730ad9","subnet":"172.16.120.0/22","updated_at":"2023-12-18T12:57:07.303744Z"},{"created_at":"2023-12-18T12:57:07.303744Z","id":"1c9c864a-73a6-4329-8b8b-f53ef43463ec","subnet":"fd5f:519c:6d46:3996::/64","updated_at":"2023-12-18T12:57:07.303744Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.303744Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "709"
+      - "711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:44 GMT
+      - Mon, 18 Dec 2023 12:57:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18f15a42-0034-4e07-89ab-877a2c371f53
+      - 47c5bca1-45de-4e3b-a192-9870235c1cfa
     status: 200 OK
     code: 200
     duration: ""
@@ -111,19 +144,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "1049"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:45 GMT
+      - Mon, 18 Dec 2023 12:57:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4ad5534-91f6-44a7-87d2-07901b6cdf11
+      - 7d3d1c85-875f-466a-b146-7e9b6872c800
     status: 200 OK
     code: 200
     duration: ""
@@ -144,19 +177,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "1049"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:15 GMT
+      - Mon, 18 Dec 2023 12:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71a6eb95-762c-40a1-a80b-c6989658055b
+      - 7add803f-f9d6-4d9d-bb5a-4148b8b11544
     status: 200 OK
     code: 200
     duration: ""
@@ -177,19 +210,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "1049"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:45 GMT
+      - Mon, 18 Dec 2023 12:58:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -199,7 +232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14c3011a-1dcc-4719-be90-68fac1c0c464
+      - 137c9b2d-845a-4f0b-811b-4cd1488eec46
     status: 200 OK
     code: 200
     duration: ""
@@ -210,19 +243,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "1049"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:15 GMT
+      - Mon, 18 Dec 2023 12:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -232,7 +265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41f389be-76e8-4fe5-9b70-5221b256a3ab
+      - 76e42663-bf54-4b1c-961f-f1bbc2b3ac8a
     status: 200 OK
     code: 200
     duration: ""
@@ -243,19 +276,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "883"
+      - "1313"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:45 GMT
+      - Mon, 18 Dec 2023 12:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -265,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d82e906-66b0-4cd0-b84c-c6e441ebef86
+      - 63887f61-6a53-4ed4-9c85-b4d3f37cc21e
     status: 200 OK
     code: 200
     duration: ""
@@ -276,19 +309,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1147"
+      - "1356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:15 GMT
+      - Mon, 18 Dec 2023 13:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0696e9fc-6231-4b99-8b29-45930ee35e19
+      - 3075bfc2-7441-46b3-8979-fd5d8ee1f070
     status: 200 OK
     code: 200
     duration: ""
@@ -309,19 +342,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840},"endpoints":[{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840}],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVSm0xMUZZU0p2dVU2S2RUUzBmQlEyd0t2bFJVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRJMU9UTXlXaGNOTXpNeE1qRTFNVEkxT1RNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1PbDRPTEhWQkFucTJNWVdWMktvaHZTYWRPSEZ0L3I5WFc2cWpUdXhDZ0RmU2NTRjdSanNyZ3cKbVhyWk4zOHMyRzE4VStwV3ZMaXEzTG96a05RQnRva0srWWNoYWMvY1Zzb2pVS1NaSklZS1pkRktITEVCV2kyTwpEdXNuOFFTVm9jZm9YWEJOdXY0L1daWkRhb0k5OGorTWVGNC9aUE40bmlpL1p1ZFdKS1BvME80eWFJSnJRRmttCmk1Z3hiT2FJY2lFOEd1TTJJUTNkVGlldVFHdWY2U1JRaExQQlg5UW92aGE2OHRhZFc3d3gvUS9OK2JDVHNuMWMKQ2IvcmJPL1F4b3Y0eHl1SUdRaXl3M09EcmpjS2JzUjhpNVRNK2xCM2Nja2x0SXNvV0lHdE5CZk01RVVzc0FITApTQkVmb0pWRS96bDFkcWZTNGxJQm1GaUczSWdtYmJFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDRaR0l3Wm1abU5DMWxNMkUyTFRRNFpHUXRPVGhsTXkwd05qTXcKT1dWbE0yTmhObU11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGhrWWpCbVptWTBMV1V6WVRZdE5EaGtaQzA1T0dVekxUQTJNekE1WldVelkyRTJZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy8yM0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKSHA3eG9ITlA5bEhhYk5XRUdyc3ZhOTB2OWhKcUp6OWtZd1ZqRG82Y2M1Zm5DTEdVY2VrckIxRU82eHIvSGlwZAoza2tTZFBwQmE4K3dsUUg4d29pVXBsdWhLS1lUY1BNemJYQUR5eDQ4MW8zZGtjTEVKN1FaTkVmcGIwcXorcmVpCkx3YzZuNFR5eFNMTlUzbXZBYXdrUkZZbTZPbnRHWXdkQ3QvaTc3TCsrdlBCYnV4R3o4Z29zbzVsYWdVVE96a1YKcGtmUnJBMElPNkt6UFBLb3dqdGljWURzcDV0VVQyNXRsaXFZK01kbWpzSDdOZXI5Uy9Rb0JSQzFzaDJBZFFNawp5SFkzSExQN2ppY0xMSVYzYkpLSXJlTHR5MlhxNTl1VU1DVnRrT0lhdWRUSzhNWnpNUzNCaDR0U3dtWDF2SHgrClRSVzFvVjFFTStKeFZ4Q1ZZY2dhSHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1352"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:49 GMT
+      - Mon, 18 Dec 2023 13:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -331,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cee69fe2-6b9c-4ca0-9770-241333de2b9e
+      - caff1c88-6c28-4c0b-a588-7410a7e76453
     status: 200 OK
     code: 200
     duration: ""
@@ -342,19 +375,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=8db0fff4-e3a6-48dd-98e3-06309ee3ca6c&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSDdvbExOSzVyQWhLQ2VZMXFwV3d0eUthakdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBNU1qVmFGdzB6TXpFeE1UZ3hOakE1TWpWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURuakdIVjVSWTJLYUV4bXpqSUFhdVpSQWk1bll1dmNCSC9MbDhkV0V2L0tJeXpnUDRMZmVoZCtXck0KSjZOMktjdVZnMWJFWG52U1NQSmwrNTJ1YVBmRDA0VWE4WTJLcmhtMG5nYTAzM3lyL2p1c1g5b21lV0ZybU1xOAo0cWRKN2l6WHRMMUJtTzVTempsSmsvcFpLSDVhQTcrRVZ4cndudEsvanY2SkJFS1l3cmd4SCt3aTEyTVdadnBPClcvVGF4aDB4K2RkTU1FSkY3YTNUR2F4bXBTNHBXUlhNRlV5TFdnYmV5dTMzaTQ5MlR1WkpNeFh1SzBGdUJPOFYKYnFubHE5UlZsTThiLzZiZ1ZVay9wL0VxRm9ROS9zZUErRkJtS3U2RjNrVk5RMlRSQWZkZTNZZVA1OFJNUzJPdgpTM29vVCszRUJOTnJWazdITThJYy81STBDWVJUQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3ROMlF6TWpZMlpETXROakl3WVMwME1ERTJMVGcwWWpjdE5HSTBOV1JqTnpFeE9HWXoKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEK3dhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBaFdjV2tuMjcrbk9TOStNc3JTVmtDZVZkRXVuaVNXcVpWT1Q5VlU3T0IwcnZHbFZvTGF3dzgwTGo5CkpFSTdhdFYxVWNtRzlWdUpvRlMwOFFScVA4ZGo5MDEvaFRGTlZDaE83V1lSZFBaMUZQTVltd09qdVhsOEh5Z1gKb2wrMWw0RC9UTUFCQUsrTXdyL3E1YWtVOHNBY1hFTzNhcStzaUxra1FSTFdSVHBMOHNieUd6c2srRWxLaS94NQp1VmRZdnVFeVBKZlFaaHppL3MxZnZlem5WTWNnL0VBMDRHdm5FazZXVGpMdjJaK1gyY1R1RHZKejVOaCtlaU9oCjRuY3o3dzY0QUI0a0F1MmN2TUFhTkNkSUZMQk55am1TaitZRHBOQ2hySmt6c1ZTVWRSTGVXTEZDa0FvUUtERm0KaE4zcGt4VktiNklPNTdvN1E2NnVOemNpVE1NQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1839"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:50 GMT
+      - Mon, 18 Dec 2023 13:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,12 +397,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91ce7f1c-69cd-4da5-8c9d-9256014b5d8d
+      - 33ad9a4a-1f9e-4711-80ac-db3947295ce1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","endpoint_spec":[{"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","ipam_config":{}}}],"same_zone":false}'
+    body: '{"instance_id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","endpoint_spec":[{"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","ipam_config":{}}}],"same_zone":false}'
     form: {}
     headers:
       Content-Type:
@@ -380,16 +413,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "334"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:51 GMT
+      - Mon, 18 Dec 2023 13:00:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -399,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0510099-3a2f-458c-82d2-90d5d248652a
+      - 208a6c58-4cb7-4421-8ec7-8517c7cd6ef3
     status: 200 OK
     code: 200
     duration: ""
@@ -410,19 +443,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "334"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:51 GMT
+      - Mon, 18 Dec 2023 13:00:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f62461f-4dd2-43cc-acda-3f00c8f76858
+      - 4cb0a9ff-7a22-4aa9-bc81-a22876ae53df
     status: 200 OK
     code: 200
     duration: ""
@@ -443,19 +476,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "334"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:10:22 GMT
+      - Mon, 18 Dec 2023 13:00:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 353293d7-e236-4b7d-a249-9689c92da725
+      - 5c5e5521-e54e-4284-aafd-d99d3dcb62a1
     status: 200 OK
     code: 200
     duration: ""
@@ -476,19 +509,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "334"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:10:52 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d041e89d-4134-47b3-bc2d-e43a727a31d6
+      - faaed988-8f83-48e4-8537-31fd119e4354
     status: 200 OK
     code: 200
     duration: ""
@@ -509,19 +542,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "334"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:11:22 GMT
+      - Mon, 18 Dec 2023 13:01:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 968ced78-25f8-4925-a61c-8caea599e8b1
+      - d6b6281e-67ae-442f-a236-b56b9515186f
     status: 200 OK
     code: 200
     duration: ""
@@ -542,19 +575,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "334"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:11:53 GMT
+      - Mon, 18 Dec 2023 13:02:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d98bbf6-b403-45a7-923e-5d2f1f2914fa
+      - 202a7687-0bb5-41b8-9a59-bccb4e0a150c
     status: 200 OK
     code: 200
     duration: ""
@@ -575,19 +608,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "334"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:23 GMT
+      - Mon, 18 Dec 2023 13:02:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df6664a9-5521-4d33-a3a9-d9adc279b70d
+      - 316fe033-734f-480b-87cb-1548e3b2705d
     status: 200 OK
     code: 200
     duration: ""
@@ -608,19 +641,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"initializing"}'
     headers:
       Content-Length:
-      - "334"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:53 GMT
+      - Mon, 18 Dec 2023 13:03:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98a36653-2c01-4cc3-a6a5-60c85c383acf
+      - e15696fa-8d34-4666-9dc6-afc6af6815d6
     status: 200 OK
     code: 200
     duration: ""
@@ -641,19 +674,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"initializing"}'
     headers:
       Content-Length:
-      - "327"
+      - "338"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:23 GMT
+      - Mon, 18 Dec 2023 13:03:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ddac09f-64d0-4deb-a79f-4f03edfb696a
+      - c81d83de-ac0e-4846-a5b9-4fa950ac2038
     status: 200 OK
     code: 200
     duration: ""
@@ -674,19 +707,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "327"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:23 GMT
+      - Mon, 18 Dec 2023 13:04:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9cc2c89e-fb80-43d1-908f-db26996b2b8a
+      - 749578be-303f-4788-94d3-60bbb7ec3b94
     status: 200 OK
     code: 200
     duration: ""
@@ -707,19 +740,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "327"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:23 GMT
+      - Mon, 18 Dec 2023 13:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d1ff846-fe32-4774-ac2f-1c5e0222a941
+      - 48d6cdbc-b30a-4db7-b30c-22588eeb7bbe
     status: 200 OK
     code: 200
     duration: ""
@@ -740,19 +773,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecb21b56-5db6-4e29-b6b3-a76a13537982
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:06:44.271272Z","dhcp_enabled":true,"id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:44.271272Z","id":"003dc11c-e4a9-407f-945d-9aab38854e43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:06:44.271272Z"},{"created_at":"2023-11-21T16:06:44.271272Z","id":"e57e47f8-f7cb-4ae2-b094-bef4fa2fc556","subnet":"fd5f:519c:6d46:bc52::/64","updated_at":"2023-11-21T16:06:44.271272Z"}],"tags":[],"updated_at":"2023-11-21T16:06:44.271272Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "709"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:23 GMT
+      - Mon, 18 Dec 2023 13:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -762,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c743046-48a9-4b3d-96a5-15444d64fa32
+      - 435b51b1-8793-4818-ab34-888fd3f5eb61
     status: 200 OK
     code: 200
     duration: ""
@@ -773,19 +806,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecb21b56-5db6-4e29-b6b3-a76a13537982
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3f55a63-bae6-4771-a8a9-be93065b26de
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:06:44.271272Z","dhcp_enabled":true,"id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:44.271272Z","id":"003dc11c-e4a9-407f-945d-9aab38854e43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:06:44.271272Z"},{"created_at":"2023-11-21T16:06:44.271272Z","id":"e57e47f8-f7cb-4ae2-b094-bef4fa2fc556","subnet":"fd5f:519c:6d46:bc52::/64","updated_at":"2023-11-21T16:06:44.271272Z"}],"tags":[],"updated_at":"2023-11-21T16:06:44.271272Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T12:57:07.303744Z","dhcp_enabled":true,"id":"f3f55a63-bae6-4771-a8a9-be93065b26de","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.303744Z","id":"907d2411-6135-4ac6-9dcd-d211a4730ad9","subnet":"172.16.120.0/22","updated_at":"2023-12-18T12:57:07.303744Z"},{"created_at":"2023-12-18T12:57:07.303744Z","id":"1c9c864a-73a6-4329-8b8b-f53ef43463ec","subnet":"fd5f:519c:6d46:3996::/64","updated_at":"2023-12-18T12:57:07.303744Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.303744Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "709"
+      - "711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:24 GMT
+      - Mon, 18 Dec 2023 13:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -795,7 +828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4417efb3-7419-4f03-ae02-bee05a054c41
+      - 115fad8f-1aa8-4864-a27f-c2080131dfdd
     status: 200 OK
     code: 200
     duration: ""
@@ -806,19 +839,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3f55a63-bae6-4771-a8a9-be93065b26de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840},"endpoints":[{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840}],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2023-12-18T12:57:07.303744Z","dhcp_enabled":true,"id":"f3f55a63-bae6-4771-a8a9-be93065b26de","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.303744Z","id":"907d2411-6135-4ac6-9dcd-d211a4730ad9","subnet":"172.16.120.0/22","updated_at":"2023-12-18T12:57:07.303744Z"},{"created_at":"2023-12-18T12:57:07.303744Z","id":"1c9c864a-73a6-4329-8b8b-f53ef43463ec","subnet":"fd5f:519c:6d46:3996::/64","updated_at":"2023-12-18T12:57:07.303744Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.303744Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1679"
+      - "711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:24 GMT
+      - Mon, 18 Dec 2023 13:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -828,7 +861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84bd8190-6bb4-4878-b8f4-f9ed766b2c6b
+      - 2260dce5-fc00-4d3d-88a5-6fef08bfd197
     status: 200 OK
     code: 200
     duration: ""
@@ -839,19 +872,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSDdvbExOSzVyQWhLQ2VZMXFwV3d0eUthakdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBNU1qVmFGdzB6TXpFeE1UZ3hOakE1TWpWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURuakdIVjVSWTJLYUV4bXpqSUFhdVpSQWk1bll1dmNCSC9MbDhkV0V2L0tJeXpnUDRMZmVoZCtXck0KSjZOMktjdVZnMWJFWG52U1NQSmwrNTJ1YVBmRDA0VWE4WTJLcmhtMG5nYTAzM3lyL2p1c1g5b21lV0ZybU1xOAo0cWRKN2l6WHRMMUJtTzVTempsSmsvcFpLSDVhQTcrRVZ4cndudEsvanY2SkJFS1l3cmd4SCt3aTEyTVdadnBPClcvVGF4aDB4K2RkTU1FSkY3YTNUR2F4bXBTNHBXUlhNRlV5TFdnYmV5dTMzaTQ5MlR1WkpNeFh1SzBGdUJPOFYKYnFubHE5UlZsTThiLzZiZ1ZVay9wL0VxRm9ROS9zZUErRkJtS3U2RjNrVk5RMlRSQWZkZTNZZVA1OFJNUzJPdgpTM29vVCszRUJOTnJWazdITThJYy81STBDWVJUQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3ROMlF6TWpZMlpETXROakl3WVMwME1ERTJMVGcwWWpjdE5HSTBOV1JqTnpFeE9HWXoKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEK3dhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBaFdjV2tuMjcrbk9TOStNc3JTVmtDZVZkRXVuaVNXcVpWT1Q5VlU3T0IwcnZHbFZvTGF3dzgwTGo5CkpFSTdhdFYxVWNtRzlWdUpvRlMwOFFScVA4ZGo5MDEvaFRGTlZDaE83V1lSZFBaMUZQTVltd09qdVhsOEh5Z1gKb2wrMWw0RC9UTUFCQUsrTXdyL3E1YWtVOHNBY1hFTzNhcStzaUxra1FSTFdSVHBMOHNieUd6c2srRWxLaS94NQp1VmRZdnVFeVBKZlFaaHppL3MxZnZlem5WTWNnL0VBMDRHdm5FazZXVGpMdjJaK1gyY1R1RHZKejVOaCtlaU9oCjRuY3o3dzY0QUI0a0F1MmN2TUFhTkNkSUZMQk55am1TaitZRHBOQ2hySmt6c1ZTVWRSTGVXTEZDa0FvUUtERm0KaE4zcGt4VktiNklPNTdvN1E2NnVOemNpVE1NQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "1687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:24 GMT
+      - Mon, 18 Dec 2023 13:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -861,7 +894,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0126f31-feed-495d-91d7-d4285303e28d
+      - 8700d3a5-3afa-43d5-83b7-7f07cbf6b6d8
     status: 200 OK
     code: 200
     duration: ""
@@ -872,19 +905,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c/certificate
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVSm0xMUZZU0p2dVU2S2RUUzBmQlEyd0t2bFJVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRJMU9UTXlXaGNOTXpNeE1qRTFNVEkxT1RNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1PbDRPTEhWQkFucTJNWVdWMktvaHZTYWRPSEZ0L3I5WFc2cWpUdXhDZ0RmU2NTRjdSanNyZ3cKbVhyWk4zOHMyRzE4VStwV3ZMaXEzTG96a05RQnRva0srWWNoYWMvY1Zzb2pVS1NaSklZS1pkRktITEVCV2kyTwpEdXNuOFFTVm9jZm9YWEJOdXY0L1daWkRhb0k5OGorTWVGNC9aUE40bmlpL1p1ZFdKS1BvME80eWFJSnJRRmttCmk1Z3hiT2FJY2lFOEd1TTJJUTNkVGlldVFHdWY2U1JRaExQQlg5UW92aGE2OHRhZFc3d3gvUS9OK2JDVHNuMWMKQ2IvcmJPL1F4b3Y0eHl1SUdRaXl3M09EcmpjS2JzUjhpNVRNK2xCM2Nja2x0SXNvV0lHdE5CZk01RVVzc0FITApTQkVmb0pWRS96bDFkcWZTNGxJQm1GaUczSWdtYmJFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDRaR0l3Wm1abU5DMWxNMkUyTFRRNFpHUXRPVGhsTXkwd05qTXcKT1dWbE0yTmhObU11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGhrWWpCbVptWTBMV1V6WVRZdE5EaGtaQzA1T0dVekxUQTJNekE1WldVelkyRTJZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy8yM0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKSHA3eG9ITlA5bEhhYk5XRUdyc3ZhOTB2OWhKcUp6OWtZd1ZqRG82Y2M1Zm5DTEdVY2VrckIxRU82eHIvSGlwZAoza2tTZFBwQmE4K3dsUUg4d29pVXBsdWhLS1lUY1BNemJYQUR5eDQ4MW8zZGtjTEVKN1FaTkVmcGIwcXorcmVpCkx3YzZuNFR5eFNMTlUzbXZBYXdrUkZZbTZPbnRHWXdkQ3QvaTc3TCsrdlBCYnV4R3o4Z29zbzVsYWdVVE96a1YKcGtmUnJBMElPNkt6UFBLb3dqdGljWURzcDV0VVQyNXRsaXFZK01kbWpzSDdOZXI5Uy9Rb0JSQzFzaDJBZFFNawp5SFkzSExQN2ppY0xMSVYzYkpLSXJlTHR5MlhxNTl1VU1DVnRrT0lhdWRUSzhNWnpNUzNCaDR0U3dtWDF2SHgrClRSVzFvVjFFTStKeFZ4Q1ZZY2dhSHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "327"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:24 GMT
+      - Mon, 18 Dec 2023 13:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -894,7 +927,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8443dcb3-2808-4f8f-816e-e629ecab8909
+      - 135e6169-0b54-43f7-9419-db36a22f6c2a
     status: 200 OK
     code: 200
     duration: ""
@@ -905,19 +938,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecb21b56-5db6-4e29-b6b3-a76a13537982
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=8db0fff4-e3a6-48dd-98e3-06309ee3ca6c&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:06:44.271272Z","dhcp_enabled":true,"id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:44.271272Z","id":"003dc11c-e4a9-407f-945d-9aab38854e43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:06:44.271272Z"},{"created_at":"2023-11-21T16:06:44.271272Z","id":"e57e47f8-f7cb-4ae2-b094-bef4fa2fc556","subnet":"fd5f:519c:6d46:bc52::/64","updated_at":"2023-11-21T16:06:44.271272Z"}],"tags":[],"updated_at":"2023-11-21T16:06:44.271272Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"ips":[{"address":"172.16.120.2/22","created_at":"2023-12-18T13:00:10.348439Z","id":"83bf4d18-5d72-40e7-8edc-d02fe9d8facf","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","mac_address":"02:00:00:23:98:5D","name":"read-replica-b61d5d36","type":"rdb_instance"},"source":{"subnet_id":"907d2411-6135-4ac6-9dcd-d211a4730ad9"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:02:31.393200Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "709"
+      - "519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:25 GMT
+      - Mon, 18 Dec 2023 13:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -927,7 +960,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42a46a78-cb46-4a50-882e-47ef040c2a8a
+      - f4e48e49-f14f-42bc-9da3-cca17f2a91b7
     status: 200 OK
     code: 200
     duration: ""
@@ -938,19 +971,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840},"endpoints":[{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840}],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "1679"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:25 GMT
+      - Mon, 18 Dec 2023 13:04:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -960,7 +993,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2efb3b3-bb97-41ef-aa57-893cc319dc89
+      - cbedd196-2afa-43b0-ae78-facce2f08cd6
     status: 200 OK
     code: 200
     duration: ""
@@ -971,19 +1004,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3f55a63-bae6-4771-a8a9-be93065b26de
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSDdvbExOSzVyQWhLQ2VZMXFwV3d0eUthakdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBNU1qVmFGdzB6TXpFeE1UZ3hOakE1TWpWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURuakdIVjVSWTJLYUV4bXpqSUFhdVpSQWk1bll1dmNCSC9MbDhkV0V2L0tJeXpnUDRMZmVoZCtXck0KSjZOMktjdVZnMWJFWG52U1NQSmwrNTJ1YVBmRDA0VWE4WTJLcmhtMG5nYTAzM3lyL2p1c1g5b21lV0ZybU1xOAo0cWRKN2l6WHRMMUJtTzVTempsSmsvcFpLSDVhQTcrRVZ4cndudEsvanY2SkJFS1l3cmd4SCt3aTEyTVdadnBPClcvVGF4aDB4K2RkTU1FSkY3YTNUR2F4bXBTNHBXUlhNRlV5TFdnYmV5dTMzaTQ5MlR1WkpNeFh1SzBGdUJPOFYKYnFubHE5UlZsTThiLzZiZ1ZVay9wL0VxRm9ROS9zZUErRkJtS3U2RjNrVk5RMlRSQWZkZTNZZVA1OFJNUzJPdgpTM29vVCszRUJOTnJWazdITThJYy81STBDWVJUQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3ROMlF6TWpZMlpETXROakl3WVMwME1ERTJMVGcwWWpjdE5HSTBOV1JqTnpFeE9HWXoKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEK3dhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBaFdjV2tuMjcrbk9TOStNc3JTVmtDZVZkRXVuaVNXcVpWT1Q5VlU3T0IwcnZHbFZvTGF3dzgwTGo5CkpFSTdhdFYxVWNtRzlWdUpvRlMwOFFScVA4ZGo5MDEvaFRGTlZDaE83V1lSZFBaMUZQTVltd09qdVhsOEh5Z1gKb2wrMWw0RC9UTUFCQUsrTXdyL3E1YWtVOHNBY1hFTzNhcStzaUxra1FSTFdSVHBMOHNieUd6c2srRWxLaS94NQp1VmRZdnVFeVBKZlFaaHppL3MxZnZlem5WTWNnL0VBMDRHdm5FazZXVGpMdjJaK1gyY1R1RHZKejVOaCtlaU9oCjRuY3o3dzY0QUI0a0F1MmN2TUFhTkNkSUZMQk55am1TaitZRHBOQ2hySmt6c1ZTVWRSTGVXTEZDa0FvUUtERm0KaE4zcGt4VktiNklPNTdvN1E2NnVOemNpVE1NQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2023-12-18T12:57:07.303744Z","dhcp_enabled":true,"id":"f3f55a63-bae6-4771-a8a9-be93065b26de","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.303744Z","id":"907d2411-6135-4ac6-9dcd-d211a4730ad9","subnet":"172.16.120.0/22","updated_at":"2023-12-18T12:57:07.303744Z"},{"created_at":"2023-12-18T12:57:07.303744Z","id":"1c9c864a-73a6-4329-8b8b-f53ef43463ec","subnet":"fd5f:519c:6d46:3996::/64","updated_at":"2023-12-18T12:57:07.303744Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.303744Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1839"
+      - "711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:25 GMT
+      - Mon, 18 Dec 2023 13:04:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -993,7 +1026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67992f13-1c4c-493e-aea5-287ba7ad9f0f
+      - b828ce98-32fd-40ca-bdf4-45887b889d1e
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,19 +1037,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "327"
+      - "1687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:25 GMT
+      - Mon, 18 Dec 2023 13:04:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1026,7 +1059,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fc56dd2-4536-4d73-b5ec-0a08d988df8c
+      - 1fa35922-9f20-48c7-a43b-418ada055a08
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,19 +1070,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c/certificate
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVSm0xMUZZU0p2dVU2S2RUUzBmQlEyd0t2bFJVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRJMU9UTXlXaGNOTXpNeE1qRTFNVEkxT1RNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1PbDRPTEhWQkFucTJNWVdWMktvaHZTYWRPSEZ0L3I5WFc2cWpUdXhDZ0RmU2NTRjdSanNyZ3cKbVhyWk4zOHMyRzE4VStwV3ZMaXEzTG96a05RQnRva0srWWNoYWMvY1Zzb2pVS1NaSklZS1pkRktITEVCV2kyTwpEdXNuOFFTVm9jZm9YWEJOdXY0L1daWkRhb0k5OGorTWVGNC9aUE40bmlpL1p1ZFdKS1BvME80eWFJSnJRRmttCmk1Z3hiT2FJY2lFOEd1TTJJUTNkVGlldVFHdWY2U1JRaExQQlg5UW92aGE2OHRhZFc3d3gvUS9OK2JDVHNuMWMKQ2IvcmJPL1F4b3Y0eHl1SUdRaXl3M09EcmpjS2JzUjhpNVRNK2xCM2Nja2x0SXNvV0lHdE5CZk01RVVzc0FITApTQkVmb0pWRS96bDFkcWZTNGxJQm1GaUczSWdtYmJFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDRaR0l3Wm1abU5DMWxNMkUyTFRRNFpHUXRPVGhsTXkwd05qTXcKT1dWbE0yTmhObU11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGhrWWpCbVptWTBMV1V6WVRZdE5EaGtaQzA1T0dVekxUQTJNekE1WldVelkyRTJZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy8yM0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKSHA3eG9ITlA5bEhhYk5XRUdyc3ZhOTB2OWhKcUp6OWtZd1ZqRG82Y2M1Zm5DTEdVY2VrckIxRU82eHIvSGlwZAoza2tTZFBwQmE4K3dsUUg4d29pVXBsdWhLS1lUY1BNemJYQUR5eDQ4MW8zZGtjTEVKN1FaTkVmcGIwcXorcmVpCkx3YzZuNFR5eFNMTlUzbXZBYXdrUkZZbTZPbnRHWXdkQ3QvaTc3TCsrdlBCYnV4R3o4Z29zbzVsYWdVVE96a1YKcGtmUnJBMElPNkt6UFBLb3dqdGljWURzcDV0VVQyNXRsaXFZK01kbWpzSDdOZXI5Uy9Rb0JSQzFzaDJBZFFNawp5SFkzSExQN2ppY0xMSVYzYkpLSXJlTHR5MlhxNTl1VU1DVnRrT0lhdWRUSzhNWnpNUzNCaDR0U3dtWDF2SHgrClRSVzFvVjFFTStKeFZ4Q1ZZY2dhSHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "327"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:26 GMT
+      - Mon, 18 Dec 2023 13:04:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1059,7 +1092,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87e9614d-ac29-4699-9a71-970d24fd1dea
+      - 968982d2-ccea-41d1-8fdb-e9311e5c6b17
     status: 200 OK
     code: 200
     duration: ""
@@ -1070,19 +1103,118 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=8db0fff4-e3a6-48dd-98e3-06309ee3ca6c&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.120.2/22","created_at":"2023-12-18T13:00:10.348439Z","id":"83bf4d18-5d72-40e7-8edc-d02fe9d8facf","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","mac_address":"02:00:00:23:98:5D","name":"read-replica-b61d5d36","type":"rdb_instance"},"source":{"subnet_id":"907d2411-6135-4ac6-9dcd-d211a4730ad9"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:02:31.393200Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "519"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:04:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 43cb02af-84fa-48f8-9caf-b0c35383eff4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "331"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:04:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8d4f604d-2eee-41da-a2c3-741304f6b23f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "331"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:04:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 795ca79f-ec3b-460f-9311-75c4f58aa51b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
-      - "330"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:26 GMT
+      - Mon, 18 Dec 2023 13:04:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1092,7 +1224,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a975fb86-62e8-4650-99d7-b81ba3445311
+      - c9323216-30c3-486c-9a2d-70be26690457
     status: 200 OK
     code: 200
     duration: ""
@@ -1103,19 +1235,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"endpoints":[{"id":"aa72c52d-5ad1-499b-8817-b2a113feaf2b","ip":"172.16.4.2","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.2/22","zone":"fr-par-1"}}],"id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"11c20222-c931-4f10-9b1b-dda4e39101d8","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
-      - "330"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:26 GMT
+      - Mon, 18 Dec 2023 13:04:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1125,7 +1257,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdb25277-3e99-43ee-b28b-00211eeaa1fe
+      - 273f105b-b64e-43c4-b5ef-bd2d144a0e27
     status: 200 OK
     code: 200
     duration: ""
@@ -1136,10 +1268,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/c53ec574-dc40-4fe0-bd6e-1a20f4143ac8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b61d5d36-332b-4004-be7d-5b3e1fb79564
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"c53ec574-dc40-4fe0-bd6e-1a20f4143ac8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b61d5d36-332b-4004-be7d-5b3e1fb79564","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1148,7 +1280,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:00 GMT
+      - Mon, 18 Dec 2023 13:04:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1158,12 +1290,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 503154eb-eb26-4c4a-9a94-bae715ee9eb5
+      - 169280ab-7520-4db4-9951-211d25cccf1b
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"instance_id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","endpoint_spec":[{"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","ipam_config":{}}}],"same_zone":true}'
+    body: '{"instance_id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","endpoint_spec":[{"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","ipam_config":{}}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -1174,16 +1306,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "333"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:02 GMT
+      - Mon, 18 Dec 2023 13:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1193,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4161542b-984c-4441-a546-f34c856a6b2b
+      - fee33af5-16c8-481d-8483-bbc77ea030d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,19 +1336,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "333"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:02 GMT
+      - Mon, 18 Dec 2023 13:04:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1226,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3ff66c6-2f4a-4612-8ab7-79ee56e938f0
+      - 7e7c996b-a68b-4274-bfc3-c6829ee4d251
     status: 200 OK
     code: 200
     duration: ""
@@ -1237,19 +1369,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "333"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:32 GMT
+      - Mon, 18 Dec 2023 13:05:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1259,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24b1a3b2-4eff-4dc3-874a-378753f92cfd
+      - 0aa59abc-67f9-4bd1-a29f-e538e193bc95
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,19 +1402,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "333"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:02 GMT
+      - Mon, 18 Dec 2023 13:05:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1292,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b104b737-9530-4545-b35c-db1b9767e3f5
+      - e708bcb1-4cbb-4d4b-8e70-859c109f8fda
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,19 +1435,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "333"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:32 GMT
+      - Mon, 18 Dec 2023 13:06:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1325,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 405e43dd-b2bf-48f3-9f07-61a625c8765b
+      - 25ead223-8062-4a51-8b5d-7dcc951ee83c
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,19 +1468,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "333"
+      - "337"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:02 GMT
+      - Mon, 18 Dec 2023 13:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1358,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d88c7fa4-70bd-4748-9aa2-6382ded3dbb3
+      - 5fdf210f-7f1a-446f-bbaa-a0d7a2bf02b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1369,19 +1501,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "326"
+      - "330"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:32 GMT
+      - Mon, 18 Dec 2023 13:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1391,7 +1523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ae61b3c-9ee3-47ae-9284-272358a462d0
+      - 3a1ceb82-386e-4bc3-aba4-e65fc5a03e79
     status: 200 OK
     code: 200
     duration: ""
@@ -1402,19 +1534,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "326"
+      - "330"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:32 GMT
+      - Mon, 18 Dec 2023 13:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1424,7 +1556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e06e4d24-dc9e-46bf-a52d-1baf7df03008
+      - b9f5f7ff-1b41-4322-a5ac-d46547f10bf4
     status: 200 OK
     code: 200
     duration: ""
@@ -1435,19 +1567,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "326"
+      - "330"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:32 GMT
+      - Mon, 18 Dec 2023 13:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1457,7 +1589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05519faf-7e28-46a7-901e-84a9a17164aa
+      - fbac1ef5-6fb9-45af-9134-0fb6e0f147df
     status: 200 OK
     code: 200
     duration: ""
@@ -1468,19 +1600,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecb21b56-5db6-4e29-b6b3-a76a13537982
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3f55a63-bae6-4771-a8a9-be93065b26de
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:06:44.271272Z","dhcp_enabled":true,"id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:44.271272Z","id":"003dc11c-e4a9-407f-945d-9aab38854e43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:06:44.271272Z"},{"created_at":"2023-11-21T16:06:44.271272Z","id":"e57e47f8-f7cb-4ae2-b094-bef4fa2fc556","subnet":"fd5f:519c:6d46:bc52::/64","updated_at":"2023-11-21T16:06:44.271272Z"}],"tags":[],"updated_at":"2023-11-21T16:06:44.271272Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T12:57:07.303744Z","dhcp_enabled":true,"id":"f3f55a63-bae6-4771-a8a9-be93065b26de","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.303744Z","id":"907d2411-6135-4ac6-9dcd-d211a4730ad9","subnet":"172.16.120.0/22","updated_at":"2023-12-18T12:57:07.303744Z"},{"created_at":"2023-12-18T12:57:07.303744Z","id":"1c9c864a-73a6-4329-8b8b-f53ef43463ec","subnet":"fd5f:519c:6d46:3996::/64","updated_at":"2023-12-18T12:57:07.303744Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.303744Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "709"
+      - "711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:32 GMT
+      - Mon, 18 Dec 2023 13:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1490,7 +1622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52aa63e7-37ff-4896-9e81-c61ee8faf621
+      - c5a7b56d-cbe6-4eee-b9af-fd8e24f21c1e
     status: 200 OK
     code: 200
     duration: ""
@@ -1501,19 +1633,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecb21b56-5db6-4e29-b6b3-a76a13537982
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3f55a63-bae6-4771-a8a9-be93065b26de
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:06:44.271272Z","dhcp_enabled":true,"id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:44.271272Z","id":"003dc11c-e4a9-407f-945d-9aab38854e43","subnet":"172.16.4.0/22","updated_at":"2023-11-21T16:06:44.271272Z"},{"created_at":"2023-11-21T16:06:44.271272Z","id":"e57e47f8-f7cb-4ae2-b094-bef4fa2fc556","subnet":"fd5f:519c:6d46:bc52::/64","updated_at":"2023-11-21T16:06:44.271272Z"}],"tags":[],"updated_at":"2023-11-21T16:06:44.271272Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T12:57:07.303744Z","dhcp_enabled":true,"id":"f3f55a63-bae6-4771-a8a9-be93065b26de","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.303744Z","id":"907d2411-6135-4ac6-9dcd-d211a4730ad9","subnet":"172.16.120.0/22","updated_at":"2023-12-18T12:57:07.303744Z"},{"created_at":"2023-12-18T12:57:07.303744Z","id":"1c9c864a-73a6-4329-8b8b-f53ef43463ec","subnet":"fd5f:519c:6d46:3996::/64","updated_at":"2023-12-18T12:57:07.303744Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.303744Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "709"
+      - "711"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:33 GMT
+      - Mon, 18 Dec 2023 13:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1523,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47ac835d-6362-471b-870e-a955dc4cfaa5
+      - 004803eb-07a0-4637-931a-98a0fc4b9a67
     status: 200 OK
     code: 200
     duration: ""
@@ -1534,19 +1666,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840},"endpoints":[{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840}],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1678"
+      - "1686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:33 GMT
+      - Mon, 18 Dec 2023 13:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1556,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3315156f-c288-4d2d-ab08-c6c7faef0562
+      - 9c9730db-d670-46e2-8ab0-2fe7ce150038
     status: 200 OK
     code: 200
     duration: ""
@@ -1567,19 +1699,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVSDdvbExOSzVyQWhLQ2VZMXFwV3d0eUthakdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpBNU1qVmFGdzB6TXpFeE1UZ3hOakE1TWpWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURuakdIVjVSWTJLYUV4bXpqSUFhdVpSQWk1bll1dmNCSC9MbDhkV0V2L0tJeXpnUDRMZmVoZCtXck0KSjZOMktjdVZnMWJFWG52U1NQSmwrNTJ1YVBmRDA0VWE4WTJLcmhtMG5nYTAzM3lyL2p1c1g5b21lV0ZybU1xOAo0cWRKN2l6WHRMMUJtTzVTempsSmsvcFpLSDVhQTcrRVZ4cndudEsvanY2SkJFS1l3cmd4SCt3aTEyTVdadnBPClcvVGF4aDB4K2RkTU1FSkY3YTNUR2F4bXBTNHBXUlhNRlV5TFdnYmV5dTMzaTQ5MlR1WkpNeFh1SzBGdUJPOFYKYnFubHE5UlZsTThiLzZiZ1ZVay9wL0VxRm9ROS9zZUErRkJtS3U2RjNrVk5RMlRSQWZkZTNZZVA1OFJNUzJPdgpTM29vVCszRUJOTnJWazdITThJYy81STBDWVJUQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3ROMlF6TWpZMlpETXROakl3WVMwME1ERTJMVGcwWWpjdE5HSTBOV1JqTnpFeE9HWXoKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpEK3dhaHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFBaFdjV2tuMjcrbk9TOStNc3JTVmtDZVZkRXVuaVNXcVpWT1Q5VlU3T0IwcnZHbFZvTGF3dzgwTGo5CkpFSTdhdFYxVWNtRzlWdUpvRlMwOFFScVA4ZGo5MDEvaFRGTlZDaE83V1lSZFBaMUZQTVltd09qdVhsOEh5Z1gKb2wrMWw0RC9UTUFCQUsrTXdyL3E1YWtVOHNBY1hFTzNhcStzaUxra1FSTFdSVHBMOHNieUd6c2srRWxLaS94NQp1VmRZdnVFeVBKZlFaaHppL3MxZnZlem5WTWNnL0VBMDRHdm5FazZXVGpMdjJaK1gyY1R1RHZKejVOaCtlaU9oCjRuY3o3dzY0QUI0a0F1MmN2TUFhTkNkSUZMQk55am1TaitZRHBOQ2hySmt6c1ZTVWRSTGVXTEZDa0FvUUtERm0KaE4zcGt4VktiNklPNTdvN1E2NnVOemNpVE1NQQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVSm0xMUZZU0p2dVU2S2RUUzBmQlEyd0t2bFJVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRJMU9UTXlXaGNOTXpNeE1qRTFNVEkxT1RNeVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU1PbDRPTEhWQkFucTJNWVdWMktvaHZTYWRPSEZ0L3I5WFc2cWpUdXhDZ0RmU2NTRjdSanNyZ3cKbVhyWk4zOHMyRzE4VStwV3ZMaXEzTG96a05RQnRva0srWWNoYWMvY1Zzb2pVS1NaSklZS1pkRktITEVCV2kyTwpEdXNuOFFTVm9jZm9YWEJOdXY0L1daWkRhb0k5OGorTWVGNC9aUE40bmlpL1p1ZFdKS1BvME80eWFJSnJRRmttCmk1Z3hiT2FJY2lFOEd1TTJJUTNkVGlldVFHdWY2U1JRaExQQlg5UW92aGE2OHRhZFc3d3gvUS9OK2JDVHNuMWMKQ2IvcmJPL1F4b3Y0eHl1SUdRaXl3M09EcmpjS2JzUjhpNVRNK2xCM2Nja2x0SXNvV0lHdE5CZk01RVVzc0FITApTQkVmb0pWRS96bDFkcWZTNGxJQm1GaUczSWdtYmJFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MDRaR0l3Wm1abU5DMWxNMkUyTFRRNFpHUXRPVGhsTXkwd05qTXcKT1dWbE0yTmhObU11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMVGhrWWpCbVptWTBMV1V6WVRZdE5EaGtaQzA1T0dVekxUQTJNekE1WldVelkyRTJZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy8yM0ljRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKSHA3eG9ITlA5bEhhYk5XRUdyc3ZhOTB2OWhKcUp6OWtZd1ZqRG82Y2M1Zm5DTEdVY2VrckIxRU82eHIvSGlwZAoza2tTZFBwQmE4K3dsUUg4d29pVXBsdWhLS1lUY1BNemJYQUR5eDQ4MW8zZGtjTEVKN1FaTkVmcGIwcXorcmVpCkx3YzZuNFR5eFNMTlUzbXZBYXdrUkZZbTZPbnRHWXdkQ3QvaTc3TCsrdlBCYnV4R3o4Z29zbzVsYWdVVE96a1YKcGtmUnJBMElPNkt6UFBLb3dqdGljWURzcDV0VVQyNXRsaXFZK01kbWpzSDdOZXI5Uy9Rb0JSQzFzaDJBZFFNawp5SFkzSExQN2ppY0xMSVYzYkpLSXJlTHR5MlhxNTl1VU1DVnRrT0lhdWRUSzhNWnpNUzNCaDR0U3dtWDF2SHgrClRSVzFvVjFFTStKeFZ4Q1ZZY2dhSHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1839"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:33 GMT
+      - Mon, 18 Dec 2023 13:07:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1589,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a360150-e6da-4877-900f-ee7d79a0cda4
+      - 6d5b4327-cd94-4361-9cff-36c32cd9546f
     status: 200 OK
     code: 200
     duration: ""
@@ -1600,19 +1732,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=8db0fff4-e3a6-48dd-98e3-06309ee3ca6c&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[{"address":"172.16.120.2/22","created_at":"2023-12-18T13:04:45.230474Z","id":"bbbab99a-882e-4d6d-b450-fec7df88a253","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","mac_address":"02:00:00:15:AA:06","name":"read-replica-4859eb7d","type":"rdb_instance"},"source":{"subnet_id":"907d2411-6135-4ac6-9dcd-d211a4730ad9"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:05:22.172499Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "326"
+      - "519"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:33 GMT
+      - Mon, 18 Dec 2023 13:07:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1622,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6638b45d-86bd-4338-8550-a6dbd3612964
+      - 25ea859e-b69d-40a6-b845-a6713980554d
     status: 200 OK
     code: 200
     duration: ""
@@ -1633,19 +1765,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "326"
+      - "330"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:34 GMT
+      - Mon, 18 Dec 2023 13:07:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1655,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26e81798-6d91-4299-bbfb-872f31a26aa4
+      - f20b711a-b3a6-4423-936e-445d7f145264
     status: 200 OK
     code: 200
     duration: ""
@@ -1666,19 +1798,52 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "330"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:07:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a4af6ee-0f83-40a4-9c8f-ed82dff62da7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "329"
+      - "333"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:34 GMT
+      - Mon, 18 Dec 2023 13:07:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1688,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1255dd0-e561-4bf6-a636-67377b822dfa
+      - 64eea7ad-7f9d-45c5-a2f6-0fb18056de04
     status: 200 OK
     code: 200
     duration: ""
@@ -1699,19 +1864,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"endpoints":[{"id":"1f6d86db-7a35-4790-bf6c-9e2788b26ad4","ip":"172.16.4.3","name":null,"port":5432,"private_network":{"private_network_id":"ecb21b56-5db6-4e29-b6b3-a76a13537982","service_ip":"172.16.4.3/22","zone":"fr-par-1"}}],"id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"fc76e408-a4ff-4fea-ba46-3051431977e3","ip":"172.16.120.2","name":null,"port":5432,"private_network":{"private_network_id":"f3f55a63-bae6-4771-a8a9-be93065b26de","service_ip":"172.16.120.2/22","zone":"fr-par-1"}}],"id":"4859eb7d-79b4-4117-85b9-632813b0cef4","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "329"
+      - "333"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:35 GMT
+      - Mon, 18 Dec 2023 13:07:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1721,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23faac3a-eb7a-456c-80a9-003704de74b7
+      - 28334552-cbb0-4588-b73c-24d02b4432a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1732,10 +1897,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"4859eb7d-79b4-4117-85b9-632813b0cef4","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1744,7 +1909,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:05 GMT
+      - Mon, 18 Dec 2023 13:07:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1754,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd8c6daa-3335-4d2d-8ff1-8f5490a33a75
+      - 709944d1-bc08-4a37-ab5c-76ebf39e78c4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1765,19 +1930,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840},"endpoints":[{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840}],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1352"
+      - "1356"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:05 GMT
+      - Mon, 18 Dec 2023 13:07:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1787,7 +1952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14ed53ff-fa28-48ee-b386-ec23dd1c79d3
+      - e3014884-51ae-49a7-91ab-c26d22d8d413
     status: 200 OK
     code: 200
     duration: ""
@@ -1798,73 +1963,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840},"endpoints":[{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840}],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1355"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:17:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 41164230-95d7-4be1-abd7-370e9a76b8d6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:44.482276Z","endpoint":{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840},"endpoints":[{"id":"bfe5f927-4a3c-4af6-8c25-f18c2d0cf68c","ip":"51.159.11.70","load_balancer":{},"name":null,"port":3840}],"engine":"PostgreSQL-14","id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"d6fa23a8-ff53-464e-b0b0-4c4a3c1eb87d","minor_version":"15.4","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1355"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:17:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b0492cb6-de14-4277-8c40-6f0b95799f73
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecb21b56-5db6-4e29-b6b3-a76a13537982
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f3f55a63-bae6-4771-a8a9-be93065b26de
     method: DELETE
   response:
     body: ""
@@ -1874,7 +1973,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:06 GMT
+      - Mon, 18 Dec 2023 13:07:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1884,7 +1983,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88b31ad2-d7e3-4ffe-8f41-b2e4149b46b8
+      - 22751214-c62b-4e12-a44a-64e9daa8ca37
     status: 204 No Content
     code: 204
     duration: ""
@@ -1895,19 +1994,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1359"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:35 GMT
+      - Mon, 18 Dec 2023 13:07:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1917,7 +2016,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb251a68-7845-45db-895e-ac1eee7ddd1c
+      - 31cbcde6-da66-4176-a38e-741784e2c6db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.510135Z","endpoint":{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170},"endpoints":[{"id":"f4caeff4-26e1-495b-a5bc-b39ff281c57e","ip":"51.159.74.238","load_balancer":{},"name":null,"port":12170}],"engine":"PostgreSQL-14","id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1359"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:07:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c713d4d-4da6-46e4-9349-a6263c9dfb16
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:08:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 93f815c0-3b34-4776-9232-3a5416ec7d16
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1928,10 +2093,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7d3266d3-620a-4016-84b7-4b45dc7118f3
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/8db0fff4-e3a6-48dd-98e3-06309ee3ca6c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"7d3266d3-620a-4016-84b7-4b45dc7118f3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"8db0fff4-e3a6-48dd-98e3-06309ee3ca6c","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1940,7 +2105,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:35 GMT
+      - Mon, 18 Dec 2023 13:08:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1950,7 +2115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a5e5abb-a8c6-4459-ad2a-1f8925c36e02
+      - 1bb2b748-3498-4e72-9652-d35e5742bd35
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1961,10 +2126,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/6262e587-b5cd-459c-bf24-7643ebcbff0a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4859eb7d-79b4-4117-85b9-632813b0cef4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"6262e587-b5cd-459c-bf24-7643ebcbff0a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"4859eb7d-79b4-4117-85b9-632813b0cef4","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1973,7 +2138,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:36 GMT
+      - Mon, 18 Dec 2023 13:08:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1983,7 +2148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50ae7e4d-71f3-486c-9e55-ad5871f38e81
+      - 6a681ca0-a71d-4e0a-8b02-33a4ff4dcab1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:02 GMT
+      - Mon, 18 Dec 2023 12:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1467531d-f890-4ac9-b759-534bd3475725
+      - ffca77c8-0849-4eb4-afdf-9ea2f23c1cef
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-multiple-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-multiple-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "940"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:21 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,12 +363,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20cecf26-4d0d-446d-b127-fe2042b09903
+      - 97876599-527a-42b2-a556-13999a0345af
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-silly-wright","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "940"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 12:57:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c2f0abb2-c500-4311-99d3-203daeb1ecdb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-pn-vigorous-black","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -379,16 +412,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T16:06:21.420340Z","dhcp_enabled":true,"id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","name":"tf-pn-silly-wright","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:21.420340Z","id":"6f8ef234-8276-444c-856d-8c44576c6810","subnet":"172.16.56.0/22","updated_at":"2023-11-21T16:06:21.420340Z"},{"created_at":"2023-11-21T16:06:21.420340Z","id":"054da6c9-838c-487b-a591-65e9ab3f61b4","subnet":"fd5f:519c:6d46:d19b::/64","updated_at":"2023-11-21T16:06:21.420340Z"}],"tags":[],"updated_at":"2023-11-21T16:06:21.420340Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T12:57:07.171263Z","dhcp_enabled":true,"id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","name":"tf-pn-vigorous-black","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.171263Z","id":"ffa583fc-6d58-40ba-b021-55e2e8ee314c","subnet":"172.16.32.0/22","updated_at":"2023-12-18T12:57:07.171263Z"},{"created_at":"2023-12-18T12:57:07.171263Z","id":"e8f34fcf-f8a9-45cb-b0c8-e7bbc2f3ffd6","subnet":"fd5f:519c:6d46:ad6c::/64","updated_at":"2023-12-18T12:57:07.171263Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.171263Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "702"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:21 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -398,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10a7bf1f-38e5-43d4-a8a8-62d3f035dc7f
+      - 9a153863-ad8e-4629-9903-c531a70874af
     status: 200 OK
     code: 200
     duration: ""
@@ -409,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/99ac85d5-336f-442b-a9d5-90b3e0c7745c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/99658be3-f4fc-45d0-b773-bc6086ed8d86
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:06:21.420340Z","dhcp_enabled":true,"id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","name":"tf-pn-silly-wright","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:21.420340Z","id":"6f8ef234-8276-444c-856d-8c44576c6810","subnet":"172.16.56.0/22","updated_at":"2023-11-21T16:06:21.420340Z"},{"created_at":"2023-11-21T16:06:21.420340Z","id":"054da6c9-838c-487b-a591-65e9ab3f61b4","subnet":"fd5f:519c:6d46:d19b::/64","updated_at":"2023-11-21T16:06:21.420340Z"}],"tags":[],"updated_at":"2023-11-21T16:06:21.420340Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T12:57:07.171263Z","dhcp_enabled":true,"id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","name":"tf-pn-vigorous-black","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.171263Z","id":"ffa583fc-6d58-40ba-b021-55e2e8ee314c","subnet":"172.16.32.0/22","updated_at":"2023-12-18T12:57:07.171263Z"},{"created_at":"2023-12-18T12:57:07.171263Z","id":"e8f34fcf-f8a9-45cb-b0c8-e7bbc2f3ffd6","subnet":"fd5f:519c:6d46:ad6c::/64","updated_at":"2023-12-18T12:57:07.171263Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.171263Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "702"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:22 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1f8f7dd-72ed-47ea-9076-3e126502a7ba
+      - e61bf996-9edb-4eed-a495-80ccf94cc36c
     status: 200 OK
     code: 200
     duration: ""
@@ -442,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "940"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:22 GMT
+      - Mon, 18 Dec 2023 12:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1faa57ae-96e5-4574-92ad-33e758928623
+      - 1e11d191-f220-4aea-b756-ad4a50e1b6a6
     status: 200 OK
     code: 200
     duration: ""
@@ -475,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "940"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:06:52 GMT
+      - Mon, 18 Dec 2023 12:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 762e99e7-e017-4643-89b7-540d60ac7a29
+      - c2a48fec-b89e-4209-984f-fcb40405cabe
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "940"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:22 GMT
+      - Mon, 18 Dec 2023 12:58:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e05f69e-28f7-4f1a-88c8-91563b26cefd
+      - 99d75f37-f22b-40b3-a40d-a3ad104120d1
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "940"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:07:52 GMT
+      - Mon, 18 Dec 2023 12:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0d62bca-7e10-43d5-9a01-e883c41059d6
+      - 21ee381c-e977-4034-9e81-619a2ea208d2
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "940"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:22 GMT
+      - Mon, 18 Dec 2023 12:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25fea8b7-1f05-4631-aef3-96ec09218a3a
+      - c4a36708-e8d5-47c4-93be-010cb1bd7c5f
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "774"
+      - "1204"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:08:52 GMT
+      - Mon, 18 Dec 2023 13:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f02f6ee0-b109-4821-bb0d-13e4ecbd6927
+      - 42867018-a840-4a2c-afa7-034f6f14022e
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1038"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:23 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c97ba98c-42ef-4abe-b1ff-16a4bf82caf5
+      - 32bc2592-c2eb-43c6-8ccc-38f6400fc5a0
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464},"endpoints":[{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464}],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVRFRqZUJDajJWVE5Zd29tcGxMc3RQQWcwQXRvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEl4T0RFeU5UazFNMW9YRFRNek1USXhOVEV5TlRrMU0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQWxDVytuU3JzZFJEdkp5ZElQL2FweGVKVmVYVi9FdzFINUxLdWFRMi9mTkxWVFdnYzh4K0sKNjNSTENLeHJtVjdVNXVkMlRhRzBtTlYxRDd2cVhNOFVEc3Q2U2hjdFlyVEtVRUd0Qk51eE5COFFkVWdsc2pxOApHSisxY3h0M2FTVk0rR3ROVmJwVXhabktLbkV6aFBGaFZTME1mMjlVbFZ3TVBhMkwySEJ1NHZDTjlFTU5KVjAvCkdES1BYTG40anBPYmpTNC9zeVlQeGZRaDNlbEFKUEc2UG5jQ1RETGNkOEZUUXNNNzc3aDl5YjdSb01BdXFodWEKdFpROGtvRW03TFNYUEtNcjdxVTR5djNIUDRqeVJ1cGJDKzl0QUJlMVRENUlSK05yelBrQ0hYbFYyZkU5MUxsTwpYTDlOL1pXYitBYXU2YjNzNDhIalh2RVZCMkVuN1p2eEl3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHhNVE11TVRjemdqeHlkeTFtTURSaE5tTTJNQzFqWW1VMkxUUTVNemd0WWpVeU1TMHcKWVRWbU5XWTFNemMyWXpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHhNVE11TVRjegpnanh5ZHkxbU1EUmhObU0yTUMxalltVTJMVFE1TXpndFlqVXlNUzB3WVRWbU5XWTFNemMyWXpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3A2NkhCRE9mY2EySEJET2ZjYTB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFHSGUzQ0VuYkxzVnluZEdMRmp1bSsyejhlc0k1ZnBYL0o1V05hNmtOYkx0VC9ZQjRkZlpPL2pBakFLdgpQK1dLd2k1d1V0eW1PckRvQ1Zkd3dITEZCazZzTWN6d3l4YUNWeko0OEtqdldyVHpOclFGMDhFeWxRUmkrUm5jCkRIZUppdGs5dUJFUEVxRWIzMTVDdE9NbVg0S3lRVjNDYXNxeFFBOHZYS2hZbWZpVmdoMEFZZ3Z4d1NDRUJ6YjcKOWUzYUtZMnhVb0RZVEthVVZsSExIUSt1dTZzRGZGc0IrUi8vRlRSemZPSVFQZTdjOTY5bTF4bmFkdU5WOEJCRQoydndYSnZGS05ucll4d2FBRUVKZUJtczF6NHVFY3hvTytUN3hhOGY3NmhyNzVHUlQ3RDVlTVNTZVVGY3RxYXAvClBUaUpuMnhEQTdURDU2N2hTTHZFc2ZSTW85bz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1247"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:53 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 911e1118-436a-48f6-b2a2-c0b3c944130d
+      - e466bed3-fc22-4792-bf1a-da357b79305a
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f04a6c60-cbe6-4938-b521-0a5f5f5376c6&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXRQc0JBemR2RGhROFozMEJBYzQ1MnE2TlM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZd09UQTNXaGNOTXpNeE1URTRNVFl3T1RBM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBqYzZCWHMrQVpQNzRqQlVsQVJVRGIwL1ltUkErWmJ4QURpaS9qMTUrZDhlUmw3QVRuMkZ1akcKY29DdGh5TXRNbFNnRy9HVWQ1RVB1NFZsaWJXVVpDcmlLa2RrcEtRQ1JSWFJmUVc0NnBSeGZQejV3RTNOWnZRWApFM04xSlZ0VjgrOUdKQU1sb0x4MTExbk9qVlBXSlRnRDRnR05JS1Z0V0ZrbmJHRWxMcGdCMk8xOEFaY1c2MjFRCm43YldSTTRHbjhxN2NScG1id21VdEdIb1o1MFdsQVJvU2pSMFVsTDlreXdwQWpDdzM1Rm1EVTdTTzVldHo4bTYKS0JBRjkycjdCVWRCNzJ5Vm1ad3dJMU1LZkQxeFFBa0NNN3lJa0s4TjdOTzVMYTVraDNneDdPZ3U1UjhTdnBTaApRaFlXc2MwQjM4N21HdFJLMFJzUGlVK2dtM05lUGhjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0T0RFMVpqVTNNekV0TnpJeFl5MDBaalF4TFdGa01qSXROR1ZqTW1KbE0yVm0KTkRnMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmt1bmh3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVR5N0ZrVnRnYnNBb2RkUFh2RkExWVd5Nk5OT3VPUmdiOWZEaURhZ2pkTGNEMHBFZElKZFdtCm44d21PRDJqWHZLcW9CR3Y5SmJpL2tvbkhNTHUwTjI0WlR2SkwydHArSHpzTVdDaDdZTXFOTmJUNjlZcFZTaWsKamhtZUFoT0pnazZnTHkxTEI3M1ZiWC84ZThxWGRERm1WY0g0ZkJYS2RkWFd6ZjVkcjZTdVhuVFRyYk0vNWhRbQpTeFhUYlEzcnBEUS9keFE2MkJYYzJGY1Y5d2t3aDhzcEc3TitJYlNWN3U1Ti9SeTMyeGRVdDcydHRjL2lGcnNBClRmMWNJTWR3WjFpU3B2dGFueWg4a2I4MFdlQ0dJYnVSVEhzcUJESkNubFRNVXMrQ1gzZWY2RXpiR1A5dzdsbmwKdzRmUm1qU0pQSEdVWmJjWmFDMUg0UUQxbjRYU0VyYVEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1843"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:53 GMT
+      - Mon, 18 Dec 2023 13:00:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,12 +761,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1196280e-85b0-4128-8814-76917f02ca3f
+      - 9939e14d-744a-4cf7-ace9-f62084ca8c11
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"815f5731-721c-4f41-ad22-4ec2be3ef485","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
+    body: '{"instance_id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -744,7 +777,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "331"
@@ -753,7 +786,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:54 GMT
+      - Mon, 18 Dec 2023 13:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ce9ce9d-19ff-483b-a0e0-b50c462fc93d
+      - 11f01b91-7ecf-4c19-adbb-437f6bf90d69
     status: 200 OK
     code: 200
     duration: ""
@@ -774,10 +807,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "331"
@@ -786,7 +819,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:09:54 GMT
+      - Mon, 18 Dec 2023 13:00:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36cd029b-4e1b-403e-b30f-73b5d859e5f5
+      - e1cac989-e8aa-4a2a-921e-d0376fef3ac9
     status: 200 OK
     code: 200
     duration: ""
@@ -807,10 +840,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "331"
@@ -819,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:10:24 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf967523-9c96-40e6-802a-8189f9f2d07e
+      - aae9dae6-0cc5-4242-a230-afd07e84dae6
     status: 200 OK
     code: 200
     duration: ""
@@ -840,10 +873,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "331"
@@ -852,7 +885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:10:54 GMT
+      - Mon, 18 Dec 2023 13:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6870a0b4-0f4b-4c79-b495-8d7aa038a732
+      - 4b2db198-1195-45c4-b210-7d1cfddd0188
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +906,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "443"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:11:24 GMT
+      - Mon, 18 Dec 2023 13:02:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10b033b8-03ca-411e-93b9-9d2e2ff85c80
+      - e2a86822-6468-48c8-948a-28747eec3207
     status: 200 OK
     code: 200
     duration: ""
@@ -906,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "443"
+      - "331"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:11:54 GMT
+      - Mon, 18 Dec 2023 13:02:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d29ff11-2ec9-40d5-a74e-aff41e8aa70c
+      - a08c3640-83db-4790-8b6c-27d60b39264c
     status: 200 OK
     code: 200
     duration: ""
@@ -939,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "436"
+      - "442"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:24 GMT
+      - Mon, 18 Dec 2023 13:03:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44294e4f-d891-42c5-a7f3-4038c4777f8c
+      - fde18d3b-6f3f-4c7b-bb0f-e84a3219149a
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "436"
+      - "442"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:24 GMT
+      - Mon, 18 Dec 2023 13:03:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b681207-055b-4ed1-a84b-d9b263ed13a9
+      - 0a007192-932c-442e-a004-1f2deda673bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "436"
+      - "442"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:25 GMT
+      - Mon, 18 Dec 2023 13:04:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aae8c777-a283-4033-addd-659627b63110
+      - ef3b387b-228b-4535-afb0-d67cd47de656
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/99ac85d5-336f-442b-a9d5-90b3e0c7745c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:06:21.420340Z","dhcp_enabled":true,"id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","name":"tf-pn-silly-wright","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:06:21.420340Z","id":"6f8ef234-8276-444c-856d-8c44576c6810","subnet":"172.16.56.0/22","updated_at":"2023-11-21T16:06:21.420340Z"},{"created_at":"2023-11-21T16:06:21.420340Z","id":"054da6c9-838c-487b-a591-65e9ab3f61b4","subnet":"fd5f:519c:6d46:d19b::/64","updated_at":"2023-11-21T16:06:21.420340Z"}],"tags":[],"updated_at":"2023-11-21T16:06:21.420340Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "702"
+      - "435"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:25 GMT
+      - Mon, 18 Dec 2023 13:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ef3c4de-eaf7-4165-87c0-625a52a03b82
+      - 1423b6c2-e579-4022-8d61-77317341a69a
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464},"endpoints":[{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464}],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1683"
+      - "435"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:25 GMT
+      - Mon, 18 Dec 2023 13:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3982583-8f8f-4a2b-b2dd-9205fc07960c
+      - daf5bc04-5b96-492f-ac9c-a9b89dd95726
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVSXRQc0JBemR2RGhROFozMEJBYzQ1MnE2TlM4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZd09UQTNXaGNOTXpNeE1URTRNVFl3T1RBM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQVBqYzZCWHMrQVpQNzRqQlVsQVJVRGIwL1ltUkErWmJ4QURpaS9qMTUrZDhlUmw3QVRuMkZ1akcKY29DdGh5TXRNbFNnRy9HVWQ1RVB1NFZsaWJXVVpDcmlLa2RrcEtRQ1JSWFJmUVc0NnBSeGZQejV3RTNOWnZRWApFM04xSlZ0VjgrOUdKQU1sb0x4MTExbk9qVlBXSlRnRDRnR05JS1Z0V0ZrbmJHRWxMcGdCMk8xOEFaY1c2MjFRCm43YldSTTRHbjhxN2NScG1id21VdEdIb1o1MFdsQVJvU2pSMFVsTDlreXdwQWpDdzM1Rm1EVTdTTzVldHo4bTYKS0JBRjkycjdCVWRCNzJ5Vm1ad3dJMU1LZkQxeFFBa0NNN3lJa0s4TjdOTzVMYTVraDNneDdPZ3U1UjhTdnBTaApRaFlXc2MwQjM4N21HdFJLMFJzUGlVK2dtM05lUGhjQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0T0RFMVpqVTNNekV0TnpJeFl5MDBaalF4TFdGa01qSXROR1ZqTW1KbE0yVm0KTkRnMUxuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bmt1bmh3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQVR5N0ZrVnRnYnNBb2RkUFh2RkExWVd5Nk5OT3VPUmdiOWZEaURhZ2pkTGNEMHBFZElKZFdtCm44d21PRDJqWHZLcW9CR3Y5SmJpL2tvbkhNTHUwTjI0WlR2SkwydHArSHpzTVdDaDdZTXFOTmJUNjlZcFZTaWsKamhtZUFoT0pnazZnTHkxTEI3M1ZiWC84ZThxWGRERm1WY0g0ZkJYS2RkWFd6ZjVkcjZTdVhuVFRyYk0vNWhRbQpTeFhUYlEzcnBEUS9keFE2MkJYYzJGY1Y5d2t3aDhzcEc3TitJYlNWN3U1Ti9SeTMyeGRVdDcydHRjL2lGcnNBClRmMWNJTWR3WjFpU3B2dGFueWg4a2I4MFdlQ0dJYnVSVEhzcUJESkNubFRNVXMrQ1gzZWY2RXpiR1A5dzdsbmwKdzRmUm1qU0pQSEdVWmJjWmFDMUg0UUQxbjRYU0VyYVEKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1843"
+      - "435"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:25 GMT
+      - Mon, 18 Dec 2023 13:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3911bc3-86f8-42e2-894f-9418f45a065d
+      - 39a49191-b3d6-406b-8e5e-1fb460b6b804
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/99658be3-f4fc-45d0-b773-bc6086ed8d86
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2023-12-18T12:57:07.171263Z","dhcp_enabled":true,"id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","name":"tf-pn-vigorous-black","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:57:07.171263Z","id":"ffa583fc-6d58-40ba-b021-55e2e8ee314c","subnet":"172.16.32.0/22","updated_at":"2023-12-18T12:57:07.171263Z"},{"created_at":"2023-12-18T12:57:07.171263Z","id":"e8f34fcf-f8a9-45cb-b0c8-e7bbc2f3ffd6","subnet":"fd5f:519c:6d46:ad6c::/64","updated_at":"2023-12-18T12:57:07.171263Z"}],"tags":[],"updated_at":"2023-12-18T12:57:07.171263Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "436"
+      - "704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:26 GMT
+      - Mon, 18 Dec 2023 13:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edf79136-d25f-4cdc-b5b3-0d7a5f301b3b
+      - de8c9057-8252-4967-a697-d1f22ec136c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "436"
+      - "1684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:27 GMT
+      - Mon, 18 Dec 2023 13:04:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7018e335-61b2-4f16-a1e8-9ac3677cb758
+      - d114c222-ad90-404a-a214-c117b103a073
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1236,151 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVRFRqZUJDajJWVE5Zd29tcGxMc3RQQWcwQXRvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR4TVRNdU1UY3pNQjRYCkRUSXpNVEl4T0RFeU5UazFNMW9YRFRNek1USXhOVEV5TlRrMU0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHhNVE11TVRjek1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQWxDVytuU3JzZFJEdkp5ZElQL2FweGVKVmVYVi9FdzFINUxLdWFRMi9mTkxWVFdnYzh4K0sKNjNSTENLeHJtVjdVNXVkMlRhRzBtTlYxRDd2cVhNOFVEc3Q2U2hjdFlyVEtVRUd0Qk51eE5COFFkVWdsc2pxOApHSisxY3h0M2FTVk0rR3ROVmJwVXhabktLbkV6aFBGaFZTME1mMjlVbFZ3TVBhMkwySEJ1NHZDTjlFTU5KVjAvCkdES1BYTG40anBPYmpTNC9zeVlQeGZRaDNlbEFKUEc2UG5jQ1RETGNkOEZUUXNNNzc3aDl5YjdSb01BdXFodWEKdFpROGtvRW03TFNYUEtNcjdxVTR5djNIUDRqeVJ1cGJDKzl0QUJlMVRENUlSK05yelBrQ0hYbFYyZkU5MUxsTwpYTDlOL1pXYitBYXU2YjNzNDhIalh2RVZCMkVuN1p2eEl3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHhNVE11TVRjemdqeHlkeTFtTURSaE5tTTJNQzFqWW1VMkxUUTVNemd0WWpVeU1TMHcKWVRWbU5XWTFNemMyWXpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHhNVE11TVRjegpnanh5ZHkxbU1EUmhObU0yTUMxalltVTJMVFE1TXpndFlqVXlNUzB3WVRWbU5XWTFNemMyWXpZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3A2NkhCRE9mY2EySEJET2ZjYTB3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFHSGUzQ0VuYkxzVnluZEdMRmp1bSsyejhlc0k1ZnBYL0o1V05hNmtOYkx0VC9ZQjRkZlpPL2pBakFLdgpQK1dLd2k1d1V0eW1PckRvQ1Zkd3dITEZCazZzTWN6d3l4YUNWeko0OEtqdldyVHpOclFGMDhFeWxRUmkrUm5jCkRIZUppdGs5dUJFUEVxRWIzMTVDdE9NbVg0S3lRVjNDYXNxeFFBOHZYS2hZbWZpVmdoMEFZZ3Z4d1NDRUJ6YjcKOWUzYUtZMnhVb0RZVEthVVZsSExIUSt1dTZzRGZGc0IrUi8vRlRSemZPSVFQZTdjOTY5bTF4bmFkdU5WOEJCRQoydndYSnZGS05ucll4d2FBRUVKZUJtczF6NHVFY3hvTytUN3hhOGY3NmhyNzVHUlQ3RDVlTVNTZVVGY3RxYXAvClBUaUpuMnhEQTdURDU2N2hTTHZFc2ZSTW85bz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 90e180db-8f0e-4ba6-bf5f-e1ab716b5fbf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f04a6c60-cbe6-4938-b521-0a5f5f5376c6&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bdb9fa37-92a8-4df5-b296-5ef461923965
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "435"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d23e4785-b4e7-4b0a-8574-c60c48734a19
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "435"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:04:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce2e3917-e3f8-4f79-9a59-a9731e4d2fe5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "439"
+      - "438"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:27 GMT
+      - Mon, 18 Dec 2023 13:04:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c97e86b6-6ce5-4afd-b9c6-09b80f9912de
+      - 2a5cb04b-3ed7-4aa6-a336-b7bfd8760d7a
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"4ce588b9-0443-4865-a306-2440b7b14e5b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99ac85d5-336f-442b-a9d5-90b3e0c7745c","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"852df45f-d1a0-4ca0-8faa-209871c7ed1b","ip":"163.172.167.207","name":null,"port":5432}],"id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"af4fa0da-ac17-4da9-86e6-9b4782690e84","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"99658be3-f4fc-45d0-b773-bc6086ed8d86","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"feadd946-a429-4250-9012-9803f4cf8108","ip":"212.47.253.181","name":null,"port":5432}],"id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "439"
+      - "438"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:27 GMT
+      - Mon, 18 Dec 2023 13:04:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 961489b1-7923-42ff-8874-0543a7443546
+      - 943ae877-bb1b-4f33-9574-55a6d8053c79
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,10 +1434,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1281,7 +1446,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:59 GMT
+      - Mon, 18 Dec 2023 13:05:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91f5b0aa-a867-4662-b5a8-f40931dd5298
+      - 67851ef5-7ace-4d36-854a-7448eecce689
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1302,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464},"endpoints":[{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464}],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1249"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:59 GMT
+      - Mon, 18 Dec 2023 13:05:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ea61082-88ec-4859-b8d5-162572800d3b
+      - 6a5aed30-d6df-44be-a405-57f723d9da49
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,17 +1500,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/99ac85d5-336f-442b-a9d5-90b3e0c7745c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: DELETE
   response:
-    body: ""
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
+      Content-Length:
+      - "1252"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:12:59 GMT
+      - Mon, 18 Dec 2023 13:05:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1522,71 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a589f33-3e29-459c-8759-3356bdbacd9a
+      - 81e3fcd1-4cab-445f-a52c-2077b519f5cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.416161Z","endpoint":{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728},"endpoints":[{"id":"ce1a73d3-70b7-4f70-9432-f1d43782487c","ip":"51.159.113.173","load_balancer":{},"name":null,"port":12728}],"engine":"PostgreSQL-15","id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1252"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:13 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fcc6eb8b-ce4f-48f6-b03a-50c5e6b59eda
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/99658be3-f4fc-45d0-b773-bc6086ed8d86
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eabc1e4d-e6ce-499a-9c15-0d3158317351
     status: 204 No Content
     code: 204
     duration: ""
@@ -1366,76 +1597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464},"endpoints":[{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464}],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1250"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:13:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6511e88c-d0b6-4db9-93e4-327a31f72166
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:06:21.670666Z","endpoint":{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464},"endpoints":[{"id":"a31155e6-5d62-458b-891e-73388d02e9ae","ip":"51.159.26.205","load_balancer":{},"name":null,"port":24464}],"engine":"PostgreSQL-15","id":"815f5731-721c-4f41-ad22-4ec2be3ef485","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1250"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:13:00 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01668cef-f6fe-48f6-8b00-9e34c6350096
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"815f5731-721c-4f41-ad22-4ec2be3ef485","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1444,7 +1609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:30 GMT
+      - Mon, 18 Dec 2023 13:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed5680c4-d9da-40dc-a1cb-0a4ce6142528
+      - 5c5db97a-7ab2-4415-9590-ea3aaa30f050
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1465,10 +1630,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/815f5731-721c-4f41-ad22-4ec2be3ef485
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f04a6c60-cbe6-4938-b521-0a5f5f5376c6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"815f5731-721c-4f41-ad22-4ec2be3ef485","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"f04a6c60-cbe6-4938-b521-0a5f5f5376c6","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1477,7 +1642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:30 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aba2665c-34c2-4fab-99c6-1e4980cd582b
+      - 9b905542-6631-4434-a2f9-0e2400f2aa1b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1498,10 +1663,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f710fb1-9e9c-4824-b744-ebd1c7670bc9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"ecc8bd10-98c8-4eeb-a69c-0b2d1c7cd46d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"9f710fb1-9e9c-4824-b744-ebd1c7670bc9","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1510,7 +1675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:13:30 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c59f5751-cbb2-4d7d-8703-40f5a28fb92d
+      - fa236505-c865-4a2f-9e70-f8af58bdbff0
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:01 GMT
+      - Mon, 18 Dec 2023 12:57:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,47 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 331ba008-215d-4a86-b5fc-f1b7ce524a04
+      - 1ac9d23a-d8f7-4eee-932c-1a92c1b7a594
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
-    method: POST
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "758"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:14:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cd9a76a0-5984-4c4e-9dcc-4295063c9652
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-pn-objective-leavitt","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"tf-pn-exciting-cohen","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -379,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T16:14:38.965066Z","dhcp_enabled":true,"id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","name":"tf-pn-objective-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:14:38.965066Z","id":"8dae6fb1-3d86-48da-a96d-9239ad3cfd07","subnet":"172.16.44.0/22","updated_at":"2023-11-21T16:14:38.965066Z"},{"created_at":"2023-11-21T16:14:38.965066Z","id":"03a56f34-17db-40b3-8a80-eed1816d763c","subnet":"fd5f:519c:6d46:4580::/64","updated_at":"2023-11-21T16:14:38.965066Z"}],"tags":[],"updated_at":"2023-11-21T16:14:38.965066Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:07:53.443624Z","dhcp_enabled":true,"id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","name":"tf-pn-exciting-cohen","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:07:53.443624Z","id":"fa233d3d-2c9f-4011-b42e-5e99e311b864","subnet":"172.16.120.0/22","updated_at":"2023-12-18T13:07:53.443624Z"},{"created_at":"2023-12-18T13:07:53.443624Z","id":"de18d81a-e0cd-4cca-9bc3-8ad6d2d64a4c","subnet":"fd5f:519c:6d46:f4d8::/64","updated_at":"2023-12-18T13:07:53.443624Z"}],"tags":[],"updated_at":"2023-12-18T13:07:53.443624Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "707"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:39 GMT
+      - Mon, 18 Dec 2023 13:07:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -398,7 +363,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b62d9750-6629-4c07-8def-35eb46445db4
+      - 1c3a259a-b1d3-4534-8c45-0d12f6eb9e6c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
+    method: POST
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "924"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:07:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 10c1a851-5b6f-4fb6-92fe-2d82080bb94e
     status: 200 OK
     code: 200
     duration: ""
@@ -409,19 +409,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/feab5f51-efa0-43fb-9a75-e2b1843ac3fe
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2023-12-18T13:07:53.443624Z","dhcp_enabled":true,"id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","name":"tf-pn-exciting-cohen","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:07:53.443624Z","id":"fa233d3d-2c9f-4011-b42e-5e99e311b864","subnet":"172.16.120.0/22","updated_at":"2023-12-18T13:07:53.443624Z"},{"created_at":"2023-12-18T13:07:53.443624Z","id":"de18d81a-e0cd-4cca-9bc3-8ad6d2d64a4c","subnet":"fd5f:519c:6d46:f4d8::/64","updated_at":"2023-12-18T13:07:53.443624Z"}],"tags":[],"updated_at":"2023-12-18T13:07:53.443624Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "758"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:39 GMT
+      - Mon, 18 Dec 2023 13:07:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54b2fdc8-e4af-44a1-898a-e0c31391ba6b
+      - 6bdf6cfa-8d56-4473-aeaa-9b1b1d98a71e
     status: 200 OK
     code: 200
     duration: ""
@@ -442,19 +442,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b45e72a7-fd30-4be0-a06b-0e654034cd54
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:14:38.965066Z","dhcp_enabled":true,"id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","name":"tf-pn-objective-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:14:38.965066Z","id":"8dae6fb1-3d86-48da-a96d-9239ad3cfd07","subnet":"172.16.44.0/22","updated_at":"2023-11-21T16:14:38.965066Z"},{"created_at":"2023-11-21T16:14:38.965066Z","id":"03a56f34-17db-40b3-8a80-eed1816d763c","subnet":"fd5f:519c:6d46:4580::/64","updated_at":"2023-11-21T16:14:38.965066Z"}],"tags":[],"updated_at":"2023-11-21T16:14:38.965066Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "707"
+      - "924"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:39 GMT
+      - Mon, 18 Dec 2023 13:07:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc51b6c2-e774-4a10-aeba-c0a28e806f61
+      - b5390fb5-5a3e-4438-921d-17b2a87e28ef
     status: 200 OK
     code: 200
     duration: ""
@@ -475,19 +475,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "924"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:09 GMT
+      - Mon, 18 Dec 2023 13:08:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c805c445-5bd0-48ca-8f59-5c6f6a8db67d
+      - c686353f-88ad-4809-82a3-03e7d6f57b33
     status: 200 OK
     code: 200
     duration: ""
@@ -508,19 +508,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "924"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:40 GMT
+      - Mon, 18 Dec 2023 13:08:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3956d7e-ca34-4f96-b49f-91360a708838
+      - f62c4903-6714-4dde-9579-1cc27d92022c
     status: 200 OK
     code: 200
     duration: ""
@@ -541,19 +541,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "924"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:10 GMT
+      - Mon, 18 Dec 2023 13:09:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c8bea64-1ef2-43cd-a658-4cc7c1f17967
+      - 74417d51-1c6d-4129-bdcb-3955c65e2511
     status: 200 OK
     code: 200
     duration: ""
@@ -574,19 +574,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "924"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:40 GMT
+      - Mon, 18 Dec 2023 13:09:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd8bb9a7-1c63-4486-9c28-6b7a14613c1f
+      - 5e99cb93-b2ab-4949-b97f-3596c211b653
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +607,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "758"
+      - "924"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:10 GMT
+      - Mon, 18 Dec 2023 13:10:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca199765-64ec-443c-900b-0121eb1416bf
+      - bc7523f6-20f4-491c-b319-978feaa1e704
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302},"endpoints":[{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302}],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "924"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:40 GMT
+      - Mon, 18 Dec 2023 13:10:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36c29f5e-b1e6-4264-b3a4-158906f87847
+      - 20df1e11-c008-4567-9a41-dd0682604802
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVZkJmTmdHeDJOMDVpQTk5Z1V5aU54WWlva1BZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpFM01qRmFGdzB6TXpFeE1UZ3hOakUzTWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMvMUUvNEoycVBtbkZ4MzluUk52VyszZmNxYXhncElpM2JIaXlkbkdxYmV4TGhkT1dTSHo3Zi80bjgKMjFuWHZLdEU4Zjdpc0kvbllFSXAzUHdEd1Jhb2h4bWxEZkkyNjN0VTU5YmR3VVdZUVNvN2N3dFUwcEZTaVNKSQpreXlNSjB1UG9udGdJSk1mSGpjWDlwanJWMHgrVVRVUlZ4R1NrVHFkTFFTQkE5WHhnRkNaYjZ0cHBvOU9HMmNFCjk2b1lJaUExRzZ0T1NKNVlQUEVwZmtadlNlajI5MmY2d1VQV0NOQjFyTHNYeVpJUGdCZEVJaStCVGp1amdpeEcKalUrNkFCcmVjTnNndFNVVllGWmZHOVpzdmFkd1VIRjFkcHJZQmg2NjNabkg3ak5hUFJCeE1qcGpBcW5qb3FoSQo2WDhYcXdmYVJYcitBVUM3YW9KT0Q2dnBsMlluQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RaR1pqWW1ZeE9UQXROVGd4WmkwME5qUXpMV0k1WW1NdE1qVXlOR1U1WkRNeU1ESXkKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySUs5aHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFCVHBwNDlEakVFeEY4S0xISTVMUktBYVVLNU5FSHpjeHZ5K0svMSs0ZlhucHZCVkdaYUxnUVRlUm91CldMVVExQUFDQkorbERtdjdjcDFNeWQ4Uk9KWE96bTh5eWsrTnhOWlVYb0s0TEM2TzVINFozQXgxL09ndWlJVFUKMUkrZzI5UndVOVZWR2NYdDQ3ZVNXekpGS2dHekd3c3psMVdsSHVaR09yQnE4SlYvREhEOVVHRi9XTkVoSVYzRQpkS1BjTmNIbGI0ZFJUV2duMDlUSVVLVCtEam5ja1U2bVBMa0x5TE9KUGRjVmZobFdQQTBMYjNpbFBYN1FJMVIyClRTWVRXd3k1cS9ZMmJlYzRxKzVSYmpSMzRZb3BrZmlkM3pSK1RubVdWUEhXbFMyOElXMk4rUlg0a1R5OTJwbjkKVkc5eWNqc2lPOW5tWDFxN0NZaUhQWllWcTNGdQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1839"
+      - "1188"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:40 GMT
+      - Mon, 18 Dec 2023 13:11:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,12 +695,111 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3179c0b-33bc-4ef2-9803-e7f9ed1c17f8
+      - 5a071823-233b-4f21-9955-5ff12e0b05d7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"dfcbf190-581f-4643-b9bc-2524e9d32022","endpoint_spec":[{"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1233"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:55 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9868f07a-da26-4401-afa7-fbe2464b7ed6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVY3ZwT1RJckc4aWNqcFc0ODhrbnM0NXg4ZUhBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXhNak5hRncwek16RXlNVFV4TXpFeE1qTmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzFIZjZocWNBYmUzUExvM2FHQnVjTUlzaFNueFkxaFNhVStsT0xmQmF4ajlING4zbVAKWlM0dENvMUhOZlNqMHZhK094ZjU3Wmdoa3lJeWxDTEc1T3FweU82RVZtOHlya1lLdVNDNFdVUDl5bmRvRjkxZQp6M0lZbzBUT2xEaEtlZGNGbXBKSnJvK1FXc3BoSnBpak5LWEVHM1NXTjNDcFpPM0hSZlU1QmNrQ2hZK1JDamR4CmR6ZXRQMDYwMDRaUnN0czMyQ1d6TUdLbGg1bW0wbzZSZmtsRGQ4K0lTQ2NkUnJHVjVqKzVxY28rejRvQ3BVaC8KQktJLzJ3NHFEUng4Z1hzTlArY2c4RUQxWFNBbEh3MkpGUnR1Q3E3NVdYdnB1aWZXdmp6RmN1eU1qM2l3b3c0VAo4MS9VTmw5dE1VbFVidCtDUXE2MmROM2YxUkRNK0RzK0dXTEpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxak5UTXlaVE16TmkweVpqYzJMVFF6WWpZdE9HUTQKTlMxaE1HVTROakJoT1RJeVl6QXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RZelV6TW1Vek16WXRNbVkzTmkwME0ySTJMVGhrT0RVdFlUQmxPRFl3WVRreU1tTXdMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpENHFsaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNqbDl2NFlyNGZxdndXc1RDUEFHaUI2OUk1TFNKM0JoUytrdVN0WmFkY1p4QldKeFlDczJVOAoxYTI5cTh5WE9RQ3lQTnRJN0FFOGUrUHFPblN6aFJ5R0hvOW1XVkx4Vy9zQWE4eTFuOHVudkN2UC8xQS9xb21IClhFRll3VXBqTzVvZUZrVnJFOXJ0dUhMbDV1aGNVMnlHbXd3VnpEZW1yQ2trL01ldDR5bVI0TFdwaWt5RURnM1kKTVlOdXVWQWJ0QkNJVGNzNG55NnZOMWpBM3B0Sy9hNmFpK0tYS3pxcm9hRVkyNHNxMmJPTjZES1lLYjh6WGlwZgpib2ZVRlEwRkxlbzVmMno1cXFRa3FWMUZ5MURETldySGluVzE3T3lzdktaUEhwWDJjazBvNnc3TWpVNGQ1NzJ4Clp6eFlNNjJLc0t5RjB1alNXWUJ2WjRjL29qRjd4WG04Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2015"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 014ce44e-ebe2-4e12-8331-9fcba86ba3bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c532e336-2f76-43b6-8d85-a0e860a922c0&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:11:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bd1e3ee6-ff12-4446-83fe-8e31c1fb7703
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"c532e336-2f76-43b6-8d85-a0e860a922c0","endpoint_spec":[{"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -711,7 +810,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "331"
@@ -720,7 +819,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:41 GMT
+      - Mon, 18 Dec 2023 13:11:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -730,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5db96f6-10c4-4a51-99da-d34d683ccb67
+      - 232b6998-9b96-4e2e-89de-385103264370
     status: 200 OK
     code: 200
     duration: ""
@@ -741,10 +840,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "331"
@@ -753,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:42 GMT
+      - Mon, 18 Dec 2023 13:11:57 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2da5252e-2790-48d9-9a51-79261c38590c
+      - 8bc18a96-7582-4f87-869d-4a6919c4de46
     status: 200 OK
     code: 200
     duration: ""
@@ -774,10 +873,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "331"
@@ -786,7 +885,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:12 GMT
+      - Mon, 18 Dec 2023 13:12:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb35022c-26f8-4de0-a2c8-815e51d07510
+      - 04eae8e8-0af5-48c9-b611-fae52bb74fc1
     status: 200 OK
     code: 200
     duration: ""
@@ -807,10 +906,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "331"
@@ -819,7 +918,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:42 GMT
+      - Mon, 18 Dec 2023 13:12:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b485e878-1ef8-47d0-9aad-7e98e91f760d
+      - 7c3e235c-d701-4352-909c-eeb2162c033f
     status: 200 OK
     code: 200
     duration: ""
@@ -840,10 +939,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "331"
@@ -852,7 +951,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:12 GMT
+      - Mon, 18 Dec 2023 13:13:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c1a0f33-5fce-4e3f-8f8b-8c87dab4d588
+      - e54cbcd3-2d96-4ea1-9eb7-af46cdb39b19
     status: 200 OK
     code: 200
     duration: ""
@@ -873,10 +972,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "331"
@@ -885,7 +984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:42 GMT
+      - Mon, 18 Dec 2023 13:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9053cdc7-7882-4122-875c-59f64eca236f
+      - 7e022146-ccb1-47fb-98f4-d47ef8289fc6
     status: 200 OK
     code: 200
     duration: ""
@@ -906,76 +1005,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"initializing"}'
-    headers:
-      Content-Length:
-      - "331"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:20:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5a191cf9-dba1-41ca-906c-adfd4438bebe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"initializing"}'
-    headers:
-      Content-Length:
-      - "331"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:20:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d9cc137e-3f7c-4ce0-9ed6-577a7987273a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -984,7 +1017,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:12 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e23dd0f-7801-4307-a512-b9251e2c52c9
+      - bed1fcea-610b-4094-93aa-a09f354554f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,10 +1038,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1017,7 +1050,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:12 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f1cd226-5183-411c-bdb8-678fb34716ad
+      - 135beeff-1771-4894-a7ff-e5fc780636b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,10 +1071,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1050,7 +1083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:12 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c4c29d7-77b9-4537-ac5a-dd6cd90ad07f
+      - bc6ad6c0-693e-41ea-8745-7a8407c6c93d
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b45e72a7-fd30-4be0-a06b-0e654034cd54
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/feab5f51-efa0-43fb-9a75-e2b1843ac3fe
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:14:38.965066Z","dhcp_enabled":true,"id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","name":"tf-pn-objective-leavitt","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:14:38.965066Z","id":"8dae6fb1-3d86-48da-a96d-9239ad3cfd07","subnet":"172.16.44.0/22","updated_at":"2023-11-21T16:14:38.965066Z"},{"created_at":"2023-11-21T16:14:38.965066Z","id":"03a56f34-17db-40b3-8a80-eed1816d763c","subnet":"fd5f:519c:6d46:4580::/64","updated_at":"2023-11-21T16:14:38.965066Z"}],"tags":[],"updated_at":"2023-11-21T16:14:38.965066Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:07:53.443624Z","dhcp_enabled":true,"id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","name":"tf-pn-exciting-cohen","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:07:53.443624Z","id":"fa233d3d-2c9f-4011-b42e-5e99e311b864","subnet":"172.16.120.0/22","updated_at":"2023-12-18T13:07:53.443624Z"},{"created_at":"2023-12-18T13:07:53.443624Z","id":"de18d81a-e0cd-4cca-9bc3-8ad6d2d64a4c","subnet":"fd5f:519c:6d46:f4d8::/64","updated_at":"2023-12-18T13:07:53.443624Z"}],"tags":[],"updated_at":"2023-12-18T13:07:53.443624Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "707"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:13 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6419833d-a4ea-479c-a6e9-781e82b107d2
+      - 65ace703-5270-4d3b-a180-83fce69a85b8
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302},"endpoints":[{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302}],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1551"
+      - "1557"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:13 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 807459f2-a340-42fa-8c31-abb672822e88
+      - 73428415-ada1-4afe-a588-087a0618edf2
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURvVENDQW9tZ0F3SUJBZ0lVZkJmTmdHeDJOMDVpQTk5Z1V5aU54WWlva1BZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzR4TVM0M01EQWVGdzB5Ck16RXhNakV4TmpFM01qRmFGdzB6TXpFeE1UZ3hOakUzTWpGYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU1URXVOekF3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMvMUUvNEoycVBtbkZ4MzluUk52VyszZmNxYXhncElpM2JIaXlkbkdxYmV4TGhkT1dTSHo3Zi80bjgKMjFuWHZLdEU4Zjdpc0kvbllFSXAzUHdEd1Jhb2h4bWxEZkkyNjN0VTU5YmR3VVdZUVNvN2N3dFUwcEZTaVNKSQpreXlNSjB1UG9udGdJSk1mSGpjWDlwanJWMHgrVVRVUlZ4R1NrVHFkTFFTQkE5WHhnRkNaYjZ0cHBvOU9HMmNFCjk2b1lJaUExRzZ0T1NKNVlQUEVwZmtadlNlajI5MmY2d1VQV0NOQjFyTHNYeVpJUGdCZEVJaStCVGp1amdpeEcKalUrNkFCcmVjTnNndFNVVllGWmZHOVpzdmFkd1VIRjFkcHJZQmg2NjNabkg3ak5hUFJCeE1qcGpBcW5qb3FoSQo2WDhYcXdmYVJYcitBVUM3YW9KT0Q2dnBsMlluQWdNQkFBR2paVEJqTUdFR0ExVWRFUVJhTUZpQ0REVXhMakUxCk9TNHhNUzQzTUlJOGNuY3RaR1pqWW1ZeE9UQXROVGd4WmkwME5qUXpMV0k1WW1NdE1qVXlOR1U1WkRNeU1ESXkKTG5Ka1lpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySUs5aHdRem53dEdNQTBHQ1NxR1NJYjNEUUVCQ3dVQQpBNElCQVFCVHBwNDlEakVFeEY4S0xISTVMUktBYVVLNU5FSHpjeHZ5K0svMSs0ZlhucHZCVkdaYUxnUVRlUm91CldMVVExQUFDQkorbERtdjdjcDFNeWQ4Uk9KWE96bTh5eWsrTnhOWlVYb0s0TEM2TzVINFozQXgxL09ndWlJVFUKMUkrZzI5UndVOVZWR2NYdDQ3ZVNXekpGS2dHekd3c3psMVdsSHVaR09yQnE4SlYvREhEOVVHRi9XTkVoSVYzRQpkS1BjTmNIbGI0ZFJUV2duMDlUSVVLVCtEam5ja1U2bVBMa0x5TE9KUGRjVmZobFdQQTBMYjNpbFBYN1FJMVIyClRTWVRXd3k1cS9ZMmJlYzRxKzVSYmpSMzRZb3BrZmlkM3pSK1RubVdWUEhXbFMyOElXMk4rUlg0a1R5OTJwbjkKVkc5eWNqc2lPOW5tWDFxN0NZaUhQWllWcTNGdQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVY3ZwT1RJckc4aWNqcFc0ODhrbnM0NXg4ZUhBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlNekV5TVRneE16RXhNak5hRncwek16RXlNVFV4TXpFeE1qTmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzFIZjZocWNBYmUzUExvM2FHQnVjTUlzaFNueFkxaFNhVStsT0xmQmF4ajlING4zbVAKWlM0dENvMUhOZlNqMHZhK094ZjU3Wmdoa3lJeWxDTEc1T3FweU82RVZtOHlya1lLdVNDNFdVUDl5bmRvRjkxZQp6M0lZbzBUT2xEaEtlZGNGbXBKSnJvK1FXc3BoSnBpak5LWEVHM1NXTjNDcFpPM0hSZlU1QmNrQ2hZK1JDamR4CmR6ZXRQMDYwMDRaUnN0czMyQ1d6TUdLbGg1bW0wbzZSZmtsRGQ4K0lTQ2NkUnJHVjVqKzVxY28rejRvQ3BVaC8KQktJLzJ3NHFEUng4Z1hzTlArY2c4RUQxWFNBbEh3MkpGUnR1Q3E3NVdYdnB1aWZXdmp6RmN1eU1qM2l3b3c0VAo4MS9VTmw5dE1VbFVidCtDUXE2MmROM2YxUkRNK0RzK0dXTEpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxak5UTXlaVE16TmkweVpqYzJMVFF6WWpZdE9HUTQKTlMxaE1HVTROakJoT1RJeVl6QXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RZelV6TW1Vek16WXRNbVkzTmkwME0ySTJMVGhrT0RVdFlUQmxPRFl3WVRreU1tTXdMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpENHFsaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNqbDl2NFlyNGZxdndXc1RDUEFHaUI2OUk1TFNKM0JoUytrdVN0WmFkY1p4QldKeFlDczJVOAoxYTI5cTh5WE9RQ3lQTnRJN0FFOGUrUHFPblN6aFJ5R0hvOW1XVkx4Vy9zQWE4eTFuOHVudkN2UC8xQS9xb21IClhFRll3VXBqTzVvZUZrVnJFOXJ0dUhMbDV1aGNVMnlHbXd3VnpEZW1yQ2trL01ldDR5bVI0TFdwaWt5RURnM1kKTVlOdXVWQWJ0QkNJVGNzNG55NnZOMWpBM3B0Sy9hNmFpK0tYS3pxcm9hRVkyNHNxMmJPTjZES1lLYjh6WGlwZgpib2ZVRlEwRkxlbzVmMno1cXFRa3FWMUZ5MURETldySGluVzE3T3lzdktaUEhwWDJjazBvNnc3TWpVNGQ1NzJ4Clp6eFlNNjJLc0t5RjB1alNXWUJ2WjRjL29qRjd4WG04Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1839"
+      - "2015"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:13 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d3b2851-241c-4678-90dd-571d90ad4ae6
+      - be0989cf-ab37-4c27-9add-4234125a0a9e
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,10 +1203,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c532e336-2f76-43b6-8d85-a0e860a922c0&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:14:33 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 95fcb6f3-a0d1-4e11-b80e-3293e42f733f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1182,7 +1248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:13 GMT
+      - Mon, 18 Dec 2023 13:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bf28d95-e120-443a-8fba-6bc0aa192238
+      - 16860242-4706-421a-a948-9ca84cae21db
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,10 +1269,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1215,7 +1281,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:14 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4215f8a-4860-4a10-820e-d79c3d5fba48
+      - 1cae66b5-f202-4429-a9b0-48e1cf52040b
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,10 +1302,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "327"
@@ -1248,7 +1314,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:14 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3ab7359-0fad-4c7d-8e18-cda16e89f2aa
+      - 69088c14-3780-4b3b-81e1-4c92ed007b7b
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,10 +1335,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"cabe25b0-eaaa-4fe7-8185-c3cceba77644","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b45e72a7-fd30-4be0-a06b-0e654034cd54","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"68503851-835b-45ff-9877-6711ce9990b3","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"feab5f51-efa0-43fb-9a75-e2b1843ac3fe","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1199610-01b6-49d0-8b08-68195e11008b","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "327"
@@ -1281,7 +1347,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:14 GMT
+      - Mon, 18 Dec 2023 13:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa9811a7-a246-4af5-9814-1d21a783098e
+      - 610f35a5-cac7-453c-9ba9-020f7a74cfdc
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,10 +1368,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b1199610-01b6-49d0-8b08-68195e11008b","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1314,7 +1380,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:44 GMT
+      - Mon, 18 Dec 2023 13:15:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2891b11b-8955-43fc-a727-9a077fc1beed
+      - 482ddb65-4b17-4649-8062-168b4491279d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1335,19 +1401,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302},"endpoints":[{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302}],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1227"
+      - "1233"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:45 GMT
+      - Mon, 18 Dec 2023 13:15:04 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 885eee40-e869-42f9-b897-1b276e8e46cd
+      - f9766aa7-249e-49d4-a4c9-2eeee5871c40
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302},"endpoints":[{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302}],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:45 GMT
+      - Mon, 18 Dec 2023 13:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc726313-f88d-4e61-837d-602f49a6bec8
+      - f3cfd56a-4c40-4651-b35b-172e7f2993a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:39.391402Z","endpoint":{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302},"endpoints":[{"id":"f4d830c2-1e03-4765-87fa-2727cf3a58d5","ip":"51.159.11.70","load_balancer":{},"name":null,"port":1302}],"engine":"PostgreSQL-15","id":"dfcbf190-581f-4643-b9bc-2524e9d32022","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:53.701655Z","endpoint":{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137},"endpoints":[{"id":"cc5c09e9-f241-45bc-aa26-4c6e0f3a9d6d","ip":"195.154.197.252","load_balancer":{},"name":null,"port":6137}],"engine":"PostgreSQL-15","id":"c532e336-2f76-43b6-8d85-a0e860a922c0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1230"
+      - "1236"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:45 GMT
+      - Mon, 18 Dec 2023 13:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3322f98e-4fc0-4706-9554-6fe54302c56b
+      - 1b09f40a-ef24-4ffc-ac7e-d5e404bb8880
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,7 +1500,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b45e72a7-fd30-4be0-a06b-0e654034cd54
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/feab5f51-efa0-43fb-9a75-e2b1843ac3fe
     method: DELETE
   response:
     body: ""
@@ -1444,7 +1510,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:45 GMT
+      - Mon, 18 Dec 2023 13:15:05 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8efcc917-6c13-4c3e-b936-1f0f96a087da
+      - 2c099cbc-9c82-4008-a985-74de7da5435b
     status: 204 No Content
     code: 204
     duration: ""
@@ -1465,10 +1531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"dfcbf190-581f-4643-b9bc-2524e9d32022","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"c532e336-2f76-43b6-8d85-a0e860a922c0","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1477,7 +1543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:22:15 GMT
+      - Mon, 18 Dec 2023 13:15:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d41b8539-b283-430a-90cc-17abe8805e09
+      - 7b20eb73-894c-46d2-b87b-493397f952fd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1498,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/dfcbf190-581f-4643-b9bc-2524e9d32022
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c532e336-2f76-43b6-8d85-a0e860a922c0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"dfcbf190-581f-4643-b9bc-2524e9d32022","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"c532e336-2f76-43b6-8d85-a0e860a922c0","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1510,7 +1576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:22:15 GMT
+      - Mon, 18 Dec 2023 13:15:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d130ec1-e684-4585-a58d-d54ad2d7394b
+      - 4dc1137c-2ef8-4bed-aff5-4a9fa4b74425
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1531,10 +1597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e33513c4-8d7c-4f5b-b887-29326fa8f968
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1199610-01b6-49d0-8b08-68195e11008b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"e33513c4-8d7c-4f5b-b887-29326fa8f968","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b1199610-01b6-49d0-8b08-68195e11008b","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1543,7 +1609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:22:15 GMT
+      - Mon, 18 Dec 2023 13:15:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 119b5c8e-ea07-4d4c-a4cf-b3015889c27d
+      - 9aaa453e-fae9-4719-8c15-8b9f59a3ee15
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-update.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-update.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 15:59:02 GMT
+      - Mon, 18 Dec 2023 12:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eab84413-e578-40e5-9963-540eb34f13ae
+      - f7bc81b5-78e5-4673-b817-35141a841fd2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,16 +344,16 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "928"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:03 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6926aa84-d1ca-486c-b70c-d446a1c03f1d
+      - 65731a47-b277-4415-92bf-4ac91949bbf1
     status: 200 OK
     code: 200
     duration: ""
@@ -374,19 +374,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "928"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:03 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07543754-2386-47ac-a442-84c5378a4e68
+      - 188d62e8-0fc2-47a1-ba1e-87dd225797ed
     status: 200 OK
     code: 200
     duration: ""
@@ -407,19 +407,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "928"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:14:33 GMT
+      - Mon, 18 Dec 2023 12:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f2b3af9-a948-4604-a2c9-1de7d0468df7
+      - 3d64fdaa-b967-4cd7-bfdd-285fe49ebdd9
     status: 200 OK
     code: 200
     duration: ""
@@ -440,19 +440,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "928"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:04 GMT
+      - Mon, 18 Dec 2023 12:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b413ec5b-3cc6-4d09-8c6c-ca8c587cb805
+      - ef5882f7-9769-49fa-8022-501d70c50d09
     status: 200 OK
     code: 200
     duration: ""
@@ -473,19 +473,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "928"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:15:34 GMT
+      - Mon, 18 Dec 2023 12:58:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31e17d3a-c0c3-4611-9d0d-07abd640703c
+      - 12858204-7d1a-4506-a7c2-b34e43d1b0db
     status: 200 OK
     code: 200
     duration: ""
@@ -506,19 +506,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "762"
+      - "928"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:04 GMT
+      - Mon, 18 Dec 2023 12:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e01ec2b3-1dc7-4f4c-8ad1-fb5ece2a761b
+      - a7f141c0-ba2e-43fc-8be1-81f543a98efd
     status: 200 OK
     code: 200
     duration: ""
@@ -539,19 +539,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1026"
+      - "928"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:16:34 GMT
+      - Mon, 18 Dec 2023 12:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf4a26c1-bfc5-4333-ac0f-15529ead594b
+      - ad4a0cd2-3780-461e-b211-68a4d3e925d0
     status: 200 OK
     code: 200
     duration: ""
@@ -572,10 +572,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117},"endpoints":[{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117}],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "928"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:00:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b5a20b7f-88ad-4d7e-a710-f5c7c4737017
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1192"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:00:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce82c630-ea3f-4e3d-bbc4-77830806d7b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1235"
@@ -584,7 +650,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:04 GMT
+      - Mon, 18 Dec 2023 13:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c5e55e8-9d80-46e1-8f64-6bf337d2cb0d
+      - 5a95b28c-b284-4bbf-b204-1fea189a9ff6
     status: 200 OK
     code: 200
     duration: ""
@@ -605,19 +671,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQ2tFd3JKZUJXZExmS3hzR2lDNG13UmZHSFFnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZeE5qSXdXaGNOTXpNeE1URTRNVFl4TmpJd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxwU1YxYUpNdDFyb0RLdFBwSHpkS0dMcHFtZisrMmE0ZkxoaDFxajk4NHhSU2ZjTXNHTUwwNjIKelV6VWhXUWpKSy9MUDh5ZFdSUlF6Mm5paVdMTUJCVCsrUVYrUmowL2hBT2FGaDBRRVFsd0szb1A4TXlIa2JtegpuRUF2Zk56ODc2eUQxU0VROTZiNEJoaHNYc3E2alVKb01uTTd1djNsaWppZ2RQcjJTeEVZa1hiQXkrNTNscXE2ClVMQjIzTVQwYmVrYm5sK3JhbHkxc2UrOGttbVQ5VXRRdDdSV0I1MkpwU0RNUE9LazY1dHkrMVBpRTRBaXEzQjUKY1ZYS1lmZ3NhcFNIcGduR3cwOXhUSkV6QjFVLzRYdXYxbldIUkhEMEJ6aE43bjZUUGVOUUVDR0NicTBaMEtPOApTR2lGNXYvY0NLV1VIZ0h5S0t6akxRWFZ4a25KZFljQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0WVRnNFlXUXpNakF0T0dNek55MDBOR00zTFdKaVpEa3RaalJpTVdSaVpqUmwKTm1JM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm4wWWh3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ0dWdENOdjVBdFhlQzZWOEszWXNTbVBsSVFYMGQwOWdVM1BRSHE1YzdoZE1DL0x2WlREMzVJClZOcVJ1aFBPLzhlT1FNNzI4elhwMTBPYkI0UTdJMjJzdnZpaEhqNjlOaWRLbzlJQ1ZkOVlNR05JNmNWL2FaazIKd0tFeHY4bjhOT0gvdjJNeEpibE1KQU9rTzVyVWNyaWFrMkdmWG0xbWJUSE1ZL3BHTXZObEJRZEUwSWcvakZsYwpIdGw1QjYrSFRHMDNMaDNhWllZZ3RMbW9OWmYxamNMbUhaNjh1TDJrN1hXaDJMRmEvZ3hVVXZmVmMzWDFjSkI1ClVsa3dKbGt4c05wcDVGRTNnV0Y3cDZNMVE4RHZLWmM4Sk9CaS9aL0pxWFI5T1FYZ2RHbjlOSGFxTTlQMUZubU8KbTIwQzlOYlJaQlJYcVF1U01PbW1hQ0M5Z29NZVdyRmgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVWS8wbStoSDRMZnJWdEJPMThCTUxCY1pKclpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVkakJFRyt4TUdhc2M4emc1a2NwMitMS2s3WHo5WGtFOUJ2OXlma25SMS8xVUJDYzFHR24KRk1CV1FDeFJaRUhoekFwS3QzSG1aTTRnTWtUVFJaTVU2QXYzUjE5dCtFeFZqUjJVUjVWMUlLYTBDdmV4dUloQwppSUg5anJWbG8zUUs2Ujk5NkFVRFZSc3Vob1NKelYveUptR01QdFlaUzA3N2wxYm5mTTFOYWVaNjgvQXZweHRECk9ld1htbjc5c3hMZGZHbGlhRURXZEphVlJjTklPSzRscUNRcEYrUTdXWkVYT05KZ21QMTBTSitrWERLT2E3NnIKSWo2ZVZKa1NHZ1lwNElyd1hlVUdTek10bGwrMmJ6RXoxb0VxK3FaK1Fuci95UDN4S3JwdGduMEQ0czUxQjBWcwptSm5HU0VIVW1lMitWWTZjOWRwdkErcitZVitUSzVxZFl3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFoTnpWa1l6Tm1NQzAwTVRFMUxUUTRPVFV0T0dZNVpDMWgKTmpCaU5tUTRZbUl6TnpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxaE56VmtZek5tTUMwME1URTFMVFE0T1RVdE9HWTVaQzFoTmpCaU5tUTRZbUl6TnpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGd1cUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVFdqZ1RFbG9XTkxuczM5ekxpMnEvcVR2S1hPSUJJckhzc0xwWlgycGZWTG5HYTJZQUlWY1k1WmpjUApsZ0VSTlVlb0k1SEEwUTg5REZwcWJOSEhhL0VUbzVzNW84Q29XRnpraW5FWFk4SitPYnYvNXpvanZxQlRubGEzCnVDbm1rOEV1VXhYdjVLRkQ4QmZtS000K2VGUzZ0cyt4SnBTcjNMU2h4WVJHZVgzbERmZS8yaHoxWmE0QllQUjUKaWhveVVFeEpvUzNzYURCSWhsM0FuMnBzWXh4dmtDckl5am1vMkF4OHpqZ09EMXVlcW00TFlPanhSSTVuMG5IcQpvM2JsRG81NmdMbjd1aEVaaGlvVnRDTHVvLzRNbFR3d2VGa3BxVE9BcXlYVkxPaVN3Wi85VTFnbDdyWDNxWG96CjU0b3BlQTY2aVNXK0lheGZDelNSUU5tZDNhRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:05 GMT
+      - Mon, 18 Dec 2023 13:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,12 +693,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8036871-96a5-438b-b945-039cb3b2e3ea
+      - add7fb57-ddee-4506-985f-dd998927bb58
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a75dc3f0-4115-4895-8f9d-a60b6d8bb373&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f98d6f3d-ac23-42ab-a022-a7d9000feaa8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -643,7 +742,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "119"
@@ -652,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:05 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dd069d9-a6de-456e-b151-ac041c4f6d74
+      - c7adff03-8b4d-4ee8-a5a7-d6a99c832b60
     status: 200 OK
     code: 200
     duration: ""
@@ -673,10 +772,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "119"
@@ -685,7 +784,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:05 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 931350f2-d95a-4d7e-9ff3-47b1460f672b
+      - 8c5a5d2c-266a-4617-98c9-5d7ac48f5ffb
     status: 200 OK
     code: 200
     duration: ""
@@ -706,10 +805,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "119"
@@ -718,7 +817,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:17:35 GMT
+      - Mon, 18 Dec 2023 13:01:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52e3b6f7-ca65-4dd3-9f8e-c3e812520193
+      - d0c005d1-802d-4a0c-b67a-5cd76620aeec
     status: 200 OK
     code: 200
     duration: ""
@@ -739,10 +838,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    headers:
+      Content-Length:
+      - "119"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:02:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3da0469a-ff04-4767-8780-4a842ba47760
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    headers:
+      Content-Length:
+      - "119"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:02:41 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7d86ef8d-29d1-47bb-9797-f27b3b042de4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    headers:
+      Content-Length:
+      - "119"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:03:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 53bf57e4-4de2-4402-ab1d-3068afe4819a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "228"
@@ -751,7 +949,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:05 GMT
+      - Mon, 18 Dec 2023 13:03:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a2942c2-d57d-4d24-ab90-2a51aa103fb9
+      - 24977eba-a366-4941-b26e-58b6fc27719d
     status: 200 OK
     code: 200
     duration: ""
@@ -772,10 +970,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "228"
@@ -784,7 +982,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:18:36 GMT
+      - Mon, 18 Dec 2023 13:04:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4588beaf-c11b-4625-b10d-945cac3a6e04
+      - 3d81b183-dbab-4134-a89b-fff924fa6fdd
     status: 200 OK
     code: 200
     duration: ""
@@ -805,10 +1003,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "228"
@@ -817,7 +1015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:06 GMT
+      - Mon, 18 Dec 2023 13:04:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e9afde6-f942-46e9-a427-4c049f69f35f
+      - bb159787-aac2-4b62-8d13-f92ceb73f601
     status: 200 OK
     code: 200
     duration: ""
@@ -838,10 +1036,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "228"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f50b97d3-a687-4cbc-a9f7-33824eb1f802
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "221"
@@ -850,7 +1081,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:36 GMT
+      - Mon, 18 Dec 2023 13:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7e41873-f07f-4bec-92ef-c6e756552cd6
+      - ac89bddc-683a-4494-a9bb-f04f6e454945
     status: 200 OK
     code: 200
     duration: ""
@@ -871,10 +1102,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "221"
@@ -883,7 +1114,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:36 GMT
+      - Mon, 18 Dec 2023 13:05:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6d490d1-d6e5-4cfa-bd36-36a159d289d9
+      - f5e9f252-bc06-450a-8109-90933cefefb3
     status: 200 OK
     code: 200
     duration: ""
@@ -904,10 +1135,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "221"
@@ -916,7 +1147,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:36 GMT
+      - Mon, 18 Dec 2023 13:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34d3baa9-6ce3-4c84-b7dd-febd50a76cfa
+      - 8edff4bb-28df-49cb-acc0-1fe0befc2ac9
     status: 200 OK
     code: 200
     duration: ""
@@ -937,10 +1168,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117},"endpoints":[{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117}],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1456"
@@ -949,7 +1180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:36 GMT
+      - Mon, 18 Dec 2023 13:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83a52c5c-44f5-4872-8da4-fd13b23a44a9
+      - d14b9107-7fef-4eed-a7ab-eac88801da9b
     status: 200 OK
     code: 200
     duration: ""
@@ -970,19 +1201,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQ2tFd3JKZUJXZExmS3hzR2lDNG13UmZHSFFnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZeE5qSXdXaGNOTXpNeE1URTRNVFl4TmpJd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxwU1YxYUpNdDFyb0RLdFBwSHpkS0dMcHFtZisrMmE0ZkxoaDFxajk4NHhSU2ZjTXNHTUwwNjIKelV6VWhXUWpKSy9MUDh5ZFdSUlF6Mm5paVdMTUJCVCsrUVYrUmowL2hBT2FGaDBRRVFsd0szb1A4TXlIa2JtegpuRUF2Zk56ODc2eUQxU0VROTZiNEJoaHNYc3E2alVKb01uTTd1djNsaWppZ2RQcjJTeEVZa1hiQXkrNTNscXE2ClVMQjIzTVQwYmVrYm5sK3JhbHkxc2UrOGttbVQ5VXRRdDdSV0I1MkpwU0RNUE9LazY1dHkrMVBpRTRBaXEzQjUKY1ZYS1lmZ3NhcFNIcGduR3cwOXhUSkV6QjFVLzRYdXYxbldIUkhEMEJ6aE43bjZUUGVOUUVDR0NicTBaMEtPOApTR2lGNXYvY0NLV1VIZ0h5S0t6akxRWFZ4a25KZFljQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0WVRnNFlXUXpNakF0T0dNek55MDBOR00zTFdKaVpEa3RaalJpTVdSaVpqUmwKTm1JM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm4wWWh3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ0dWdENOdjVBdFhlQzZWOEszWXNTbVBsSVFYMGQwOWdVM1BRSHE1YzdoZE1DL0x2WlREMzVJClZOcVJ1aFBPLzhlT1FNNzI4elhwMTBPYkI0UTdJMjJzdnZpaEhqNjlOaWRLbzlJQ1ZkOVlNR05JNmNWL2FaazIKd0tFeHY4bjhOT0gvdjJNeEpibE1KQU9rTzVyVWNyaWFrMkdmWG0xbWJUSE1ZL3BHTXZObEJRZEUwSWcvakZsYwpIdGw1QjYrSFRHMDNMaDNhWllZZ3RMbW9OWmYxamNMbUhaNjh1TDJrN1hXaDJMRmEvZ3hVVXZmVmMzWDFjSkI1ClVsa3dKbGt4c05wcDVGRTNnV0Y3cDZNMVE4RHZLWmM4Sk9CaS9aL0pxWFI5T1FYZ2RHbjlOSGFxTTlQMUZubU8KbTIwQzlOYlJaQlJYcVF1U01PbW1hQ0M5Z29NZVdyRmgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVWS8wbStoSDRMZnJWdEJPMThCTUxCY1pKclpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVkakJFRyt4TUdhc2M4emc1a2NwMitMS2s3WHo5WGtFOUJ2OXlma25SMS8xVUJDYzFHR24KRk1CV1FDeFJaRUhoekFwS3QzSG1aTTRnTWtUVFJaTVU2QXYzUjE5dCtFeFZqUjJVUjVWMUlLYTBDdmV4dUloQwppSUg5anJWbG8zUUs2Ujk5NkFVRFZSc3Vob1NKelYveUptR01QdFlaUzA3N2wxYm5mTTFOYWVaNjgvQXZweHRECk9ld1htbjc5c3hMZGZHbGlhRURXZEphVlJjTklPSzRscUNRcEYrUTdXWkVYT05KZ21QMTBTSitrWERLT2E3NnIKSWo2ZVZKa1NHZ1lwNElyd1hlVUdTek10bGwrMmJ6RXoxb0VxK3FaK1Fuci95UDN4S3JwdGduMEQ0czUxQjBWcwptSm5HU0VIVW1lMitWWTZjOWRwdkErcitZVitUSzVxZFl3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFoTnpWa1l6Tm1NQzAwTVRFMUxUUTRPVFV0T0dZNVpDMWgKTmpCaU5tUTRZbUl6TnpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxaE56VmtZek5tTUMwME1URTFMVFE0T1RVdE9HWTVaQzFoTmpCaU5tUTRZbUl6TnpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGd1cUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVFdqZ1RFbG9XTkxuczM5ekxpMnEvcVR2S1hPSUJJckhzc0xwWlgycGZWTG5HYTJZQUlWY1k1WmpjUApsZ0VSTlVlb0k1SEEwUTg5REZwcWJOSEhhL0VUbzVzNW84Q29XRnpraW5FWFk4SitPYnYvNXpvanZxQlRubGEzCnVDbm1rOEV1VXhYdjVLRkQ4QmZtS000K2VGUzZ0cyt4SnBTcjNMU2h4WVJHZVgzbERmZS8yaHoxWmE0QllQUjUKaWhveVVFeEpvUzNzYURCSWhsM0FuMnBzWXh4dmtDckl5am1vMkF4OHpqZ09EMXVlcW00TFlPanhSSTVuMG5IcQpvM2JsRG81NmdMbjd1aEVaaGlvVnRDTHVvLzRNbFR3d2VGa3BxVE9BcXlYVkxPaVN3Wi85VTFnbDdyWDNxWG96CjU0b3BlQTY2aVNXK0lheGZDelNSUU5tZDNhRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:37 GMT
+      - Mon, 18 Dec 2023 13:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 378f3e7a-aa9e-4410-9d65-d836e10da64e
+      - 6f9edafe-0543-44d7-b2fb-f8c2f92f39f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,10 +1234,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a75dc3f0-4115-4895-8f9d-a60b6d8bb373&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:42 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b8c0c68b-6f3d-4e9b-84d1-87cb34aacc7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "221"
@@ -1015,7 +1279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:37 GMT
+      - Mon, 18 Dec 2023 13:05:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1025,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19da91d8-9ee1-4f4e-83c2-43912bf3effd
+      - 50bbd9d9-f026-4820-b4b6-ec106ae11bd2
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,10 +1300,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117},"endpoints":[{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117}],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1456"
@@ -1048,7 +1312,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:37 GMT
+      - Mon, 18 Dec 2023 13:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1058,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80e4cea5-74a3-4028-9fe7-4ff038b655e4
+      - 955e601e-b728-4a96-b5ed-4b4d90712e40
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1333,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQ2tFd3JKZUJXZExmS3hzR2lDNG13UmZHSFFnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZeE5qSXdXaGNOTXpNeE1URTRNVFl4TmpJd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxwU1YxYUpNdDFyb0RLdFBwSHpkS0dMcHFtZisrMmE0ZkxoaDFxajk4NHhSU2ZjTXNHTUwwNjIKelV6VWhXUWpKSy9MUDh5ZFdSUlF6Mm5paVdMTUJCVCsrUVYrUmowL2hBT2FGaDBRRVFsd0szb1A4TXlIa2JtegpuRUF2Zk56ODc2eUQxU0VROTZiNEJoaHNYc3E2alVKb01uTTd1djNsaWppZ2RQcjJTeEVZa1hiQXkrNTNscXE2ClVMQjIzTVQwYmVrYm5sK3JhbHkxc2UrOGttbVQ5VXRRdDdSV0I1MkpwU0RNUE9LazY1dHkrMVBpRTRBaXEzQjUKY1ZYS1lmZ3NhcFNIcGduR3cwOXhUSkV6QjFVLzRYdXYxbldIUkhEMEJ6aE43bjZUUGVOUUVDR0NicTBaMEtPOApTR2lGNXYvY0NLV1VIZ0h5S0t6akxRWFZ4a25KZFljQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0WVRnNFlXUXpNakF0T0dNek55MDBOR00zTFdKaVpEa3RaalJpTVdSaVpqUmwKTm1JM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm4wWWh3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ0dWdENOdjVBdFhlQzZWOEszWXNTbVBsSVFYMGQwOWdVM1BRSHE1YzdoZE1DL0x2WlREMzVJClZOcVJ1aFBPLzhlT1FNNzI4elhwMTBPYkI0UTdJMjJzdnZpaEhqNjlOaWRLbzlJQ1ZkOVlNR05JNmNWL2FaazIKd0tFeHY4bjhOT0gvdjJNeEpibE1KQU9rTzVyVWNyaWFrMkdmWG0xbWJUSE1ZL3BHTXZObEJRZEUwSWcvakZsYwpIdGw1QjYrSFRHMDNMaDNhWllZZ3RMbW9OWmYxamNMbUhaNjh1TDJrN1hXaDJMRmEvZ3hVVXZmVmMzWDFjSkI1ClVsa3dKbGt4c05wcDVGRTNnV0Y3cDZNMVE4RHZLWmM4Sk9CaS9aL0pxWFI5T1FYZ2RHbjlOSGFxTTlQMUZubU8KbTIwQzlOYlJaQlJYcVF1U01PbW1hQ0M5Z29NZVdyRmgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVWS8wbStoSDRMZnJWdEJPMThCTUxCY1pKclpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVkakJFRyt4TUdhc2M4emc1a2NwMitMS2s3WHo5WGtFOUJ2OXlma25SMS8xVUJDYzFHR24KRk1CV1FDeFJaRUhoekFwS3QzSG1aTTRnTWtUVFJaTVU2QXYzUjE5dCtFeFZqUjJVUjVWMUlLYTBDdmV4dUloQwppSUg5anJWbG8zUUs2Ujk5NkFVRFZSc3Vob1NKelYveUptR01QdFlaUzA3N2wxYm5mTTFOYWVaNjgvQXZweHRECk9ld1htbjc5c3hMZGZHbGlhRURXZEphVlJjTklPSzRscUNRcEYrUTdXWkVYT05KZ21QMTBTSitrWERLT2E3NnIKSWo2ZVZKa1NHZ1lwNElyd1hlVUdTek10bGwrMmJ6RXoxb0VxK3FaK1Fuci95UDN4S3JwdGduMEQ0czUxQjBWcwptSm5HU0VIVW1lMitWWTZjOWRwdkErcitZVitUSzVxZFl3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFoTnpWa1l6Tm1NQzAwTVRFMUxUUTRPVFV0T0dZNVpDMWgKTmpCaU5tUTRZbUl6TnpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxaE56VmtZek5tTUMwME1URTFMVFE0T1RVdE9HWTVaQzFoTmpCaU5tUTRZbUl6TnpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGd1cUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVFdqZ1RFbG9XTkxuczM5ekxpMnEvcVR2S1hPSUJJckhzc0xwWlgycGZWTG5HYTJZQUlWY1k1WmpjUApsZ0VSTlVlb0k1SEEwUTg5REZwcWJOSEhhL0VUbzVzNW84Q29XRnpraW5FWFk4SitPYnYvNXpvanZxQlRubGEzCnVDbm1rOEV1VXhYdjVLRkQ4QmZtS000K2VGUzZ0cyt4SnBTcjNMU2h4WVJHZVgzbERmZS8yaHoxWmE0QllQUjUKaWhveVVFeEpvUzNzYURCSWhsM0FuMnBzWXh4dmtDckl5am1vMkF4OHpqZ09EMXVlcW00TFlPanhSSTVuMG5IcQpvM2JsRG81NmdMbjd1aEVaaGlvVnRDTHVvLzRNbFR3d2VGa3BxVE9BcXlYVkxPaVN3Wi85VTFnbDdyWDNxWG96CjU0b3BlQTY2aVNXK0lheGZDelNSUU5tZDNhRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:37 GMT
+      - Mon, 18 Dec 2023 13:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc9b2c1b-0a8c-49b8-a093-e6241713aefa
+      - a28ca5e9-563d-4bee-983f-e541e83aac86
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,10 +1366,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a75dc3f0-4115-4895-8f9d-a60b6d8bb373&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:05:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 222f6b9c-dc10-4edc-9c52-533777d76116
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "221"
@@ -1114,7 +1411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:38 GMT
+      - Mon, 18 Dec 2023 13:05:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,12 +1421,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a397cf8b-f634-4e3d-bcb6-b91de33964e0
+      - 0593c38a-783f-4fec-a2a6-c177aef4257a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-vigilant-diffie","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"tf-pn-youthful-hellman","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -1140,16 +1437,16 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-21T16:19:38.650072Z","dhcp_enabled":true,"id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","name":"tf-pn-vigilant-diffie","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:19:38.650072Z","id":"421c4fde-1aec-464c-a38f-40a81dda5693","subnet":"172.16.56.0/22","updated_at":"2023-11-21T16:19:38.650072Z"},{"created_at":"2023-11-21T16:19:38.650072Z","id":"42e7fd9b-94fb-43b8-853d-cd60564ab0b6","subnet":"fd5f:519c:6d46:47e2::/64","updated_at":"2023-11-21T16:19:38.650072Z"}],"tags":[],"updated_at":"2023-11-21T16:19:38.650072Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:05:43.705425Z","dhcp_enabled":true,"id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","name":"tf-pn-youthful-hellman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:05:43.705425Z","id":"f8c50604-d9cf-47bc-865d-6c03d2c39824","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:05:43.705425Z"},{"created_at":"2023-12-18T13:05:43.705425Z","id":"44b57754-f3e6-41c5-ba34-71c0888d8b8d","subnet":"fd5f:519c:6d46:6e4b::/64","updated_at":"2023-12-18T13:05:43.705425Z"}],"tags":[],"updated_at":"2023-12-18T13:05:43.705425Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "705"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:39 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57b4c1b3-bb72-4d7b-91c0-c2634c5a24a5
+      - 281ed6d9-eaea-428a-8c1f-edefabfd9b33
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0621c29-d4c1-436e-8d9d-de59db16b2f1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b52a3df7-bc0c-4d8f-9654-8b21344e83a2
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:19:38.650072Z","dhcp_enabled":true,"id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","name":"tf-pn-vigilant-diffie","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:19:38.650072Z","id":"421c4fde-1aec-464c-a38f-40a81dda5693","subnet":"172.16.56.0/22","updated_at":"2023-11-21T16:19:38.650072Z"},{"created_at":"2023-11-21T16:19:38.650072Z","id":"42e7fd9b-94fb-43b8-853d-cd60564ab0b6","subnet":"fd5f:519c:6d46:47e2::/64","updated_at":"2023-11-21T16:19:38.650072Z"}],"tags":[],"updated_at":"2023-11-21T16:19:38.650072Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:05:43.705425Z","dhcp_enabled":true,"id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","name":"tf-pn-youthful-hellman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:05:43.705425Z","id":"f8c50604-d9cf-47bc-865d-6c03d2c39824","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:05:43.705425Z"},{"created_at":"2023-12-18T13:05:43.705425Z","id":"44b57754-f3e6-41c5-ba34-71c0888d8b8d","subnet":"fd5f:519c:6d46:6e4b::/64","updated_at":"2023-12-18T13:05:43.705425Z"}],"tags":[],"updated_at":"2023-12-18T13:05:43.705425Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "705"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:40 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 785af9a7-7448-45f5-9314-d33457f1f08c
+      - 256310ef-8cac-40d5-96f9-b4f9771baafa
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,10 +1500,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "221"
@@ -1215,7 +1512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:40 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26d5beb3-f049-4317-ad10-d0627e978830
+      - 7db47e36-9432-4b5f-b327-1a2085a6e6ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,7 +1533,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/de59af1c-aa0b-4c56-ab86-4b97528dac42
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/cc9368b5-5311-4fc3-a42a-52fb1e861ef1
     method: DELETE
   response:
     body: ""
@@ -1246,7 +1543,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:40 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0a4d481-0d6e-47f9-9f8b-28f86bcf472a
+      - d88f96be-0811-43bc-af89-d1a8d26595c7
     status: 204 No Content
     code: 204
     duration: ""
@@ -1267,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"de59af1c-aa0b-4c56-ab86-4b97528dac42","ip":"51.15.208.154","name":null,"port":5432}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"cc9368b5-5311-4fc3-a42a-52fb1e861ef1","ip":"51.15.251.111","name":null,"port":5432}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
       - "227"
@@ -1279,7 +1576,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:19:40 GMT
+      - Mon, 18 Dec 2023 13:05:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19ad7b72-5437-4de1-80f1-f03dd86250b5
+      - 890f8ccf-37ed-49b3-950d-a9efec3fdd3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,10 +1597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "112"
@@ -1312,7 +1609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:10 GMT
+      - Mon, 18 Dec 2023 13:06:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,12 +1619,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 597a9a95-62a4-4803-b24e-646f0db6c922
+      - b83a09f5-00a8-466f-9795-97f8c07dd1ab
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20"}}]}'
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20"}}]}'
     form: {}
     headers:
       Content-Type:
@@ -1335,10 +1632,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "331"
@@ -1347,7 +1644,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:11 GMT
+      - Mon, 18 Dec 2023 13:06:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 010c9780-8ac7-4de2-8805-e503fc07315a
+      - 30414186-6bb4-412a-a151-5246354feaf0
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,10 +1665,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "331"
@@ -1380,7 +1677,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:11 GMT
+      - Mon, 18 Dec 2023 13:06:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ec397f4-6a80-4737-a491-366b749d720a
+      - e1054773-b271-4d9a-a7dc-da2178439ea2
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,10 +1698,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1413,7 +1710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:41 GMT
+      - Mon, 18 Dec 2023 13:06:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dc64e63-63fc-4b74-8767-0120ae27a911
+      - bfebf4f0-9d18-4e82-a31f-6b26633f52e7
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,10 +1731,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1446,7 +1743,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:41 GMT
+      - Mon, 18 Dec 2023 13:06:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcbe6bb6-cf85-4ed8-8a8b-a46798ee1fb0
+      - c820f958-096a-4e34-8977-3acccc62aac8
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,10 +1764,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1479,7 +1776,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:41 GMT
+      - Mon, 18 Dec 2023 13:06:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d576705d-57d3-4db5-8a47-67844ea29af3
+      - 50dd3ada-2bd7-4521-b3bb-6923147043fe
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,19 +1797,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0621c29-d4c1-436e-8d9d-de59db16b2f1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b52a3df7-bc0c-4d8f-9654-8b21344e83a2
     method: GET
   response:
-    body: '{"created_at":"2023-11-21T16:19:38.650072Z","dhcp_enabled":true,"id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","name":"tf-pn-vigilant-diffie","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-11-21T16:19:38.650072Z","id":"421c4fde-1aec-464c-a38f-40a81dda5693","subnet":"172.16.56.0/22","updated_at":"2023-11-21T16:19:38.650072Z"},{"created_at":"2023-11-21T16:19:38.650072Z","id":"42e7fd9b-94fb-43b8-853d-cd60564ab0b6","subnet":"fd5f:519c:6d46:47e2::/64","updated_at":"2023-11-21T16:19:38.650072Z"}],"tags":[],"updated_at":"2023-11-21T16:19:38.650072Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2023-12-18T13:05:43.705425Z","dhcp_enabled":true,"id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","name":"tf-pn-youthful-hellman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:05:43.705425Z","id":"f8c50604-d9cf-47bc-865d-6c03d2c39824","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:05:43.705425Z"},{"created_at":"2023-12-18T13:05:43.705425Z","id":"44b57754-f3e6-41c5-ba34-71c0888d8b8d","subnet":"fd5f:519c:6d46:6e4b::/64","updated_at":"2023-12-18T13:05:43.705425Z"}],"tags":[],"updated_at":"2023-12-18T13:05:43.705425Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "705"
+      - "707"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:41 GMT
+      - Mon, 18 Dec 2023 13:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfd54a97-f44e-4532-b0de-d986097a2c39
+      - e30369f4-7efd-485c-9518-f5929207e4d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,10 +1830,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117},"endpoints":[{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117}],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1559"
@@ -1545,7 +1842,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:41 GMT
+      - Mon, 18 Dec 2023 13:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c85934c8-2063-49cf-a0db-0e33353e680f
+      - 2f192c14-bda8-4393-b25f-106679493ac7
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1863,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURwRENDQW95Z0F3SUJBZ0lVQ2tFd3JKZUJXZExmS3hzR2lDNG13UmZHSFFnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5Tmk0eU1EVXdIaGNOCk1qTXhNVEl4TVRZeE5qSXdXaGNOTXpNeE1URTRNVFl4TmpJd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTJMakl3TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxwU1YxYUpNdDFyb0RLdFBwSHpkS0dMcHFtZisrMmE0ZkxoaDFxajk4NHhSU2ZjTXNHTUwwNjIKelV6VWhXUWpKSy9MUDh5ZFdSUlF6Mm5paVdMTUJCVCsrUVYrUmowL2hBT2FGaDBRRVFsd0szb1A4TXlIa2JtegpuRUF2Zk56ODc2eUQxU0VROTZiNEJoaHNYc3E2alVKb01uTTd1djNsaWppZ2RQcjJTeEVZa1hiQXkrNTNscXE2ClVMQjIzTVQwYmVrYm5sK3JhbHkxc2UrOGttbVQ5VXRRdDdSV0I1MkpwU0RNUE9LazY1dHkrMVBpRTRBaXEzQjUKY1ZYS1lmZ3NhcFNIcGduR3cwOXhUSkV6QjFVLzRYdXYxbldIUkhEMEJ6aE43bjZUUGVOUUVDR0NicTBaMEtPOApTR2lGNXYvY0NLV1VIZ0h5S0t6akxRWFZ4a25KZFljQ0F3RUFBYU5tTUdRd1lnWURWUjBSQkZzd1dZSU5OVEV1Ck1UVTVMakkyTGpJd05ZSThjbmN0WVRnNFlXUXpNakF0T0dNek55MDBOR00zTFdKaVpEa3RaalJpTVdSaVpqUmwKTm1JM0xuSmtZaTVtY2kxd1lYSXVjMk4zTG1Oc2IzVmtod1F6bm4wWWh3UXpueHJOTUEwR0NTcUdTSWIzRFFFQgpDd1VBQTRJQkFRQ0dWdENOdjVBdFhlQzZWOEszWXNTbVBsSVFYMGQwOWdVM1BRSHE1YzdoZE1DL0x2WlREMzVJClZOcVJ1aFBPLzhlT1FNNzI4elhwMTBPYkI0UTdJMjJzdnZpaEhqNjlOaWRLbzlJQ1ZkOVlNR05JNmNWL2FaazIKd0tFeHY4bjhOT0gvdjJNeEpibE1KQU9rTzVyVWNyaWFrMkdmWG0xbWJUSE1ZL3BHTXZObEJRZEUwSWcvakZsYwpIdGw1QjYrSFRHMDNMaDNhWllZZ3RMbW9OWmYxamNMbUhaNjh1TDJrN1hXaDJMRmEvZ3hVVXZmVmMzWDFjSkI1ClVsa3dKbGt4c05wcDVGRTNnV0Y3cDZNMVE4RHZLWmM4Sk9CaS9aL0pxWFI5T1FYZ2RHbjlOSGFxTTlQMUZubU8KbTIwQzlOYlJaQlJYcVF1U01PbW1hQ0M5Z29NZVdyRmgKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVWS8wbStoSDRMZnJWdEJPMThCTUxCY1pKclpRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVkakJFRyt4TUdhc2M4emc1a2NwMitMS2s3WHo5WGtFOUJ2OXlma25SMS8xVUJDYzFHR24KRk1CV1FDeFJaRUhoekFwS3QzSG1aTTRnTWtUVFJaTVU2QXYzUjE5dCtFeFZqUjJVUjVWMUlLYTBDdmV4dUloQwppSUg5anJWbG8zUUs2Ujk5NkFVRFZSc3Vob1NKelYveUptR01QdFlaUzA3N2wxYm5mTTFOYWVaNjgvQXZweHRECk9ld1htbjc5c3hMZGZHbGlhRURXZEphVlJjTklPSzRscUNRcEYrUTdXWkVYT05KZ21QMTBTSitrWERLT2E3NnIKSWo2ZVZKa1NHZ1lwNElyd1hlVUdTek10bGwrMmJ6RXoxb0VxK3FaK1Fuci95UDN4S3JwdGduMEQ0czUxQjBWcwptSm5HU0VIVW1lMitWWTZjOWRwdkErcitZVitUSzVxZFl3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFoTnpWa1l6Tm1NQzAwTVRFMUxUUTRPVFV0T0dZNVpDMWgKTmpCaU5tUTRZbUl6TnpNdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxaE56VmtZek5tTUMwME1URTFMVFE0T1RVdE9HWTVaQzFoTmpCaU5tUTRZbUl6TnpNdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRNUGd1cUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVFdqZ1RFbG9XTkxuczM5ekxpMnEvcVR2S1hPSUJJckhzc0xwWlgycGZWTG5HYTJZQUlWY1k1WmpjUApsZ0VSTlVlb0k1SEEwUTg5REZwcWJOSEhhL0VUbzVzNW84Q29XRnpraW5FWFk4SitPYnYvNXpvanZxQlRubGEzCnVDbm1rOEV1VXhYdjVLRkQ4QmZtS000K2VGUzZ0cyt4SnBTcjNMU2h4WVJHZVgzbERmZS8yaHoxWmE0QllQUjUKaWhveVVFeEpvUzNzYURCSWhsM0FuMnBzWXh4dmtDckl5am1vMkF4OHpqZ09EMXVlcW00TFlPanhSSTVuMG5IcQpvM2JsRG81NmdMbjd1aEVaaGlvVnRDTHVvLzRNbFR3d2VGa3BxVE9BcXlYVkxPaVN3Wi85VTFnbDdyWDNxWG96CjU0b3BlQTY2aVNXK0lheGZDelNSUU5tZDNhRT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1843"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:42 GMT
+      - Mon, 18 Dec 2023 13:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be027938-11b4-4797-8310-bf18871779f4
+      - bf7a5d58-57ae-4dd7-8550-88049badcb20
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,10 +1896,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a75dc3f0-4115-4895-8f9d-a60b6d8bb373&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:06:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a73024e3-a0ad-4f2f-ab46-ceea2e16010b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1611,7 +1941,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:42 GMT
+      - Mon, 18 Dec 2023 13:06:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 835e1390-77fb-465c-a7b9-ca1c514b48e4
+      - e0258a56-a627-4426-88da-4ada5d38e336
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,10 +1962,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "324"
@@ -1644,7 +1974,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:42 GMT
+      - Mon, 18 Dec 2023 13:06:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb3d98c0-e031-4516-b7cc-4af1b253165f
+      - 4a363e77-e005-44ee-bc7c-e1ea53ae08de
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,10 +1995,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "327"
@@ -1677,7 +2007,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:43 GMT
+      - Mon, 18 Dec 2023 13:06:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +2017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 947295e6-1e87-4bd4-9804-1a033b8c5262
+      - 9040c7d6-70d6-4322-ba65-456b6aa23b60
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,10 +2028,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0ad5eec4-16e1-4cac-a5f8-2c41e1d1e6a6","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"d0621c29-d4c1-436e-8d9d-de59db16b2f1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"acba41b2-cd51-4649-a002-fb47ae148544","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"ca1809a2-54c5-4ecc-a41f-4b9ff7082429","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b52a3df7-bc0c-4d8f-9654-8b21344e83a2","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "327"
@@ -1710,7 +2040,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:20:43 GMT
+      - Mon, 18 Dec 2023 13:06:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +2050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46a4d554-faa6-4b95-a711-ac78fe440b64
+      - 003bfa4b-113b-48a3-8462-731837dd51ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,10 +2061,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"acba41b2-cd51-4649-a002-fb47ae148544","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1743,7 +2073,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:13 GMT
+      - Mon, 18 Dec 2023 13:07:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +2083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea1e373d-82f0-45d0-acf7-04a37f3f4304
+      - 2a1a2d16-2a91-4f5b-94aa-40759e7c19d4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1764,10 +2094,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117},"endpoints":[{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117}],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1235"
@@ -1776,7 +2106,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:13 GMT
+      - Mon, 18 Dec 2023 13:07:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +2116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0462a57b-00d3-41a6-b8e6-b0853b1342e5
+      - 373a91f6-9be4-4106-b193-4ad36da6066a
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,10 +2127,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117},"endpoints":[{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117}],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1238"
@@ -1809,7 +2139,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:13 GMT
+      - Mon, 18 Dec 2023 13:07:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +2149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0927eb98-fd4d-4370-a4cd-aba322610eaa
+      - f85d3a26-9f2b-4eb1-9b7e-fa53e031b89e
     status: 200 OK
     code: 200
     duration: ""
@@ -1830,17 +2160,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d0621c29-d4c1-436e-8d9d-de59db16b2f1
-    method: DELETE
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
+    method: GET
   response:
-    body: ""
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:57:07.462055Z","endpoint":{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315},"endpoints":[{"id":"049e3c1d-d779-4454-a0bc-4eca5ebfb8a5","ip":"51.159.207.148","load_balancer":{},"name":null,"port":8315}],"engine":"PostgreSQL-15","id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
+      Content-Length:
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:14 GMT
+      - Mon, 18 Dec 2023 13:07:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1850,7 +2182,38 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1a1f9b2-7044-4b1b-9dcb-97433066a695
+      - d12da84c-ec8e-4007-bfc1-1f8b51aa97f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b52a3df7-bc0c-4d8f-9654-8b21344e83a2
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:07:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 45954973-b74c-4c0d-9050-06e27fd09742
     status: 204 No Content
     code: 204
     duration: ""
@@ -1861,43 +2224,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-11-21T16:14:03.381994Z","endpoint":{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117},"endpoints":[{"id":"03045f54-72e0-4f66-b3c6-f5d786629a2a","ip":"51.159.26.205","load_balancer":{},"name":null,"port":17117}],"engine":"PostgreSQL-15","id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1238"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 21 Nov 2023 16:21:14 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - caf689c2-b7f0-4286-8e17-148651d88f27
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1906,7 +2236,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:44 GMT
+      - Mon, 18 Dec 2023 13:07:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1916,7 +2246,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fd20f10-115e-4d06-80aa-ce29bfc6045e
+      - 7c69e840-d550-42e7-ba16-29fdc9d5302f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1927,10 +2257,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a75dc3f0-4115-4895-8f9d-a60b6d8bb373
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"a88ad320-8c37-44c7-bbd9-f4b1dbf4e6b7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a75dc3f0-4115-4895-8f9d-a60b6d8bb373","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1939,7 +2269,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:44 GMT
+      - Mon, 18 Dec 2023 13:07:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1949,7 +2279,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e4211d9-fd4c-4760-b933-97c5873ba4b1
+      - 1f0c26e9-b529-476a-9b56-ac21cd3ec2ae
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1960,10 +2290,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/acba41b2-cd51-4649-a002-fb47ae148544
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ec191056-0f5c-4ebf-82c5-c8c6228f0115
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"acba41b2-cd51-4649-a002-fb47ae148544","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"ec191056-0f5c-4ebf-82c5-c8c6228f0115","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1972,7 +2302,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 21 Nov 2023 16:21:44 GMT
+      - Mon, 18 Dec 2023 13:07:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1982,7 +2312,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 898a1e70-6618-427e-9c7e-4b9ac1370afd
+      - 8e7bf757-9709-4ae6-a7bc-6907ad940520
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-user-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-user-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:30 GMT
+      - Mon, 18 Dec 2023 12:57:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10650abe-5854-402d-b7d8-09db646e2ce6
+      - 828aa735-9c9a-494c-87f2-20d326f04045
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"TestAccScalewayRdbUser_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"load_balancer":{}}],"backup_same_region":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"TestAccScalewayRdbUser_Basic","engine":"PostgreSQL-15","user_name":"","password":"","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":false,"tags":["terraform-test","scaleway_rdb_user","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:31 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 439b337d-603b-46cb-a44f-fe6be8e47248
+      - c60ee92e-88a2-4b4d-ac7a-c2e16111eb63
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:49:35 GMT
+      - Mon, 18 Dec 2023 12:57:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 007548e7-eeb9-450b-a885-49a24808cec8
+      - 12ee43a9-0fee-4702-9b03-a57fc8af3d9f
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:50:05 GMT
+      - Mon, 18 Dec 2023 12:57:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb0c6e54-ae67-49c5-9fd2-f719a354cc70
+      - ffd9ed81-521d-4824-9267-9fee46d6734a
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:50:35 GMT
+      - Mon, 18 Dec 2023 12:58:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95b2068f-4589-4e66-9c30-24ac70ba07b2
+      - 35c2f0cd-6c46-4476-888c-7c3f117326b7
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:51:29 GMT
+      - Mon, 18 Dec 2023 12:58:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4ee5ace-fdbf-44d7-bf09-ffd4666d1ece
+      - 57e518bf-0a23-438c-b6c0-1bf7d53129d2
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:51:59 GMT
+      - Mon, 18 Dec 2023 12:59:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9065eba8-0d8c-4c44-9dc3-db2a0fec6f79
+      - 7ec5a734-e89c-4c18-985a-06220c1827b1
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:52:29 GMT
+      - Mon, 18 Dec 2023 12:59:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab26869d-c7d2-4b27-8ede-0c51f4630da0
+      - 3984738f-5009-4fe0-b33a-f9adfd52fad6
     status: 200 OK
     code: 200
     duration: ""
@@ -572,19 +572,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "956"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:00 GMT
+      - Mon, 18 Dec 2023 13:00:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80d734db-3523-48b7-b3c0-f5895d27f98a
+      - 256a04ec-650d-4727-855e-10efa6e6b15f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1220"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:00:39 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6bb2b28c-36d8-470b-a1f9-d80def6e8640
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1265"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cb950caf-2fbc-4bf4-a785-0e08ace0f987
     status: 200 OK
     code: 200
     duration: ""
@@ -607,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:00 GMT
+      - Mon, 18 Dec 2023 13:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23be96e1-a870-4ae7-b9ab-d63151d4234c
+      - 4c2e5f89-ce2a-44c6-a772-d5fc90f29d46
     status: 200 OK
     code: 200
     duration: ""
@@ -640,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:00 GMT
+      - Mon, 18 Dec 2023 13:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 785046ae-9b7f-4c81-8865-52c5f683d19f
+      - 1e0648ca-a1c8-462b-af57-4a5d8d4cc379
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +739,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/certificate
     method: GET
   response:
-    body: '{"total_count":0,"users":[]}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTk85dVRmUjdYampSclM1RGg1Y010emFRNjI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVY0VML3g5aEl4YzNQeXNSNGovODJNRFMwb2JLei9hQUc2ZkNFKy8wM0pzUjVVOG54OEUKU3NkN0NzSU9vbG5VVkFkbTZ2WWNzdmZENW55Qlpha2dCSUxsZ1RTWnlGN0M1Y3hIOTdldHRuYS96ck9hRHYyTgpkeDJBSWw3V2orNVZyK0R6R2FaKzFyNFlUOWdhUk9jT09vUEJ6ZDBCc0MyWkNMUFVhMzdoc0FudDZYTVJTTVZLCm1wdmszWUxTWGM4MC8xMHhYTjdlQTNmSHRzdmpNRWU0WGFBS2RJR3F1d1dLdVhCcnRJZm42OUlsanR5U29Hak4KbUg0RnVieDRWSE51akxpYmVWQVJFYzVISVJHNDRpcnduYTFjOEppV1IzQklpNlpqejF0Sm95RUlRZG9tZXc2cgpsU3cxbmhHUXhNYWYrdnNRN0tKZFpUeGJTbFFIZThaOEZ3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB3TmpBd1pqWXhZeTB4T0RWbExUUXdPR1l0WW1GaVppMDMKTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwd05qQXdaall4WXkweE9EVmxMVFF3T0dZdFltRmlaaTAzTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVmpmb3ZaeUtqN2UvT3lZbDMwMFJCeXViSk11ZDVQeFBmWGh4MmZUeGNhVTJkMkJBdWx6WndXYWhvRgp5UnNiZFE3STJhbTVhUkdjRWxsdFI2QjdwOVpUV3lkSW4wd2lYWk45b1FDOTdWaTFKTW81VjFnZndCVTQwOS9rCkN0ejdXV3A4NlBkMncvbVBoeHNXZVpkMGVrT21obmU0cFVvTVd2UVFjYXluOVJWZS9YY2hCNkd4VzQ0bkNnQmkKN1FtenkzNHNSVnFWSzd1bHlXMm9FMk9lMllVV1ZEK0VvYnNTTWlRQUE5Zmx5TUxZN1R2STNFWExqV0k2MFVGYgpxVmdjeHovcEJYeW9xZjgwYi9RZ2xhOGhwelRpSTZBcFU2Rm11dHNnc05hRDN2Z2krNURYYlNwdllGUFFNd3V3CmN1Uy9PSXdGVTZWQi9BUi94MC9FeldDVndrcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "28"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:00 GMT
+      - Mon, 18 Dec 2023 13:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10ec1353-8b69-452f-9493-10b5128de327
+      - 2c0284af-bdf2-4cbe-aad4-6a0d00303ea7
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +772,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0600f61c-185e-408f-babf-73bddd2210b5&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVZVU3VzhXOVVaVUNJM2FyaUw5WTR0dHRFMThJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTnk0eE1USXdIaGNOCk1qTXhNakU0TURrMU1qUXdXaGNOTXpNeE1qRTFNRGsxTWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTNMakV4TWpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUw0YzZTSWc5ZWRZNCtBSG1VY1J5MTBZcGtjYUV0QndTd2NZQytrcEgvWFVuU1hkK3lvLzJncG4KYVZWTk1XbnAvZ3F1RDhhY2NFcC9pOU9hY0dsS1JDenVSZnpkbUJuWmp5eDh3MHgwblNjOG5VbS9tY0c3Nk5pZApyL0dKdE5CZzkyeVpMOXZ1Z2FLcXdsNlFBNisxTlBZcXRoMTdKeE9uMXpEYzdqek85R05oUUJZaUN1QnNHTmZxCnRGV2syNlB0QjNmUEMrYWlOWDYyd2JZV3lMUnYrVlpOU243c3dyd3BCbFB3MlQwT1B4ZXV0TlI2SWQxRWY4bGoKSDFmbDAyQm9XZE90MytLOXozc01hVExXZVBhNUt5R2UyMUJKWVBZNi9iK21iWW9TeFhxTFh1QUsrRUFEMWNucwpnbGVENkZZVWErZkVWaWMxWWZvNnhpMW41c3BkTUdNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU5UY3VNVEV5Z2p4eWR5MDFNR1kxTlRFd09DMWxaR1l3TFRReVpqTXRZbVptTUMwNVpXRmgKWW1VeU16azBPV1l1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0MU55NHhNVEtDUEhKMwpMVFV3WmpVMU1UQTRMV1ZrWmpBdE5ESm1NeTFpWm1Zd0xUbGxZV0ZpWlRJek9UUTVaaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlucm9jRU01NDVjSWNFTTU0NWNEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKQ0FTWk96bTVzOXpURlUyMTVkcEZZb0wyWGYwN2FxNEVsVHZsM3VTbGd6ZXgxazgvQWE1dWRVTU9SbEZTTmtkTwp5dTZQaHpENzVqcUJLQlJwbU8vN2txQnltbmpyek03elNnbUNMSkdCcmtaTnBCQXVveFdaMHlmNDRadnlnbzFRCjkzdE9GTFJsY3M2V2EyL1FrSHUyc2VUemY1MEVYZERxYkhTZjEvWmNHbGVzSEc5YmJjTXpBaFJ5TXgzZzRveS8KUk8yaDgwTjV1bk9Ddm83amZxWWg2QitpL3RVZmlxVjdOSWpZUG5TS2xpNEtYSGNtUGxpeE5KcUtCNVVJYmJIRQoxczRjQ2cwSkNmRHd5SmZTRzRURXBIejNlL1FQakkxd0R5VXY3aFlYRTZBbHJwQkFYTW9lclExRVkwL1RvYnUyClJuYmFUZlN6VzdMMW1hTUJNU3QwY1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "2007"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:00 GMT
+      - Mon, 18 Dec 2023 13:01:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a23e90b1-631d-4f02-a862-a16de2b782dc
+      - 681fab07-cf20-44a9-be3f-d12efff260dd
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:00 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab4436da-7bca-43d8-bb4a-fc197c79a0db
+      - 5761c310-b2ca-4a4c-806c-bfc978ab8e94
     status: 200 OK
     code: 200
     duration: ""
@@ -774,7 +840,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users
     method: POST
   response:
     body: '{"is_admin":true,"name":"foo"}'
@@ -786,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:00 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48ee48dc-edcb-4cfa-b072-ce8d2c9ec4d0
+      - d0b62cc0-9766-45b5-9b6c-891060caeb3e
     status: 200 OK
     code: 200
     duration: ""
@@ -807,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:01 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46372528-b941-4594-8235-409c0b848fe2
+      - 146c3fa6-0456-41d2-a03d-205c7ebcf4b1
     status: 200 OK
     code: 200
     duration: ""
@@ -840,40 +906,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "58"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b941a21f-add3-45e9-8e48-271bf97f3832
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
@@ -885,7 +918,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:01 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - beb46220-0962-4039-9f57-f7bc4626798e
+      - 13da9de9-aba4-4fea-9851-f19c98307669
     status: 200 OK
     code: 200
     duration: ""
@@ -906,40 +939,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - baf27cc2-fe68-4529-a780-27a8c6aa897d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?order_by=name_asc&page=1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
@@ -951,7 +951,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:01 GMT
+      - Mon, 18 Dec 2023 13:01:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ca93fcd-573c-40cf-b0eb-5fc308e9804a
+      - 7e861481-0f57-46da-ab00-ef256e93d9a8
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVZVU3VzhXOVVaVUNJM2FyaUw5WTR0dHRFMThJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTnk0eE1USXdIaGNOCk1qTXhNakU0TURrMU1qUXdXaGNOTXpNeE1qRTFNRGsxTWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTNMakV4TWpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUw0YzZTSWc5ZWRZNCtBSG1VY1J5MTBZcGtjYUV0QndTd2NZQytrcEgvWFVuU1hkK3lvLzJncG4KYVZWTk1XbnAvZ3F1RDhhY2NFcC9pOU9hY0dsS1JDenVSZnpkbUJuWmp5eDh3MHgwblNjOG5VbS9tY0c3Nk5pZApyL0dKdE5CZzkyeVpMOXZ1Z2FLcXdsNlFBNisxTlBZcXRoMTdKeE9uMXpEYzdqek85R05oUUJZaUN1QnNHTmZxCnRGV2syNlB0QjNmUEMrYWlOWDYyd2JZV3lMUnYrVlpOU243c3dyd3BCbFB3MlQwT1B4ZXV0TlI2SWQxRWY4bGoKSDFmbDAyQm9XZE90MytLOXozc01hVExXZVBhNUt5R2UyMUJKWVBZNi9iK21iWW9TeFhxTFh1QUsrRUFEMWNucwpnbGVENkZZVWErZkVWaWMxWWZvNnhpMW41c3BkTUdNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU5UY3VNVEV5Z2p4eWR5MDFNR1kxTlRFd09DMWxaR1l3TFRReVpqTXRZbVptTUMwNVpXRmgKWW1VeU16azBPV1l1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0MU55NHhNVEtDUEhKMwpMVFV3WmpVMU1UQTRMV1ZrWmpBdE5ESm1NeTFpWm1Zd0xUbGxZV0ZpWlRJek9UUTVaaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlucm9jRU01NDVjSWNFTTU0NWNEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKQ0FTWk96bTVzOXpURlUyMTVkcEZZb0wyWGYwN2FxNEVsVHZsM3VTbGd6ZXgxazgvQWE1dWRVTU9SbEZTTmtkTwp5dTZQaHpENzVqcUJLQlJwbU8vN2txQnltbmpyek03elNnbUNMSkdCcmtaTnBCQXVveFdaMHlmNDRadnlnbzFRCjkzdE9GTFJsY3M2V2EyL1FrSHUyc2VUemY1MEVYZERxYkhTZjEvWmNHbGVzSEc5YmJjTXpBaFJ5TXgzZzRveS8KUk8yaDgwTjV1bk9Ddm83amZxWWg2QitpL3RVZmlxVjdOSWpZUG5TS2xpNEtYSGNtUGxpeE5KcUtCNVVJYmJIRQoxczRjQ2cwSkNmRHd5SmZTRzRURXBIejNlL1FQakkxd0R5VXY3aFlYRTZBbHJwQkFYTW9lclExRVkwL1RvYnUyClJuYmFUZlN6VzdMMW1hTUJNU3QwY1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2007"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:01 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 667850c0-e16d-4f14-a391-022a64b083a4
+      - fe6bce19-cf7f-4702-8c70-dea9dfd11565
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +1005,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTk85dVRmUjdYampSclM1RGg1Y010emFRNjI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVY0VML3g5aEl4YzNQeXNSNGovODJNRFMwb2JLei9hQUc2ZkNFKy8wM0pzUjVVOG54OEUKU3NkN0NzSU9vbG5VVkFkbTZ2WWNzdmZENW55Qlpha2dCSUxsZ1RTWnlGN0M1Y3hIOTdldHRuYS96ck9hRHYyTgpkeDJBSWw3V2orNVZyK0R6R2FaKzFyNFlUOWdhUk9jT09vUEJ6ZDBCc0MyWkNMUFVhMzdoc0FudDZYTVJTTVZLCm1wdmszWUxTWGM4MC8xMHhYTjdlQTNmSHRzdmpNRWU0WGFBS2RJR3F1d1dLdVhCcnRJZm42OUlsanR5U29Hak4KbUg0RnVieDRWSE51akxpYmVWQVJFYzVISVJHNDRpcnduYTFjOEppV1IzQklpNlpqejF0Sm95RUlRZG9tZXc2cgpsU3cxbmhHUXhNYWYrdnNRN0tKZFpUeGJTbFFIZThaOEZ3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB3TmpBd1pqWXhZeTB4T0RWbExUUXdPR1l0WW1GaVppMDMKTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwd05qQXdaall4WXkweE9EVmxMVFF3T0dZdFltRmlaaTAzTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVmpmb3ZaeUtqN2UvT3lZbDMwMFJCeXViSk11ZDVQeFBmWGh4MmZUeGNhVTJkMkJBdWx6WndXYWhvRgp5UnNiZFE3STJhbTVhUkdjRWxsdFI2QjdwOVpUV3lkSW4wd2lYWk45b1FDOTdWaTFKTW81VjFnZndCVTQwOS9rCkN0ejdXV3A4NlBkMncvbVBoeHNXZVpkMGVrT21obmU0cFVvTVd2UVFjYXluOVJWZS9YY2hCNkd4VzQ0bkNnQmkKN1FtenkzNHNSVnFWSzd1bHlXMm9FMk9lMllVV1ZEK0VvYnNTTWlRQUE5Zmx5TUxZN1R2STNFWExqV0k2MFVGYgpxVmdjeHovcEJYeW9xZjgwYi9RZ2xhOGhwelRpSTZBcFU2Rm11dHNnc05hRDN2Z2krNURYYlNwdllGUFFNd3V3CmN1Uy9PSXdGVTZWQi9BUi94MC9FeldDVndrcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1263"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:01 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d96c6de5-5d0c-402d-a038-ea32333fe14d
+      - 876334c8-f0b1-4b13-8032-c1522c80ca85
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,19 +1038,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0600f61c-185e-408f-babf-73bddd2210b5&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
+    body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "58"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:02 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f56143e-369a-4a35-9c55-721fb0065833
+      - 903ada0d-c27f-497f-b8cb-a63a2b224cce
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1071,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:02 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02205754-1b5f-47e2-b368-8bf4d50209f8
+      - 57fa3b82-b490-487a-8e6b-10d0c7c82bbc
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,73 +1104,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVZVU3VzhXOVVaVUNJM2FyaUw5WTR0dHRFMThJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTnk0eE1USXdIaGNOCk1qTXhNakU0TURrMU1qUXdXaGNOTXpNeE1qRTFNRGsxTWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTNMakV4TWpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUw0YzZTSWc5ZWRZNCtBSG1VY1J5MTBZcGtjYUV0QndTd2NZQytrcEgvWFVuU1hkK3lvLzJncG4KYVZWTk1XbnAvZ3F1RDhhY2NFcC9pOU9hY0dsS1JDenVSZnpkbUJuWmp5eDh3MHgwblNjOG5VbS9tY0c3Nk5pZApyL0dKdE5CZzkyeVpMOXZ1Z2FLcXdsNlFBNisxTlBZcXRoMTdKeE9uMXpEYzdqek85R05oUUJZaUN1QnNHTmZxCnRGV2syNlB0QjNmUEMrYWlOWDYyd2JZV3lMUnYrVlpOU243c3dyd3BCbFB3MlQwT1B4ZXV0TlI2SWQxRWY4bGoKSDFmbDAyQm9XZE90MytLOXozc01hVExXZVBhNUt5R2UyMUJKWVBZNi9iK21iWW9TeFhxTFh1QUsrRUFEMWNucwpnbGVENkZZVWErZkVWaWMxWWZvNnhpMW41c3BkTUdNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU5UY3VNVEV5Z2p4eWR5MDFNR1kxTlRFd09DMWxaR1l3TFRReVpqTXRZbVptTUMwNVpXRmgKWW1VeU16azBPV1l1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0MU55NHhNVEtDUEhKMwpMVFV3WmpVMU1UQTRMV1ZrWmpBdE5ESm1NeTFpWm1Zd0xUbGxZV0ZpWlRJek9UUTVaaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlucm9jRU01NDVjSWNFTTU0NWNEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKQ0FTWk96bTVzOXpURlUyMTVkcEZZb0wyWGYwN2FxNEVsVHZsM3VTbGd6ZXgxazgvQWE1dWRVTU9SbEZTTmtkTwp5dTZQaHpENzVqcUJLQlJwbU8vN2txQnltbmpyek03elNnbUNMSkdCcmtaTnBCQXVveFdaMHlmNDRadnlnbzFRCjkzdE9GTFJsY3M2V2EyL1FrSHUyc2VUemY1MEVYZERxYkhTZjEvWmNHbGVzSEc5YmJjTXpBaFJ5TXgzZzRveS8KUk8yaDgwTjV1bk9Ddm83amZxWWg2QitpL3RVZmlxVjdOSWpZUG5TS2xpNEtYSGNtUGxpeE5KcUtCNVVJYmJIRQoxczRjQ2cwSkNmRHd5SmZTRzRURXBIejNlL1FQakkxd0R5VXY3aFlYRTZBbHJwQkFYTW9lclExRVkwL1RvYnUyClJuYmFUZlN6VzdMMW1hTUJNU3QwY1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2007"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c70ce53b-5dc1-4a90-b38c-ea93fcb367a8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42d56521-53db-4863-bb96-ae7f9afa7bf9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
@@ -1182,7 +1116,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:02 GMT
+      - Mon, 18 Dec 2023 13:01:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f2a783b-7128-4056-96dc-cb092982f295
+      - 49c64970-99c5-4532-b200-f01b35ac85aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,19 +1137,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:03 GMT
+      - Mon, 18 Dec 2023 13:01:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61e41698-ed94-40cb-b8dd-6f60fc4c8018
+      - 29b8afc2-e96d-4cda-8582-d0eb1bf61fb6
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,7 +1170,172 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTk85dVRmUjdYampSclM1RGg1Y010emFRNjI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVY0VML3g5aEl4YzNQeXNSNGovODJNRFMwb2JLei9hQUc2ZkNFKy8wM0pzUjVVOG54OEUKU3NkN0NzSU9vbG5VVkFkbTZ2WWNzdmZENW55Qlpha2dCSUxsZ1RTWnlGN0M1Y3hIOTdldHRuYS96ck9hRHYyTgpkeDJBSWw3V2orNVZyK0R6R2FaKzFyNFlUOWdhUk9jT09vUEJ6ZDBCc0MyWkNMUFVhMzdoc0FudDZYTVJTTVZLCm1wdmszWUxTWGM4MC8xMHhYTjdlQTNmSHRzdmpNRWU0WGFBS2RJR3F1d1dLdVhCcnRJZm42OUlsanR5U29Hak4KbUg0RnVieDRWSE51akxpYmVWQVJFYzVISVJHNDRpcnduYTFjOEppV1IzQklpNlpqejF0Sm95RUlRZG9tZXc2cgpsU3cxbmhHUXhNYWYrdnNRN0tKZFpUeGJTbFFIZThaOEZ3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB3TmpBd1pqWXhZeTB4T0RWbExUUXdPR1l0WW1GaVppMDMKTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwd05qQXdaall4WXkweE9EVmxMVFF3T0dZdFltRmlaaTAzTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVmpmb3ZaeUtqN2UvT3lZbDMwMFJCeXViSk11ZDVQeFBmWGh4MmZUeGNhVTJkMkJBdWx6WndXYWhvRgp5UnNiZFE3STJhbTVhUkdjRWxsdFI2QjdwOVpUV3lkSW4wd2lYWk45b1FDOTdWaTFKTW81VjFnZndCVTQwOS9rCkN0ejdXV3A4NlBkMncvbVBoeHNXZVpkMGVrT21obmU0cFVvTVd2UVFjYXluOVJWZS9YY2hCNkd4VzQ0bkNnQmkKN1FtenkzNHNSVnFWSzd1bHlXMm9FMk9lMllVV1ZEK0VvYnNTTWlRQUE5Zmx5TUxZN1R2STNFWExqV0k2MFVGYgpxVmdjeHovcEJYeW9xZjgwYi9RZ2xhOGhwelRpSTZBcFU2Rm11dHNnc05hRDN2Z2krNURYYlNwdllGUFFNd3V3CmN1Uy9PSXdGVTZWQi9BUi94MC9FeldDVndrcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a821fc2-3bb8-4308-8a76-7ec436ec8ab2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0600f61c-185e-408f-babf-73bddd2210b5&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0782ceae-cb79-4b60-a181-67a3dfbb5b46
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1265"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4f3cd24c-c906-41ad-9aa2-837600e317ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=foo&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "58"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b56fabda-caa2-4db2-b3bf-799c285a4479
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1265"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:12 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab309669-88c0-433d-9255-abc74df4e0cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users/foo
     method: DELETE
   response:
     body: ""
@@ -1246,7 +1345,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:03 GMT
+      - Mon, 18 Dec 2023 13:01:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e29a701b-ddd8-4187-ae71-9b07127eee21
+      - 70afd778-0c8a-4c73-a506-2abba4b186f8
     status: 204 No Content
     code: 204
     duration: ""
@@ -1267,19 +1366,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:03 GMT
+      - Mon, 18 Dec 2023 13:01:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e612563-40b7-45c4-85eb-388ddef4ea59
+      - f6983e89-9c5a-47cd-9a8b-7b0349e5c4b3
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,7 +1401,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"bar"}'
@@ -1314,7 +1413,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:03 GMT
+      - Mon, 18 Dec 2023 13:01:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fcfe09d-8d32-4cf7-8052-eaf5ecc904c2
+      - 2d8ed627-a84e-4a23-8691-335976e5cf1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,19 +1434,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:04 GMT
+      - Mon, 18 Dec 2023 13:01:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ff6aab0-ccac-4dd4-8001-b3b7ec173f94
+      - 8921aa1b-9058-44fd-a2a8-2c934a0a1260
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,40 +1467,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?name=bar&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8076438d-9a2d-4d9b-9008-e6382073ad38
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?name=bar&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=bar&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
@@ -1413,7 +1479,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:04 GMT
+      - Mon, 18 Dec 2023 13:01:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d23e610d-a538-4bcc-89b3-8cca8265cad1
+      - 59c0b462-ed7e-4dc8-ab46-64695879cc1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,106 +1500,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c62043a5-afad-4b74-b5e7-a2f16ddbee9c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVZVU3VzhXOVVaVUNJM2FyaUw5WTR0dHRFMThJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTnk0eE1USXdIaGNOCk1qTXhNakU0TURrMU1qUXdXaGNOTXpNeE1qRTFNRGsxTWpRd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTNMakV4TWpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUw0YzZTSWc5ZWRZNCtBSG1VY1J5MTBZcGtjYUV0QndTd2NZQytrcEgvWFVuU1hkK3lvLzJncG4KYVZWTk1XbnAvZ3F1RDhhY2NFcC9pOU9hY0dsS1JDenVSZnpkbUJuWmp5eDh3MHgwblNjOG5VbS9tY0c3Nk5pZApyL0dKdE5CZzkyeVpMOXZ1Z2FLcXdsNlFBNisxTlBZcXRoMTdKeE9uMXpEYzdqek85R05oUUJZaUN1QnNHTmZxCnRGV2syNlB0QjNmUEMrYWlOWDYyd2JZV3lMUnYrVlpOU243c3dyd3BCbFB3MlQwT1B4ZXV0TlI2SWQxRWY4bGoKSDFmbDAyQm9XZE90MytLOXozc01hVExXZVBhNUt5R2UyMUJKWVBZNi9iK21iWW9TeFhxTFh1QUsrRUFEMWNucwpnbGVENkZZVWErZkVWaWMxWWZvNnhpMW41c3BkTUdNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU5UY3VNVEV5Z2p4eWR5MDFNR1kxTlRFd09DMWxaR1l3TFRReVpqTXRZbVptTUMwNVpXRmgKWW1VeU16azBPV1l1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0MU55NHhNVEtDUEhKMwpMVFV3WmpVMU1UQTRMV1ZrWmpBdE5ESm1NeTFpWm1Zd0xUbGxZV0ZpWlRJek9UUTVaaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnlucm9jRU01NDVjSWNFTTU0NWNEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKQ0FTWk96bTVzOXpURlUyMTVkcEZZb0wyWGYwN2FxNEVsVHZsM3VTbGd6ZXgxazgvQWE1dWRVTU9SbEZTTmtkTwp5dTZQaHpENzVqcUJLQlJwbU8vN2txQnltbmpyek03elNnbUNMSkdCcmtaTnBCQXVveFdaMHlmNDRadnlnbzFRCjkzdE9GTFJsY3M2V2EyL1FrSHUyc2VUemY1MEVYZERxYkhTZjEvWmNHbGVzSEc5YmJjTXpBaFJ5TXgzZzRveS8KUk8yaDgwTjV1bk9Ddm83amZxWWg2QitpL3RVZmlxVjdOSWpZUG5TS2xpNEtYSGNtUGxpeE5KcUtCNVVJYmJIRQoxczRjQ2cwSkNmRHd5SmZTRzRURXBIejNlL1FQakkxd0R5VXY3aFlYRTZBbHJwQkFYTW9lclExRVkwL1RvYnUyClJuYmFUZlN6VzdMMW1hTUJNU3QwY1E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2007"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 73eb2914-212f-45ae-9b14-20dd464fe7eb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1263"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 09:53:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e8a4f340-f1fd-496a-a0d9-d8dfd8b6cf6f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users?name=bar&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=bar&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
@@ -1545,7 +1512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:05 GMT
+      - Mon, 18 Dec 2023 13:01:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c58a32b-c636-472a-93a3-eb5b49e32c88
+      - 4731aafb-2c99-420e-9642-6b0d25ec9830
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:05 GMT
+      - Mon, 18 Dec 2023 13:01:14 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94386f2d-1319-4f2a-bc67-b30aca80cbb8
+      - ed006a38-8416-4f98-8a90-9781d9a7d71f
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,7 +1566,172 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f/users/bar
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTk85dVRmUjdYampSclM1RGg1Y010emFRNjI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVY0VML3g5aEl4YzNQeXNSNGovODJNRFMwb2JLei9hQUc2ZkNFKy8wM0pzUjVVOG54OEUKU3NkN0NzSU9vbG5VVkFkbTZ2WWNzdmZENW55Qlpha2dCSUxsZ1RTWnlGN0M1Y3hIOTdldHRuYS96ck9hRHYyTgpkeDJBSWw3V2orNVZyK0R6R2FaKzFyNFlUOWdhUk9jT09vUEJ6ZDBCc0MyWkNMUFVhMzdoc0FudDZYTVJTTVZLCm1wdmszWUxTWGM4MC8xMHhYTjdlQTNmSHRzdmpNRWU0WGFBS2RJR3F1d1dLdVhCcnRJZm42OUlsanR5U29Hak4KbUg0RnVieDRWSE51akxpYmVWQVJFYzVISVJHNDRpcnduYTFjOEppV1IzQklpNlpqejF0Sm95RUlRZG9tZXc2cgpsU3cxbmhHUXhNYWYrdnNRN0tKZFpUeGJTbFFIZThaOEZ3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB3TmpBd1pqWXhZeTB4T0RWbExUUXdPR1l0WW1GaVppMDMKTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwd05qQXdaall4WXkweE9EVmxMVFF3T0dZdFltRmlaaTAzTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVmpmb3ZaeUtqN2UvT3lZbDMwMFJCeXViSk11ZDVQeFBmWGh4MmZUeGNhVTJkMkJBdWx6WndXYWhvRgp5UnNiZFE3STJhbTVhUkdjRWxsdFI2QjdwOVpUV3lkSW4wd2lYWk45b1FDOTdWaTFKTW81VjFnZndCVTQwOS9rCkN0ejdXV3A4NlBkMncvbVBoeHNXZVpkMGVrT21obmU0cFVvTVd2UVFjYXluOVJWZS9YY2hCNkd4VzQ0bkNnQmkKN1FtenkzNHNSVnFWSzd1bHlXMm9FMk9lMllVV1ZEK0VvYnNTTWlRQUE5Zmx5TUxZN1R2STNFWExqV0k2MFVGYgpxVmdjeHovcEJYeW9xZjgwYi9RZ2xhOGhwelRpSTZBcFU2Rm11dHNnc05hRDN2Z2krNURYYlNwdllGUFFNd3V3CmN1Uy9PSXdGVTZWQi9BUi94MC9FeldDVndrcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - be8f79c1-0f44-4307-be2d-0fb4e0317ac4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0600f61c-185e-408f-babf-73bddd2210b5&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 09214269-86d5-4290-92ae-82c193e02bc6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1265"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:14 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f52e59a7-2d78-4f7c-b4a9-df70417b20a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=bar&order_by=name_asc
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
+    headers:
+      Content-Length:
+      - "59"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 794b9346-5f12-44ff-b794-ad372e8c05e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1265"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 13:01:15 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0789ff78-17e7-462f-9abd-b2f11a39ac5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users/bar
     method: DELETE
   response:
     body: ""
@@ -1609,7 +1741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:05 GMT
+      - Mon, 18 Dec 2023 13:01:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1619,7 +1751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6eeef512-2e9e-4533-bb18-75643cd44af2
+      - bff4672a-1528-49b2-bed9-ee4279d88202
     status: 204 No Content
     code: 204
     duration: ""
@@ -1630,19 +1762,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1263"
+      - "1265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:06 GMT
+      - Mon, 18 Dec 2023 13:01:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1652,7 +1784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22f1eb8c-8f72-4a43-906b-b1f79dc527f6
+      - 12db8343-5440-4eb7-949a-ee16c9f0c19f
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,19 +1795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:06 GMT
+      - Mon, 18 Dec 2023 13:01:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1685,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4c842bf-1f90-4ce7-8dfb-4840b668116d
+      - 3e6009b8-4587-4813-b3ec-7f5c687f8e85
     status: 200 OK
     code: 200
     duration: ""
@@ -1696,19 +1828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T09:49:31.195901Z","retention":7},"created_at":"2023-12-18T09:49:31.195901Z","endpoint":{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088},"endpoints":[{"id":"fd72ce51-7818-4ffe-a36c-9c8a45d2887f","ip":"51.158.57.112","load_balancer":{},"name":null,"port":29088}],"engine":"PostgreSQL-15","id":"50f55108-edf0-42f3-bff0-9eaabe23949f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1266"
+      - "1268"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:06 GMT
+      - Mon, 18 Dec 2023 13:01:15 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1718,7 +1850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da32930d-1409-4080-8afb-763edcb05068
+      - 06f064ba-421b-4b0a-8852-38870baff78c
     status: 200 OK
     code: 200
     duration: ""
@@ -1729,10 +1861,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"50f55108-edf0-42f3-bff0-9eaabe23949f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0600f61c-185e-408f-babf-73bddd2210b5","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1741,7 +1873,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:37 GMT
+      - Mon, 18 Dec 2023 13:01:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1751,7 +1883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ac0aa55-0bf6-463b-a2f6-77a58eba5a37
+      - 99ec873e-15d4-4b41-a676-530b646a80ac
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1762,10 +1894,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/50f55108-edf0-42f3-bff0-9eaabe23949f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"50f55108-edf0-42f3-bff0-9eaabe23949f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"0600f61c-185e-408f-babf-73bddd2210b5","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1774,7 +1906,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 09:53:37 GMT
+      - Mon, 18 Dec 2023 13:01:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1784,7 +1916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2253031d-0730-41e8-9941-b1313c1def07
+      - 003e8dd5-3eee-4494-b92b-6d16d468877d
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-user-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-user-basic.cassette.yaml
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:06 GMT
+      - Mon, 18 Dec 2023 14:10:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 828aa735-9c9a-494c-87f2-20d326f04045
+      - 4ff14acc-a23d-4261-b026-698368fd6b4f
     status: 200 OK
     code: 200
     duration: ""
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -353,7 +353,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:07 GMT
+      - Mon, 18 Dec 2023 14:10:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c60ee92e-88a2-4b4d-ac7a-c2e16111eb63
+      - 1f026aa1-f689-4c6a-9c66-93b1caccac06
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -386,7 +386,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:07 GMT
+      - Mon, 18 Dec 2023 14:10:59 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12ee43a9-0fee-4702-9b03-a57fc8af3d9f
+      - 7c69283a-a4f1-427f-960a-25cd49ecaf60
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -419,7 +419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:37 GMT
+      - Mon, 18 Dec 2023 14:11:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffd9ed81-521d-4824-9267-9fee46d6734a
+      - 6d624b9e-2b92-49dd-ab41-4f4f27288dcf
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:58:08 GMT
+      - Mon, 18 Dec 2023 14:12:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35c2f0cd-6c46-4476-888c-7c3f117326b7
+      - 4a07de07-b2c6-4dfd-b07b-ac1557ceea10
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:58:38 GMT
+      - Mon, 18 Dec 2023 14:12:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57e518bf-0a23-438c-b6c0-1bf7d53129d2
+      - ecff70b0-de1e-4cb9-b4f6-a286ebf8e9cf
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -518,7 +518,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:59:08 GMT
+      - Mon, 18 Dec 2023 14:13:02 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ec5a734-e89c-4c18-985a-06220c1827b1
+      - 7a3dd8b7-460b-415f-92d7-c2cf36c329de
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "956"
@@ -551,7 +551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:59:38 GMT
+      - Mon, 18 Dec 2023 14:13:32 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3984738f-5009-4fe0-b33a-f9adfd52fad6
+      - 7d39b173-3aff-4e61-87af-a3ce46f754bb
     status: 200 OK
     code: 200
     duration: ""
@@ -572,43 +572,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "956"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:00:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 256a04ec-650d-4727-855e-10efa6e6b15f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1220"
@@ -617,7 +584,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:00:39 GMT
+      - Mon, 18 Dec 2023 14:14:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bb2b28c-36d8-470b-a1f9-d80def6e8640
+      - c553c72a-62d1-4a51-b3e1-edd0783c8642
     status: 200 OK
     code: 200
     duration: ""
@@ -638,19 +605,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:09 GMT
+      - Mon, 18 Dec 2023 14:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -660,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb950caf-2fbc-4bf4-a785-0e08ace0f987
+      - a704cc1a-def6-4b56-acc3-df431a9d0e39
     status: 200 OK
     code: 200
     duration: ""
@@ -673,19 +640,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:09 GMT
+      - Mon, 18 Dec 2023 14:14:33 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c2e5f89-ce2a-44c6-a772-d5fc90f29d46
+      - 7bdb3bb4-9475-4ed1-87ed-4d72e91e65a8
     status: 200 OK
     code: 200
     duration: ""
@@ -706,19 +673,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:09 GMT
+      - Mon, 18 Dec 2023 14:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e0648ca-a1c8-462b-af57-4a5d8d4cc379
+      - e5738794-37f8-4c6e-91e7-531ed6b302e4
     status: 200 OK
     code: 200
     duration: ""
@@ -739,19 +706,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?order_by=name_asc&page=1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTk85dVRmUjdYampSclM1RGg1Y010emFRNjI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVY0VML3g5aEl4YzNQeXNSNGovODJNRFMwb2JLei9hQUc2ZkNFKy8wM0pzUjVVOG54OEUKU3NkN0NzSU9vbG5VVkFkbTZ2WWNzdmZENW55Qlpha2dCSUxsZ1RTWnlGN0M1Y3hIOTdldHRuYS96ck9hRHYyTgpkeDJBSWw3V2orNVZyK0R6R2FaKzFyNFlUOWdhUk9jT09vUEJ6ZDBCc0MyWkNMUFVhMzdoc0FudDZYTVJTTVZLCm1wdmszWUxTWGM4MC8xMHhYTjdlQTNmSHRzdmpNRWU0WGFBS2RJR3F1d1dLdVhCcnRJZm42OUlsanR5U29Hak4KbUg0RnVieDRWSE51akxpYmVWQVJFYzVISVJHNDRpcnduYTFjOEppV1IzQklpNlpqejF0Sm95RUlRZG9tZXc2cgpsU3cxbmhHUXhNYWYrdnNRN0tKZFpUeGJTbFFIZThaOEZ3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB3TmpBd1pqWXhZeTB4T0RWbExUUXdPR1l0WW1GaVppMDMKTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwd05qQXdaall4WXkweE9EVmxMVFF3T0dZdFltRmlaaTAzTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVmpmb3ZaeUtqN2UvT3lZbDMwMFJCeXViSk11ZDVQeFBmWGh4MmZUeGNhVTJkMkJBdWx6WndXYWhvRgp5UnNiZFE3STJhbTVhUkdjRWxsdFI2QjdwOVpUV3lkSW4wd2lYWk45b1FDOTdWaTFKTW81VjFnZndCVTQwOS9rCkN0ejdXV3A4NlBkMncvbVBoeHNXZVpkMGVrT21obmU0cFVvTVd2UVFjYXluOVJWZS9YY2hCNkd4VzQ0bkNnQmkKN1FtenkzNHNSVnFWSzd1bHlXMm9FMk9lMllVV1ZEK0VvYnNTTWlRQUE5Zmx5TUxZN1R2STNFWExqV0k2MFVGYgpxVmdjeHovcEJYeW9xZjgwYi9RZ2xhOGhwelRpSTZBcFU2Rm11dHNnc05hRDN2Z2krNURYYlNwdllGUFFNd3V3CmN1Uy9PSXdGVTZWQi9BUi94MC9FeldDVndrcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"total_count":0,"users":[]}'
     headers:
       Content-Length:
-      - "2011"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:09 GMT
+      - Mon, 18 Dec 2023 14:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c0284af-bdf2-4cbe-aad4-6a0d00303ea7
+      - e4b26283-c6c6-4e65-a762-06dcb088deba
     status: 200 OK
     code: 200
     duration: ""
@@ -772,7 +739,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0600f61c-185e-408f-babf-73bddd2210b5&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVkZXUmpWdVZpcUsweno4YkNEL0xiUFluQWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRReE16VXpXaGNOTXpNeE1qRTFNVFF4TXpVeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUo3UVVib0w1bHBvNmk1UGpPREE3MU53TGhXaFNPNThKU0ZpM3Y1cEIvYUladkVaZXBHc1ZqM1EKd0NwN3YxazdNT2E4ckxHdjZ4alJ1VkR2MzNqdkFyWTVSVGVuVzRld2IxOU5Fd2UxQU9MMEpLYWVwM1o4QXdVSApxSGRETjJYUzFOd0lLNFhLRWZpbGwzMGlrajEwY1FnY2VGV3dvSXpPczFEVWRFSEEwMXc1K3BwQjFxMEU0VnI2CklFdmt0cXdpb2llRERQSURzRTFlUW9lTUs0ajE5WVNETzBZTWlRNitGSUl2VFNrcGRXa3FFYXcxaERSVWdMN2EKOG5UdElkVVR4aEo3NG8xaVBsMGFjUWxIb3JNYjNzRWoyOHFFVDB2VkpGYTB2WWhCbFdSSVY1OVpYdjhEdjlWYwoyNjZxNEZNUTZhUys5clc2bDNNTjl5WlFxNnNJeGdFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxOelUwT1dSaE9TMDNPRFkzTFRRMlltSXRPR1E1TWkwd05UUmoKWkRCa1pUY3habU11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1UzTlRRNVpHRTVMVGM0TmpjdE5EWmlZaTA0WkRreUxUQTFOR05rTUdSbE56Rm1ZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy9YUjRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKUnZqTUpUZnRPTVJ0U2R4Tkh1TTBpV3RJdjJGSksvbUdkekgxNUpKdDdsVTlFa1FRdnJsSWdsbnEzVDFjb0ZHNApQK1JaRUFLT0NFbVU0b3Nsb2lNY3NvdlR1akxRZDltbDhsYnRoeFZaYWU0L2tnVmU1bFVhTSttRlBDUXpFOTdJCnBKQk5qSkNRNXRka1AyK2x4MTVxcGpicFZlWE5lUUdCQ0p3YkYyUjdXM0FzWmdRdndoZ1lzSjFiTloxaWVVT2YKSWtiZlVSc1ByT0dVLzIrOWMzRVQ5MG1QSkJKaThvNGluVHVKTHhrQWdRekEwdHZ5SkcxQVZ3bE4zcUJ6MFdkTQpTS3ZucVd5VnJHZDRnMC9aN2V5MmFKMEQrNjcvYUtabFdxUFJZQWtncUc1bmp3QTkveFozcTRXbnIzbHhGMkU1CkpQd0lWUXY0M01EMHhtSVhpZnppL0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:14:34 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf0388c8-c248-4e07-8a61-7599477972c3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e7549da9-7867-46bb-8d92-054cd0de71fc&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -784,7 +784,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:09 GMT
+      - Mon, 18 Dec 2023 14:14:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 681fab07-cf20-44a9-be3f-d12efff260dd
+      - 817b709f-0f24-4dd3-9b44-6eec800cc9fc
     status: 200 OK
     code: 200
     duration: ""
@@ -805,19 +805,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:10 GMT
+      - Mon, 18 Dec 2023 14:14:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5761c310-b2ca-4a4c-806c-bfc978ab8e94
+      - 55732730-f67e-4d0a-b563-ff8da38f4051
     status: 200 OK
     code: 200
     duration: ""
@@ -840,7 +840,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users
     method: POST
   response:
     body: '{"is_admin":true,"name":"foo"}'
@@ -852,7 +852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:10 GMT
+      - Mon, 18 Dec 2023 14:14:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0b62cc0-9766-45b5-9b6c-891060caeb3e
+      - e12d91ad-a930-4437-8281-c0000d2b399c
     status: 200 OK
     code: 200
     duration: ""
@@ -873,19 +873,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:10 GMT
+      - Mon, 18 Dec 2023 14:14:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 146c3fa6-0456-41d2-a03d-205c7ebcf4b1
+      - 6a1cf66e-0792-4569-9980-786709a5fe4b
     status: 200 OK
     code: 200
     duration: ""
@@ -906,40 +906,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=foo&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
-    headers:
-      Content-Length:
-      - "58"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:01:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 13da9de9-aba4-4fea-9851-f19c98307669
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
@@ -951,7 +918,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:10 GMT
+      - Mon, 18 Dec 2023 14:14:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e861481-0f57-46da-ab00-ef256e93d9a8
+      - 182f9a07-f8b9-485a-aad2-20a8743af53a
     status: 200 OK
     code: 200
     duration: ""
@@ -972,19 +939,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?name=foo&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
     headers:
       Content-Length:
-      - "1265"
+      - "58"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:11 GMT
+      - Mon, 18 Dec 2023 14:14:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe6bce19-cf7f-4702-8c70-dea9dfd11565
+      - b5ff0dcc-92f6-44e0-a7e4-7b050948a2ea
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,19 +972,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTk85dVRmUjdYampSclM1RGg1Y010emFRNjI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVY0VML3g5aEl4YzNQeXNSNGovODJNRFMwb2JLei9hQUc2ZkNFKy8wM0pzUjVVOG54OEUKU3NkN0NzSU9vbG5VVkFkbTZ2WWNzdmZENW55Qlpha2dCSUxsZ1RTWnlGN0M1Y3hIOTdldHRuYS96ck9hRHYyTgpkeDJBSWw3V2orNVZyK0R6R2FaKzFyNFlUOWdhUk9jT09vUEJ6ZDBCc0MyWkNMUFVhMzdoc0FudDZYTVJTTVZLCm1wdmszWUxTWGM4MC8xMHhYTjdlQTNmSHRzdmpNRWU0WGFBS2RJR3F1d1dLdVhCcnRJZm42OUlsanR5U29Hak4KbUg0RnVieDRWSE51akxpYmVWQVJFYzVISVJHNDRpcnduYTFjOEppV1IzQklpNlpqejF0Sm95RUlRZG9tZXc2cgpsU3cxbmhHUXhNYWYrdnNRN0tKZFpUeGJTbFFIZThaOEZ3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB3TmpBd1pqWXhZeTB4T0RWbExUUXdPR1l0WW1GaVppMDMKTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwd05qQXdaall4WXkweE9EVmxMVFF3T0dZdFltRmlaaTAzTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVmpmb3ZaeUtqN2UvT3lZbDMwMFJCeXViSk11ZDVQeFBmWGh4MmZUeGNhVTJkMkJBdWx6WndXYWhvRgp5UnNiZFE3STJhbTVhUkdjRWxsdFI2QjdwOVpUV3lkSW4wd2lYWk45b1FDOTdWaTFKTW81VjFnZndCVTQwOS9rCkN0ejdXV3A4NlBkMncvbVBoeHNXZVpkMGVrT21obmU0cFVvTVd2UVFjYXluOVJWZS9YY2hCNkd4VzQ0bkNnQmkKN1FtenkzNHNSVnFWSzd1bHlXMm9FMk9lMllVV1ZEK0VvYnNTTWlRQUE5Zmx5TUxZN1R2STNFWExqV0k2MFVGYgpxVmdjeHovcEJYeW9xZjgwYi9RZ2xhOGhwelRpSTZBcFU2Rm11dHNnc05hRDN2Z2krNURYYlNwdllGUFFNd3V3CmN1Uy9PSXdGVTZWQi9BUi94MC9FeldDVndrcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2011"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:11 GMT
+      - Mon, 18 Dec 2023 14:14:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 876334c8-f0b1-4b13-8032-c1522c80ca85
+      - 59170120-ed8f-4d62-ac4f-b1802e05b61c
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,7 +1005,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0600f61c-185e-408f-babf-73bddd2210b5&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?order_by=name_asc&page=1
+    method: GET
+  response:
+    body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
+    headers:
+      Content-Length:
+      - "58"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:14:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 09c50e87-6b41-42f3-8999-305125c0ed2b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVkZXUmpWdVZpcUsweno4YkNEL0xiUFluQWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRReE16VXpXaGNOTXpNeE1qRTFNVFF4TXpVeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUo3UVVib0w1bHBvNmk1UGpPREE3MU53TGhXaFNPNThKU0ZpM3Y1cEIvYUladkVaZXBHc1ZqM1EKd0NwN3YxazdNT2E4ckxHdjZ4alJ1VkR2MzNqdkFyWTVSVGVuVzRld2IxOU5Fd2UxQU9MMEpLYWVwM1o4QXdVSApxSGRETjJYUzFOd0lLNFhLRWZpbGwzMGlrajEwY1FnY2VGV3dvSXpPczFEVWRFSEEwMXc1K3BwQjFxMEU0VnI2CklFdmt0cXdpb2llRERQSURzRTFlUW9lTUs0ajE5WVNETzBZTWlRNitGSUl2VFNrcGRXa3FFYXcxaERSVWdMN2EKOG5UdElkVVR4aEo3NG8xaVBsMGFjUWxIb3JNYjNzRWoyOHFFVDB2VkpGYTB2WWhCbFdSSVY1OVpYdjhEdjlWYwoyNjZxNEZNUTZhUys5clc2bDNNTjl5WlFxNnNJeGdFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxOelUwT1dSaE9TMDNPRFkzTFRRMlltSXRPR1E1TWkwd05UUmoKWkRCa1pUY3habU11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1UzTlRRNVpHRTVMVGM0TmpjdE5EWmlZaTA0WkRreUxUQTFOR05rTUdSbE56Rm1ZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy9YUjRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKUnZqTUpUZnRPTVJ0U2R4Tkh1TTBpV3RJdjJGSksvbUdkekgxNUpKdDdsVTlFa1FRdnJsSWdsbnEzVDFjb0ZHNApQK1JaRUFLT0NFbVU0b3Nsb2lNY3NvdlR1akxRZDltbDhsYnRoeFZaYWU0L2tnVmU1bFVhTSttRlBDUXpFOTdJCnBKQk5qSkNRNXRka1AyK2x4MTVxcGpicFZlWE5lUUdCQ0p3YkYyUjdXM0FzWmdRdndoZ1lzSjFiTloxaWVVT2YKSWtiZlVSc1ByT0dVLzIrOWMzRVQ5MG1QSkJKaThvNGluVHVKTHhrQWdRekEwdHZ5SkcxQVZ3bE4zcUJ6MFdkTQpTS3ZucVd5VnJHZDRnMC9aN2V5MmFKMEQrNjcvYUtabFdxUFJZQWtncUc1bmp3QTkveFozcTRXbnIzbHhGMkU1CkpQd0lWUXY0M01EMHhtSVhpZnppL0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:14:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2f91ba16-3143-4976-ac37-67efd60f2959
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e7549da9-7867-46bb-8d92-054cd0de71fc&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1050,7 +1083,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:11 GMT
+      - Mon, 18 Dec 2023 14:14:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 903ada0d-c27f-497f-b8cb-a63a2b224cce
+      - 4ac4c777-2564-47e7-88a8-5e694d3cc827
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,19 +1104,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:11 GMT
+      - Mon, 18 Dec 2023 14:14:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1093,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57fa3b82-b490-487a-8e6b-10d0c7c82bbc
+      - 04168d8b-e3f9-49cd-8c19-b69b7600adbd
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,7 +1137,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
@@ -1116,7 +1149,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:11 GMT
+      - Mon, 18 Dec 2023 14:14:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1126,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49c64970-99c5-4532-b200-f01b35ac85aa
+      - abbd583c-f8f8-499f-b77e-dbcfdb605933
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,19 +1170,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:12 GMT
+      - Mon, 18 Dec 2023 14:14:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29b8afc2-e96d-4cda-8582-d0eb1bf61fb6
+      - 25884fb8-e788-4172-89a9-bb6c375a2fa6
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,19 +1203,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTk85dVRmUjdYampSclM1RGg1Y010emFRNjI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVY0VML3g5aEl4YzNQeXNSNGovODJNRFMwb2JLei9hQUc2ZkNFKy8wM0pzUjVVOG54OEUKU3NkN0NzSU9vbG5VVkFkbTZ2WWNzdmZENW55Qlpha2dCSUxsZ1RTWnlGN0M1Y3hIOTdldHRuYS96ck9hRHYyTgpkeDJBSWw3V2orNVZyK0R6R2FaKzFyNFlUOWdhUk9jT09vUEJ6ZDBCc0MyWkNMUFVhMzdoc0FudDZYTVJTTVZLCm1wdmszWUxTWGM4MC8xMHhYTjdlQTNmSHRzdmpNRWU0WGFBS2RJR3F1d1dLdVhCcnRJZm42OUlsanR5U29Hak4KbUg0RnVieDRWSE51akxpYmVWQVJFYzVISVJHNDRpcnduYTFjOEppV1IzQklpNlpqejF0Sm95RUlRZG9tZXc2cgpsU3cxbmhHUXhNYWYrdnNRN0tKZFpUeGJTbFFIZThaOEZ3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB3TmpBd1pqWXhZeTB4T0RWbExUUXdPR1l0WW1GaVppMDMKTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwd05qQXdaall4WXkweE9EVmxMVFF3T0dZdFltRmlaaTAzTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVmpmb3ZaeUtqN2UvT3lZbDMwMFJCeXViSk11ZDVQeFBmWGh4MmZUeGNhVTJkMkJBdWx6WndXYWhvRgp5UnNiZFE3STJhbTVhUkdjRWxsdFI2QjdwOVpUV3lkSW4wd2lYWk45b1FDOTdWaTFKTW81VjFnZndCVTQwOS9rCkN0ejdXV3A4NlBkMncvbVBoeHNXZVpkMGVrT21obmU0cFVvTVd2UVFjYXluOVJWZS9YY2hCNkd4VzQ0bkNnQmkKN1FtenkzNHNSVnFWSzd1bHlXMm9FMk9lMllVV1ZEK0VvYnNTTWlRQUE5Zmx5TUxZN1R2STNFWExqV0k2MFVGYgpxVmdjeHovcEJYeW9xZjgwYi9RZ2xhOGhwelRpSTZBcFU2Rm11dHNnc05hRDN2Z2krNURYYlNwdllGUFFNd3V3CmN1Uy9PSXdGVTZWQi9BUi94MC9FeldDVndrcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVkZXUmpWdVZpcUsweno4YkNEL0xiUFluQWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRReE16VXpXaGNOTXpNeE1qRTFNVFF4TXpVeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUo3UVVib0w1bHBvNmk1UGpPREE3MU53TGhXaFNPNThKU0ZpM3Y1cEIvYUladkVaZXBHc1ZqM1EKd0NwN3YxazdNT2E4ckxHdjZ4alJ1VkR2MzNqdkFyWTVSVGVuVzRld2IxOU5Fd2UxQU9MMEpLYWVwM1o4QXdVSApxSGRETjJYUzFOd0lLNFhLRWZpbGwzMGlrajEwY1FnY2VGV3dvSXpPczFEVWRFSEEwMXc1K3BwQjFxMEU0VnI2CklFdmt0cXdpb2llRERQSURzRTFlUW9lTUs0ajE5WVNETzBZTWlRNitGSUl2VFNrcGRXa3FFYXcxaERSVWdMN2EKOG5UdElkVVR4aEo3NG8xaVBsMGFjUWxIb3JNYjNzRWoyOHFFVDB2VkpGYTB2WWhCbFdSSVY1OVpYdjhEdjlWYwoyNjZxNEZNUTZhUys5clc2bDNNTjl5WlFxNnNJeGdFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxOelUwT1dSaE9TMDNPRFkzTFRRMlltSXRPR1E1TWkwd05UUmoKWkRCa1pUY3habU11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1UzTlRRNVpHRTVMVGM0TmpjdE5EWmlZaTA0WkRreUxUQTFOR05rTUdSbE56Rm1ZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy9YUjRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKUnZqTUpUZnRPTVJ0U2R4Tkh1TTBpV3RJdjJGSksvbUdkekgxNUpKdDdsVTlFa1FRdnJsSWdsbnEzVDFjb0ZHNApQK1JaRUFLT0NFbVU0b3Nsb2lNY3NvdlR1akxRZDltbDhsYnRoeFZaYWU0L2tnVmU1bFVhTSttRlBDUXpFOTdJCnBKQk5qSkNRNXRka1AyK2x4MTVxcGpicFZlWE5lUUdCQ0p3YkYyUjdXM0FzWmdRdndoZ1lzSjFiTloxaWVVT2YKSWtiZlVSc1ByT0dVLzIrOWMzRVQ5MG1QSkJKaThvNGluVHVKTHhrQWdRekEwdHZ5SkcxQVZ3bE4zcUJ6MFdkTQpTS3ZucVd5VnJHZDRnMC9aN2V5MmFKMEQrNjcvYUtabFdxUFJZQWtncUc1bmp3QTkveFozcTRXbnIzbHhGMkU1CkpQd0lWUXY0M01EMHhtSVhpZnppL0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2011"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:12 GMT
+      - Mon, 18 Dec 2023 14:14:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a821fc2-3bb8-4308-8a76-7ec436ec8ab2
+      - 2a133286-d3fa-460f-954e-6f72551cdbd9
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,7 +1236,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0600f61c-185e-408f-babf-73bddd2210b5&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e7549da9-7867-46bb-8d92-054cd0de71fc&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1215,7 +1248,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:12 GMT
+      - Mon, 18 Dec 2023 14:14:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0782ceae-cb79-4b60-a181-67a3dfbb5b46
+      - e17d199a-d265-4c5e-be33-26cc9f552504
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,19 +1269,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:12 GMT
+      - Mon, 18 Dec 2023 14:14:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f3cd24c-c906-41ad-9aa2-837600e317ad
+      - 2df23377-5518-4536-a641-9a418d9c80ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,7 +1302,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=foo&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?name=foo&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":true,"name":"foo"}]}'
@@ -1281,7 +1314,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:12 GMT
+      - Mon, 18 Dec 2023 14:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b56fabda-caa2-4db2-b3bf-799c285a4479
+      - 6af612cc-7947-4cf0-8cd7-e0e2fd6d23de
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,19 +1335,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:12 GMT
+      - Mon, 18 Dec 2023 14:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab309669-88c0-433d-9255-abc74df4e0cd
+      - 062ca96c-c4a3-4c51-b004-767ef448e8ad
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,7 +1368,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users/foo
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users/foo
     method: DELETE
   response:
     body: ""
@@ -1345,7 +1378,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:13 GMT
+      - Mon, 18 Dec 2023 14:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70afd778-0c8a-4c73-a506-2abba4b186f8
+      - 618fe8ff-12fd-4d30-b704-991eb10065c1
     status: 204 No Content
     code: 204
     duration: ""
@@ -1366,19 +1399,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:13 GMT
+      - Mon, 18 Dec 2023 14:14:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6983e89-9c5a-47cd-9a8b-7b0349e5c4b3
+      - 040c4f76-aebe-4c47-9595-f0ef54024ecf
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,7 +1434,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users
     method: POST
   response:
     body: '{"is_admin":false,"name":"bar"}'
@@ -1413,7 +1446,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:13 GMT
+      - Mon, 18 Dec 2023 14:14:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d8ed627-a84e-4a23-8691-335976e5cf1a
+      - cad47155-1b20-42f3-b51e-cd1f3c1e4438
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,19 +1467,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:13 GMT
+      - Mon, 18 Dec 2023 14:14:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1456,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8921aa1b-9058-44fd-a2a8-2c934a0a1260
+      - b1d738e9-b7ae-42e6-91de-851f731ae980
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,40 +1500,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=bar&order_by=name_asc
-    method: GET
-  response:
-    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
-    headers:
-      Content-Length:
-      - "59"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:01:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 59c0b462-ed7e-4dc8-ab46-64695879cc1c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=bar&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?name=bar&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
@@ -1512,7 +1512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:13 GMT
+      - Mon, 18 Dec 2023 14:14:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4731aafb-2c99-420e-9642-6b0d25ec9830
+      - 5a8eae3f-7f52-42f9-a16a-c10f0b6ff2f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,19 +1533,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?name=bar&order_by=name_asc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
     headers:
       Content-Length:
-      - "1265"
+      - "59"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:14 GMT
+      - Mon, 18 Dec 2023 14:14:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed006a38-8416-4f98-8a90-9781d9a7d71f
+      - b63458ec-a548-4bd5-852d-e3bee71e7b53
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,19 +1566,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTk85dVRmUjdYampSclM1RGg1Y010emFRNjI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSXpNVEl4T0RFek1EQXlPVm9YRFRNek1USXhOVEV6TURBeU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTRVY0VML3g5aEl4YzNQeXNSNGovODJNRFMwb2JLei9hQUc2ZkNFKy8wM0pzUjVVOG54OEUKU3NkN0NzSU9vbG5VVkFkbTZ2WWNzdmZENW55Qlpha2dCSUxsZ1RTWnlGN0M1Y3hIOTdldHRuYS96ck9hRHYyTgpkeDJBSWw3V2orNVZyK0R6R2FaKzFyNFlUOWdhUk9jT09vUEJ6ZDBCc0MyWkNMUFVhMzdoc0FudDZYTVJTTVZLCm1wdmszWUxTWGM4MC8xMHhYTjdlQTNmSHRzdmpNRWU0WGFBS2RJR3F1d1dLdVhCcnRJZm42OUlsanR5U29Hak4KbUg0RnVieDRWSE51akxpYmVWQVJFYzVISVJHNDRpcnduYTFjOEppV1IzQklpNlpqejF0Sm95RUlRZG9tZXc2cgpsU3cxbmhHUXhNYWYrdnNRN0tKZFpUeGJTbFFIZThaOEZ3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTB3TmpBd1pqWXhZeTB4T0RWbExUUXdPR1l0WW1GaVppMDMKTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkwd05qQXdaall4WXkweE9EVmxMVFF3T0dZdFltRmlaaTAzTTJKa1pHUXlNakV3WWpVdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3JPNkhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFKVmpmb3ZaeUtqN2UvT3lZbDMwMFJCeXViSk11ZDVQeFBmWGh4MmZUeGNhVTJkMkJBdWx6WndXYWhvRgp5UnNiZFE3STJhbTVhUkdjRWxsdFI2QjdwOVpUV3lkSW4wd2lYWk45b1FDOTdWaTFKTW81VjFnZndCVTQwOS9rCkN0ejdXV3A4NlBkMncvbVBoeHNXZVpkMGVrT21obmU0cFVvTVd2UVFjYXluOVJWZS9YY2hCNkd4VzQ0bkNnQmkKN1FtenkzNHNSVnFWSzd1bHlXMm9FMk9lMllVV1ZEK0VvYnNTTWlRQUE5Zmx5TUxZN1R2STNFWExqV0k2MFVGYgpxVmdjeHovcEJYeW9xZjgwYi9RZ2xhOGhwelRpSTZBcFU2Rm11dHNnc05hRDN2Z2krNURYYlNwdllGUFFNd3V3CmN1Uy9PSXdGVTZWQi9BUi94MC9FeldDVndrcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2011"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:14 GMT
+      - Mon, 18 Dec 2023 14:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be8f79c1-0f44-4307-be2d-0fb4e0317ac4
+      - d12e2ef8-43be-48ee-ba9e-0866032a20de
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,7 +1599,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=0600f61c-185e-408f-babf-73bddd2210b5&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVkZXUmpWdVZpcUsweno4YkNEL0xiUFluQWFjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU16Z3dIaGNOCk1qTXhNakU0TVRReE16VXpXaGNOTXpNeE1qRTFNVFF4TXpVeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl6T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUo3UVVib0w1bHBvNmk1UGpPREE3MU53TGhXaFNPNThKU0ZpM3Y1cEIvYUladkVaZXBHc1ZqM1EKd0NwN3YxazdNT2E4ckxHdjZ4alJ1VkR2MzNqdkFyWTVSVGVuVzRld2IxOU5Fd2UxQU9MMEpLYWVwM1o4QXdVSApxSGRETjJYUzFOd0lLNFhLRWZpbGwzMGlrajEwY1FnY2VGV3dvSXpPczFEVWRFSEEwMXc1K3BwQjFxMEU0VnI2CklFdmt0cXdpb2llRERQSURzRTFlUW9lTUs0ajE5WVNETzBZTWlRNitGSUl2VFNrcGRXa3FFYXcxaERSVWdMN2EKOG5UdElkVVR4aEo3NG8xaVBsMGFjUWxIb3JNYjNzRWoyOHFFVDB2VkpGYTB2WWhCbFdSSVY1OVpYdjhEdjlWYwoyNjZxNEZNUTZhUys5clc2bDNNTjl5WlFxNnNJeGdFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNak00Z2p4eWR5MWxOelUwT1dSaE9TMDNPRFkzTFRRMlltSXRPR1E1TWkwd05UUmoKWkRCa1pUY3habU11Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNemlDUEhKMwpMV1UzTlRRNVpHRTVMVGM0TmpjdE5EWmlZaTA0WkRreUxUQTFOR05rTUdSbE56Rm1ZeTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNdy9YUjRjRU01OUs3b2NFTTU5SzdqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKUnZqTUpUZnRPTVJ0U2R4Tkh1TTBpV3RJdjJGSksvbUdkekgxNUpKdDdsVTlFa1FRdnJsSWdsbnEzVDFjb0ZHNApQK1JaRUFLT0NFbVU0b3Nsb2lNY3NvdlR1akxRZDltbDhsYnRoeFZaYWU0L2tnVmU1bFVhTSttRlBDUXpFOTdJCnBKQk5qSkNRNXRka1AyK2x4MTVxcGpicFZlWE5lUUdCQ0p3YkYyUjdXM0FzWmdRdndoZ1lzSjFiTloxaWVVT2YKSWtiZlVSc1ByT0dVLzIrOWMzRVQ5MG1QSkJKaThvNGluVHVKTHhrQWdRekEwdHZ5SkcxQVZ3bE4zcUJ6MFdkTQpTS3ZucVd5VnJHZDRnMC9aN2V5MmFKMEQrNjcvYUtabFdxUFJZQWtncUc1bmp3QTkveFozcTRXbnIzbHhGMkU1CkpQd0lWUXY0M01EMHhtSVhpZnppL0E9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 18 Dec 2023 14:14:40 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6608ee24-9f3d-459f-b9a5-ff67cd968ed0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e7549da9-7867-46bb-8d92-054cd0de71fc&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1611,7 +1644,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:14 GMT
+      - Mon, 18 Dec 2023 14:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1621,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09214269-86d5-4290-92ae-82c193e02bc6
+      - 853761de-8461-478e-b5ba-01b8ed0793d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,19 +1665,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:14 GMT
+      - Mon, 18 Dec 2023 14:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1654,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f52e59a7-2d78-4f7c-b4a9-df70417b20a0
+      - 01a9a6ca-bf7c-4f50-b761-3a8e6751205f
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,7 +1698,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users?name=bar&order_by=name_asc
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users?name=bar&order_by=name_asc
     method: GET
   response:
     body: '{"total_count":1,"users":[{"is_admin":false,"name":"bar"}]}'
@@ -1677,7 +1710,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:15 GMT
+      - Mon, 18 Dec 2023 14:14:40 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1687,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 794b9346-5f12-44ff-b794-ad372e8c05e7
+      - 20e92ec8-0258-4001-81a7-5f269527aef2
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,19 +1731,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:15 GMT
+      - Mon, 18 Dec 2023 14:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1720,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0789ff78-17e7-462f-9abd-b2f11a39ac5c
+      - cb743668-8e52-4a59-81c7-a5f5ba84c035
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,7 +1764,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5/users/bar
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc/users/bar
     method: DELETE
   response:
     body: ""
@@ -1741,7 +1774,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:15 GMT
+      - Mon, 18 Dec 2023 14:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1751,7 +1784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bff4672a-1528-49b2-bed9-ee4279d88202
+      - 57036829-81a3-4b73-b314-2295f57b2538
     status: 204 No Content
     code: 204
     duration: ""
@@ -1762,19 +1795,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1265"
+      - "1263"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:15 GMT
+      - Mon, 18 Dec 2023 14:14:41 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1784,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12db8343-5440-4eb7-949a-ee16c9f0c19f
+      - a7bd2e67-6591-47c6-83e2-989dae21d752
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,19 +1828,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:15 GMT
+      - Mon, 18 Dec 2023 14:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1817,7 +1850,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e6009b8-4587-4813-b3ec-7f5c687f8e85
+      - dc31dd0e-5586-4613-937f-eff23b6255d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,19 +1861,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T12:57:07.402469Z","retention":7},"created_at":"2023-12-18T12:57:07.402469Z","endpoint":{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663},"endpoints":[{"id":"418223e0-349f-4149-badb-4c077776fe49","ip":"51.159.207.148","load_balancer":{},"name":null,"port":25663}],"engine":"PostgreSQL-15","id":"0600f61c-185e-408f-babf-73bddd2210b5","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":false,"frequency":24,"next_run_at":"2023-12-19T14:10:59.355092Z","retention":7},"created_at":"2023-12-18T14:10:59.355092Z","endpoint":{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601},"endpoints":[{"id":"1dd269a6-4396-4ab8-b64b-b5af3808a9b3","ip":"51.159.74.238","load_balancer":{},"name":null,"port":17601}],"engine":"PostgreSQL-15","id":"e7549da9-7867-46bb-8d92-054cd0de71fc","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"TestAccScalewayRdbUser_Basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_user","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1268"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:15 GMT
+      - Mon, 18 Dec 2023 14:14:42 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1850,7 +1883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06f064ba-421b-4b0a-8852-38870baff78c
+      - e8b48f45-9022-4eee-94dc-aed01cca09d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1861,10 +1894,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0600f61c-185e-408f-babf-73bddd2210b5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e7549da9-7867-46bb-8d92-054cd0de71fc","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1873,7 +1906,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:46 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1883,7 +1916,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99ec873e-15d4-4b41-a676-530b646a80ac
+      - 16cbda59-8b73-46ad-9898-b71e6d133ab3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1894,10 +1927,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/0600f61c-185e-408f-babf-73bddd2210b5
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e7549da9-7867-46bb-8d92-054cd0de71fc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"0600f61c-185e-408f-babf-73bddd2210b5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e7549da9-7867-46bb-8d92-054cd0de71fc","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1906,7 +1939,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:01:46 GMT
+      - Mon, 18 Dec 2023 14:15:12 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1916,7 +1949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 003e8dd5-3eee-4494-b92b-6d16d468877d
+      - 75451f03-3367-4d06-bcfc-219501fd0e73
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
This PR changes the way endpoints are handled to integrate the latest changes in the RDB API: if a private network is defined, there is no more default public endpoint. So if the user wants both a private and a public endpoint, they must explicitly declare a `load_balancer {}` empty block alongside the `private_network`. This also means there is no need for the `disable_public_endpoint` field anymore.
Closes #2281 

Also there was a problem with the updates of private network endpoints, that did not always use IPAM as they should.
Closes #2299

The PR should also fix the nightly tests.