### PR TITLE
feat(k8s): add warning if cluster type is not prefixed by kapsule or multicloud

### DIFF
--- a/scaleway/resource_k8s_cluster.go
+++ b/scaleway/resource_k8s_cluster.go
@@ -3,7 +3,6 @@ package scaleway
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -335,7 +334,7 @@ func resourceScalewayK8SClusterCreate(ctx context.Context, d *schema.ResourceDat
 		clusterType = ""
 	}
 
-	if !slices.ContainsFunc([]string{"kapsule", "multicloud"}, func(s string) bool { return strings.HasPrefix(clusterType.(string), s) }) {
+	if !strings.HasPrefix(d.Get("type").(string), "kapsule") && !strings.HasPrefix(d.Get("type").(string), "multicloud") {
 		diags = append(diags, diag.Diagnostic{
 			Severity:      diag.Warning,
 			Summary:       "Unexpected cluster type",
@@ -628,7 +627,7 @@ func resourceScalewayK8SClusterUpdate(ctx context.Context, d *schema.ResourceDat
 
 	var diags diag.Diagnostics
 
-	if !slices.ContainsFunc([]string{"kapsule", "multicloud"}, func(s string) bool { return strings.HasPrefix(d.Get("type").(string), s) }) {
+	if !strings.HasPrefix(d.Get("type").(string), "kapsule") && !strings.HasPrefix(d.Get("type").(string), "multicloud") {
 		diags = append(diags, diag.Diagnostic{
 			Severity:      diag.Warning,
 			Summary:       "Unexpected cluster type",

--- a/scaleway/resource_k8s_cluster.go
+++ b/scaleway/resource_k8s_cluster.go
@@ -337,9 +337,10 @@ func resourceScalewayK8SClusterCreate(ctx context.Context, d *schema.ResourceDat
 
 	if !slices.ContainsFunc([]string{"kapsule", "multicloud"}, func(s string) bool { return strings.HasPrefix(clusterType.(string), s) }) {
 		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "Unexpected cluster type",
-			Detail:   fmt.Sprintf("The expected cluster type is one of %v, but got %s", []string{"kapsule", "multicloud", "kapsule-dedicated-*", "multicloud-dedicated-*"}, clusterType.(string)),
+			Severity:      diag.Warning,
+			Summary:       "Unexpected cluster type",
+			Detail:        fmt.Sprintf("The expected cluster type is one of %v, but got %s", []string{"kapsule", "multicloud", "kapsule-dedicated-*", "multicloud-dedicated-*"}, clusterType.(string)),
+			AttributePath: cty.GetAttrPath("type"),
 		})
 	}
 
@@ -629,9 +630,10 @@ func resourceScalewayK8SClusterUpdate(ctx context.Context, d *schema.ResourceDat
 
 	if !slices.ContainsFunc([]string{"kapsule", "multicloud"}, func(s string) bool { return strings.HasPrefix(d.Get("type").(string), s) }) {
 		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  "Unexpected cluster type",
-			Detail:   fmt.Sprintf("The expected cluster type is one of %v, but got %s", []string{"kapsule", "multicloud", "kapsule-dedicated-*", "multicloud-dedicated-*"}, d.Get("type").(string)),
+			Severity:      diag.Warning,
+			Summary:       "Unexpected cluster type",
+			Detail:        fmt.Sprintf("The expected cluster type is one of %v, but got %s", []string{"kapsule", "multicloud", "kapsule-dedicated-*", "multicloud-dedicated-*"}, d.Get("type").(string)),
+			AttributePath: cty.GetAttrPath("type"),
 		})
 	}
 


### PR DESCRIPTION
This PR add a warning if cluster type is not prefixed by kapsule or multicloud, instead of returning an error.