### PR TITLE
ci: use official tfproviderlint

### DIFF
--- a/.github/workflows/tfproviderlint.yml
+++ b/.github/workflows/tfproviderlint.yml
@@ -14,6 +14,6 @@ jobs:
         with:
           go-version: 1.21
       - name: Install tfproviderlint
-        run: go install github.com/Codelax/tfproviderlint/cmd/tfproviderlint@9a212663f6cab5b28933496a85d7f7168d82360f
+        run: go install github.com/bflad/tfproviderlint/cmd/tfproviderlint@latest
       - name: Run tfproviderlint
         run: tfproviderlint ./...


### PR DESCRIPTION
A fork was previously used as the official version was broken