### PR TITLE
fix(rdb): read replica: endpoints management

### DIFF
--- a/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:08 GMT
+      - Thu, 18 Jan 2024 12:42:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49f8db96-d97d-426e-bed3-eb1395da3e8a
+      - 712b2915-b68d-4527-a610-3dd6a9e38c21
     status: 200 OK
     code: 200
     duration: ""
@@ -339,21 +339,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff5d9fcd-b1b5-4950-8ed1-eb0864fe28fa
+      - 32446f0b-1b87-4a12-8a45-5b1724bab906
     status: 200 OK
     code: 200
     duration: ""
@@ -372,21 +372,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cd054af-8685-4977-a9dc-2e822e8585cb
+      - 60b472ec-e810-420e-8676-64f82eb3a9b8
     status: 200 OK
     code: 200
     duration: ""
@@ -405,21 +405,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:42 GMT
+      - Thu, 18 Jan 2024 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c3a8a65-637b-48ae-8d87-821f9247c47b
+      - 99c52524-fac8-4e18-8a2a-6296bf8c03e6
     status: 200 OK
     code: 200
     duration: ""
@@ -438,21 +438,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:12 GMT
+      - Thu, 18 Jan 2024 12:43:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f34f71c-0768-4f31-97f0-aea0bdc79860
+      - 5cdaae38-0e0c-4035-a671-cf181dd432e9
     status: 200 OK
     code: 200
     duration: ""
@@ -471,21 +471,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:42 GMT
+      - Thu, 18 Jan 2024 12:44:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78448f40-1d57-4a02-b165-9a48dbd5e714
+      - c85a95e0-1011-4b80-b539-01ec6bef9ffe
     status: 200 OK
     code: 200
     duration: ""
@@ -504,21 +504,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "761"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:12 GMT
+      - Thu, 18 Jan 2024 12:44:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8ae1840-0d97-4e7c-8f66-db31b594f9ec
+      - a25d837e-4c8b-4873-a80e-29e0cbf56621
     status: 200 OK
     code: 200
     duration: ""
@@ -537,21 +537,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "1025"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:43 GMT
+      - Thu, 18 Jan 2024 12:45:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3936ed6c-640b-430c-83c2-50b1f15e3fa2
+      - f03fb2c6-c4f5-416a-9a92-2bbef72a7846
     status: 200 OK
     code: 200
     duration: ""
@@ -570,21 +570,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622},"endpoints":[{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622}],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "790"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 12:45:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 081d694c-b9ec-433a-b38b-fbfceaeaf445
+      - c8ba76d2-f2f6-4f85-9af9-ba6bca72a901
     status: 200 OK
     code: 200
     duration: ""
@@ -603,21 +603,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVS2psd2RLWXVRam9qaFFTc1dQZVEwUmU2dy9rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpFdU1UWXdNQjRYCkRUSTBNREV4T0RFeU5EVXdObG9YRFRNME1ERXhOVEV5TkRVd05sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekV1TVRZd01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTBXM2JDZk1jaTJQL0JIaE1tY2FUNUNjTEFwUE91OVFUbW5JZzIvbGd0UDFLSm42ODZ1WUgKZnNmZUxYU0JMRWVyZFhFRlZzNzR3RnMyMzFGVlNnbnFBUzEwbnhhWmpHbHBsa2dDd3F0UEZ0TExGN0NhZjhxRQp4L1EwcDk1NzlnaGN3cjU1OUhBK0hXZ1FXUVV2SkJZUDZpMDlpWWpTUnNhTUlnMUhka0FqQXlQd0RZeXJ5UVpQClFKbVYwYTFEWU1nQzdMVlhnZkFrYWV6MHpKNFN0akY5MmF3eERaMUhiMXF4T2t4RjFFR0JZZGVlc3lVVXhCdEYKTkk3RVJNRHYzZ1FoNzRYK0FUbzBIUE9MSlNYODZJUndGWE8wdXYyNnYxSW1ad3IyWjExM0lYVUp4ZVZCcnI3eQpMRFNoVU9zRVN2REMyanAyS00yZTY0S2JrUjZlQmY3NWN3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOekV1TVRZd2dqeHlkeTB6WlRsak5qZzVPQzFrTW1FMUxUUTBOamt0WWpWak9TMHgKWVRSaFl6ZzBNMkUxTkRRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOekV1TVRZdwpnanh5ZHkwelpUbGpOamc1T0Mxa01tRTFMVFEwTmprdFlqVmpPUzB4WVRSaFl6ZzBNMkUxTkRRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3J6cUhCTU9hUjZDSEJNT2FSNkF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFHeURuOStWbllhbzF3RUFuWkpTYlNaQ1lvd3JSdXBualJZajVWQXNqTE5ab0M4ZjZsT3BZaUpBc1M0Vgo3VVpLQmZyMFF0WlNwRDRyNWJvVEMrTEFnL1YvejhCUTVPcHk5UnE1T1YwTHRXNlp6TzI1ZnBreHlKU3Q4ekNBCkVRcC9HUmhWSG9NRzJkVUtkeGIrTTIxR3B2dXdSMXpTRFJTVTk1Vkc1VW1LODd4SXdKOUtYOGIvLzRrOHM0L0oKSlFvV083SEFKSng5dXB1d2ovaVVqTXN1WlVQTHFoeGl0VlliM3A4VXQ0M3VsWmZXQUwvN01wOXZOeGNueEdYbgp3UnRQMkZhb2NmUVJxaW1Kc00xNDhsdEtmR20vNFFHMzFKVFJTdWN5RW44ZiswZnZyeVpxOEVPNWtlRmNzaTQ4Cks4amxsNWNPUXFkMUhFVkI5SDBLMHk2dFlQMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1065"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:43 GMT
+      - Thu, 18 Jan 2024 12:45:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8447d56a-4bca-4b2b-b307-fd798d834c4e
+      - b2a82615-a165-474b-94a8-e1f0964da4e2
     status: 200 OK
     code: 200
     duration: ""
@@ -636,87 +636,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749},"endpoints":[{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749}],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1280"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:29:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f620ed6b-5884-40d7-807b-9f66af398621
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRU5jM1IvWmlvTnkwekovZkVJVm5UWW02ZVpnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TURZdU5URXdIaGNOCk1qUXdNVEE1TVRjeU9ESTRXaGNOTXpRd01UQTJNVGN5T0RJNFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSXdOaTQxTVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0xbGd4UTlvdmVCMlBOQ1NJc21OWElYUitVL3B5NGtoMGRHbmE0QlZEc3F0aEhHbWxpdTduZEgKWGFsNjQyVm1Kd0FLSHJVOFhKN3ZIeW93MEt4d3BkSkpNOW9VZzVhTEd6b0RRWms1Z1BWbUFHOHl4ZlZCRFFBTQp1WGdOTXJ1M1pnMXNjVGJPMUxkMlpnYnhVUjRtRlNrUnhXMURscDdBa29YV1o5TSthaWtIYWdWQVBJOW9ZMmptCjAwOFRSc3JzQlVmREVLY281bDNKR2dUbEY1QTVGWFI0ZWEySTZqTHJ1cjkzc09uUytWMlNnakx4bU9QWUxHTzQKcWNFQyt4SVZkNVIydjBxSTA2blR2cDFkbjlsYVYrUjdrU2xKMThFYmVLTzZHbDhINklaN2c0VkY0VWtIQ0FscgphSkt0UjBYV0FjbDBVcGdRNllhZFd0M3RpRnRYcjhNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qQTJMalV4Z2p4eWR5MDROR1l5WlRRek5pMWxPVFEyTFRRM09UVXRZakU1TUMxak5EQXoKWkRRM00yRmlOMlV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU1EWXVOVEdDUEhKMwpMVGcwWmpKbE5ETTJMV1U1TkRZdE5EYzVOUzFpTVRrd0xXTTBNRE5rTkRjellXSTNaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVsK1ljRU01L09NNGNFTTUvT016QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVWNYeWdCVTg4SkJ4SThnZllkRFBpdy95V3hEazFrYStqc2dERFpmNnYzMmNsMW9ncXpYOUNoTkxmcXBpNytTeQpSb1VtVnB6UmlrcXJDVDcxSHkzNXhwYkhPMTlMTWJidVZlRVo5TUZmRWJFMzZJVUhNZHNidkR6bEw1QThxd3IrCnArbTE1YlBpWnVQR0tKMlhpOC9BU29MY1VCQnJES3JlYi95OUx1UUEwNEY5Unk3aUN5aHNEWnduYWtCMEE5aW0KNkJOS0ZSS2hadlI4M1lYUUI1ZlN3Skpubm4ybEpVUllyN1hJYlp4K2FuSHdVQnhRR1pmT2VwcHBOelhlKzNrNgphTGZkVFBHdFJoelNWR2pNWlNwd1F5ekpwSGRnTDZZb1Y3dWR4TUFwNVZOZzV0Yk1hRk1sbnZmU2J2NDFvOGhSCmVYTExJTkdmRWFYUWIyTUpkWTJlZGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2009"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:29:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f6b3a8f6-8fa5-49d0-bb51-314990d7c6c5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=84f2e436-e946-4795-b190-c403d473ab7e&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3e9c6898-d2a5-4469-b5c9-1a4ac843a544&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:13 GMT
+      - Thu, 18 Jan 2024 12:45:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,32 +660,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acca5575-9af9-42e4-8bef-e4f9be35fe80
+      - 72c02bae-5bd7-4ea9-9e3f-306e6a4e55d1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
+    body: '{"instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "177"
+      - "172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:14 GMT
+      - Thu, 18 Jan 2024 12:45:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dca91acb-52b9-48f4-b05c-fe4f1da5ab53
+      - 3e04e5c1-f9ec-401e-92d0-bb93f53c5ebf
     status: 200 OK
     code: 200
     duration: ""
@@ -770,21 +704,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "177"
+      - "172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:14 GMT
+      - Thu, 18 Jan 2024 12:45:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fea7238b-1caa-4f87-979e-3a627179fb8b
+      - c682eea7-e20c-434b-8e2d-cd0e9c8b2e17
     status: 200 OK
     code: 200
     duration: ""
@@ -803,21 +737,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "177"
+      - "172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:44 GMT
+      - Thu, 18 Jan 2024 12:46:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44909958-0975-4d10-9892-6a2766e5a97c
+      - 72ddb1db-8ea7-4ad3-9762-520fe39901dd
     status: 200 OK
     code: 200
     duration: ""
@@ -836,21 +770,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "292"
+      - "280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:14 GMT
+      - Thu, 18 Jan 2024 12:46:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df588438-2bde-42bf-a6ce-946ede487521
+      - ddd63347-ece2-4f95-be5b-ac158db977b4
     status: 200 OK
     code: 200
     duration: ""
@@ -869,21 +803,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "292"
+      - "280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:44 GMT
+      - Thu, 18 Jan 2024 12:47:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62af90d2-4625-4564-8c14-8dbdcf531ce2
+      - 59949c44-e4a7-49cd-966b-03ac7333b19d
     status: 200 OK
     code: 200
     duration: ""
@@ -902,21 +836,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "292"
+      - "280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:14 GMT
+      - Thu, 18 Jan 2024 12:47:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d52847be-b072-48e8-8aff-25580a83a6a5
+      - 14e7700e-059c-42d3-8f6c-3b1bb8a8f77d
     status: 200 OK
     code: 200
     duration: ""
@@ -935,21 +869,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "292"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:45 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 262c04d7-9671-4d2a-8831-c90392c1f584
+      - f86faa2f-95c3-483d-8412-16bbfeda37d9
     status: 200 OK
     code: 200
     duration: ""
@@ -968,21 +902,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "285"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:15 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -992,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 639b18f1-3b4d-4069-9d9e-ac8b13ecf97b
+      - f6f80b14-01c9-487c-88e0-3bf2938a375c
     status: 200 OK
     code: 200
     duration: ""
@@ -1001,153 +935,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
-    method: GET
-  response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "285"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dac8f893-43a5-4013-86fb-d50fb8cc516d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
-    method: GET
-  response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "285"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 46d265aa-9d15-4ee9-96e7-e69782cc6c4b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749},"endpoints":[{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749}],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1565"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4cbe81ab-5e23-42ed-b62d-34af23a31d60
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRU5jM1IvWmlvTnkwekovZkVJVm5UWW02ZVpnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TURZdU5URXdIaGNOCk1qUXdNVEE1TVRjeU9ESTRXaGNOTXpRd01UQTJNVGN5T0RJNFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSXdOaTQxTVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0xbGd4UTlvdmVCMlBOQ1NJc21OWElYUitVL3B5NGtoMGRHbmE0QlZEc3F0aEhHbWxpdTduZEgKWGFsNjQyVm1Kd0FLSHJVOFhKN3ZIeW93MEt4d3BkSkpNOW9VZzVhTEd6b0RRWms1Z1BWbUFHOHl4ZlZCRFFBTQp1WGdOTXJ1M1pnMXNjVGJPMUxkMlpnYnhVUjRtRlNrUnhXMURscDdBa29YV1o5TSthaWtIYWdWQVBJOW9ZMmptCjAwOFRSc3JzQlVmREVLY281bDNKR2dUbEY1QTVGWFI0ZWEySTZqTHJ1cjkzc09uUytWMlNnakx4bU9QWUxHTzQKcWNFQyt4SVZkNVIydjBxSTA2blR2cDFkbjlsYVYrUjdrU2xKMThFYmVLTzZHbDhINklaN2c0VkY0VWtIQ0FscgphSkt0UjBYV0FjbDBVcGdRNllhZFd0M3RpRnRYcjhNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qQTJMalV4Z2p4eWR5MDROR1l5WlRRek5pMWxPVFEyTFRRM09UVXRZakU1TUMxak5EQXoKWkRRM00yRmlOMlV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU1EWXVOVEdDUEhKMwpMVGcwWmpKbE5ETTJMV1U1TkRZdE5EYzVOUzFpTVRrd0xXTTBNRE5rTkRjellXSTNaUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVsK1ljRU01L09NNGNFTTUvT016QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVWNYeWdCVTg4SkJ4SThnZllkRFBpdy95V3hEazFrYStqc2dERFpmNnYzMmNsMW9ncXpYOUNoTkxmcXBpNytTeQpSb1VtVnB6UmlrcXJDVDcxSHkzNXhwYkhPMTlMTWJidVZlRVo5TUZmRWJFMzZJVUhNZHNidkR6bEw1QThxd3IrCnArbTE1YlBpWnVQR0tKMlhpOC9BU29MY1VCQnJES3JlYi95OUx1UUEwNEY5Unk3aUN5aHNEWnduYWtCMEE5aW0KNkJOS0ZSS2hadlI4M1lYUUI1ZlN3Skpubm4ybEpVUllyN1hJYlp4K2FuSHdVQnhRR1pmT2VwcHBOelhlKzNrNgphTGZkVFBHdFJoelNWR2pNWlNwd1F5ekpwSGRnTDZZb1Y3dWR4TUFwNVZOZzV0Yk1hRk1sbnZmU2J2NDFvOGhSCmVYTExJTkdmRWFYUWIyTUpkWTJlZGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2009"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7d7ea6a5-ed0c-4443-b1b2-b25342e2ef63
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=84f2e436-e946-4795-b190-c403d473ab7e&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3e9c6898-d2a5-4469-b5c9-1a4ac843a544&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:15 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97f20741-aae1-402e-8367-d295e1b006aa
+      - 7e3a4d97-8fb1-4045-88b0-7f8fd2407d32
     status: 200 OK
     code: 200
     duration: ""
@@ -1166,21 +968,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "285"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:16 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b52d6db-1385-4e86-ba3b-826485248100
+      - f26a9ed7-b028-4751-b84f-bfea75a34d3a
     status: 200 OK
     code: 200
     duration: ""
@@ -1199,21 +1001,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622},"endpoints":[{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622}],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "285"
+      - "1507"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:16 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49c2a837-1bb1-484a-8e5d-d6b296e4c4ec
+      - a1e41d25-663c-4a91-a972-c33ae0742384
     status: 200 OK
     code: 200
     duration: ""
@@ -1232,21 +1034,186 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVS2psd2RLWXVRam9qaFFTc1dQZVEwUmU2dy9rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpFdU1UWXdNQjRYCkRUSTBNREV4T0RFeU5EVXdObG9YRFRNME1ERXhOVEV5TkRVd05sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekV1TVRZd01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQTBXM2JDZk1jaTJQL0JIaE1tY2FUNUNjTEFwUE91OVFUbW5JZzIvbGd0UDFLSm42ODZ1WUgKZnNmZUxYU0JMRWVyZFhFRlZzNzR3RnMyMzFGVlNnbnFBUzEwbnhhWmpHbHBsa2dDd3F0UEZ0TExGN0NhZjhxRQp4L1EwcDk1NzlnaGN3cjU1OUhBK0hXZ1FXUVV2SkJZUDZpMDlpWWpTUnNhTUlnMUhka0FqQXlQd0RZeXJ5UVpQClFKbVYwYTFEWU1nQzdMVlhnZkFrYWV6MHpKNFN0akY5MmF3eERaMUhiMXF4T2t4RjFFR0JZZGVlc3lVVXhCdEYKTkk3RVJNRHYzZ1FoNzRYK0FUbzBIUE9MSlNYODZJUndGWE8wdXYyNnYxSW1ad3IyWjExM0lYVUp4ZVZCcnI3eQpMRFNoVU9zRVN2REMyanAyS00yZTY0S2JrUjZlQmY3NWN3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOekV1TVRZd2dqeHlkeTB6WlRsak5qZzVPQzFrTW1FMUxUUTBOamt0WWpWak9TMHgKWVRSaFl6ZzBNMkUxTkRRdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOekV1TVRZdwpnanh5ZHkwelpUbGpOamc1T0Mxa01tRTFMVFEwTmprdFlqVmpPUzB4WVRSaFl6ZzBNMkUxTkRRdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3J6cUhCTU9hUjZDSEJNT2FSNkF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFHeURuOStWbllhbzF3RUFuWkpTYlNaQ1lvd3JSdXBualJZajVWQXNqTE5ab0M4ZjZsT3BZaUpBc1M0Vgo3VVpLQmZyMFF0WlNwRDRyNWJvVEMrTEFnL1YvejhCUTVPcHk5UnE1T1YwTHRXNlp6TzI1ZnBreHlKU3Q4ekNBCkVRcC9HUmhWSG9NRzJkVUtkeGIrTTIxR3B2dXdSMXpTRFJTVTk1Vkc1VW1LODd4SXdKOUtYOGIvLzRrOHM0L0oKSlFvV083SEFKSng5dXB1d2ovaVVqTXN1WlVQTHFoeGl0VlliM3A4VXQ0M3VsWmZXQUwvN01wOXZOeGNueEdYbgp3UnRQMkZhb2NmUVJxaW1Kc00xNDhsdEtmR20vNFFHMzFKVFJTdWN5RW44ZiswZnZyeVpxOEVPNWtlRmNzaTQ4Cks4amxsNWNPUXFkMUhFVkI5SDBLMHk2dFlQMD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2195f240-b0c0-4699-ad84-d90efbb240db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3e9c6898-d2a5-4469-b5c9-1a4ac843a544&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c4d371e-3dd0-4400-9204-d1a9f1569d62
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "273"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b1706871-1a58-49dd-a203-2c4b3802e39f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3e9c6898-d2a5-4469-b5c9-1a4ac843a544&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab492ad5-e337-46b3-a691-c069fe481457
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "273"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 701f9588-329d-458f-9c25-032a4d618145
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: DELETE
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "288"
+      - "276"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:16 GMT
+      - Thu, 18 Jan 2024 12:48:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3121fc03-8516-449b-abf8-803a4145f20e
+      - 126985d3-3612-4294-ada9-b8da66af195d
     status: 200 OK
     code: 200
     duration: ""
@@ -1265,21 +1232,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b51e8b42-e4cd-430a-897b-4c7c3b3b275e","ip":"163.172.153.140","name":null,"port":5432}],"id":"faec1ba4-68bc-4a42-8656-f5669734ee97","instance_id":"84f2e436-e946-4795-b190-c403d473ab7e","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"8db9f889-ba27-4304-8a15-517d49a3523e","ip":"51.15.255.52","name":null,"port":5432}],"id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","instance_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "288"
+      - "276"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:16 GMT
+      - Thu, 18 Jan 2024 12:48:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1289,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03c5b4d9-e4ef-4e44-a557-4b5bd88a0e55
+      - 69272763-523b-4e2f-b94c-28d05f702363
     status: 200 OK
     code: 200
     duration: ""
@@ -1298,12 +1265,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"faec1ba4-68bc-4a42-8656-f5669734ee97","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1312,7 +1279,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:46 GMT
+      - Thu, 18 Jan 2024 12:48:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1322,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4382bd2c-4843-449d-9c7e-ed9874bf8b04
+      - 2a8c6fe5-aabe-47af-ae4c-b4a00ab791a8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1331,21 +1298,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749},"endpoints":[{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749}],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622},"endpoints":[{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622}],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1280"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:46 GMT
+      - Thu, 18 Jan 2024 12:48:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1355,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eabf2d10-5fe4-4013-94fe-40328a75e6ed
+      - 0c5041a0-c39a-4e92-b0f0-902e23fe3765
     status: 200 OK
     code: 200
     duration: ""
@@ -1364,21 +1331,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749},"endpoints":[{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749}],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622},"endpoints":[{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622}],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1283"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:47 GMT
+      - Thu, 18 Jan 2024 12:48:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b021dbde-bba3-423c-a0e4-16860f471107
+      - de7d5a10-c55d-4c57-8e05-2cc64245c14b
     status: 200 OK
     code: 200
     duration: ""
@@ -1397,21 +1364,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:11.981057Z","endpoint":{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749},"endpoints":[{"id":"2c2e9fae-a2fd-4dd1-803c-dffa8d941387","ip":"51.159.206.51","load_balancer":{},"name":null,"port":2749}],"engine":"PostgreSQL-15","id":"84f2e436-e946-4795-b190-c403d473ab7e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.314667Z","endpoint":{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622},"endpoints":[{"id":"6184ff49-ad1d-47c3-a5e8-da0a4476f43c","ip":"195.154.71.160","load_balancer":{},"name":null,"port":7622}],"engine":"PostgreSQL-15","id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1283"
+      - "1237"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:47 GMT
+      - Thu, 18 Jan 2024 12:48:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b7ccb1c-8d03-4ee5-bdaa-f48097bbf889
+      - 47ab0396-28c9-45a1-a4f4-4986afb8f0fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1430,12 +1397,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"84f2e436-e946-4795-b190-c403d473ab7e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1444,7 +1411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:33:17 GMT
+      - Thu, 18 Jan 2024 12:49:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a802614-7e57-410d-ba5a-844663ce7a54
+      - 609dca05-36d8-4599-933f-67a41fa697e3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1463,12 +1430,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/84f2e436-e946-4795-b190-c403d473ab7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3e9c6898-d2a5-4469-b5c9-1a4ac843a544
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"84f2e436-e946-4795-b190-c403d473ab7e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"3e9c6898-d2a5-4469-b5c9-1a4ac843a544","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1477,7 +1444,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:33:17 GMT
+      - Thu, 18 Jan 2024 12:49:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e23874e-00ab-4064-9c61-8ad7e96f10ae
+      - d9cd08e5-b739-47a6-96bb-aab684c59874
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1496,12 +1463,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/faec1ba4-68bc-4a42-8656-f5669734ee97
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/085858e1-d11c-40b5-a40a-ba0022c44c4e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"faec1ba4-68bc-4a42-8656-f5669734ee97","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"085858e1-d11c-40b5-a40a-ba0022c44c4e","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1510,7 +1477,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:33:17 GMT
+      - Thu, 18 Jan 2024 12:49:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26177f68-fca7-46e1-85b3-6667c31ee5b1
+      - feeef8fa-efdd-4e15-821e-ee7b4dc1de06
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
@@ -2,95 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
-    method: POST
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "915"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7ee32537-3025-4ba1-bb21-9b88f31b9eb2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "915"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e15f04d-ae41-46a3-ba19-3216306b84e4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: '{"name":"test-rdb-rr-different-zone","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 12:59:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -100,7 +32,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 641a9c59-02f2-43c4-bd6a-e21818918789
+      - e0918ae0-2abb-4204-9639-29f9bca808b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
+    method: POST
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "883"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:59:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7e4c692e-6fb9-4f97-ab77-078a8e148240
     status: 200 OK
     code: 200
     duration: ""
@@ -109,21 +76,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:13 GMT
+      - Thu, 18 Jan 2024 12:59:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -133,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5d34257-c12f-4bca-842d-4684ad35a788
+      - 859538be-a89d-44b4-b510-a187a23d612e
     status: 200 OK
     code: 200
     duration: ""
@@ -142,21 +109,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:42 GMT
+      - Thu, 18 Jan 2024 12:59:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -166,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d6ce3a6-0a14-461e-a698-aafe75144c6c
+      - 5a7010a4-e3a5-4021-86b1-d6c6b5ceb1f6
     status: 200 OK
     code: 200
     duration: ""
@@ -175,21 +142,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:12 GMT
+      - Thu, 18 Jan 2024 12:59:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -199,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca2db7d6-9f34-4440-9a0f-279cf038d343
+      - dba6f583-a716-4e7e-86cc-a074639cfc30
     status: 200 OK
     code: 200
     duration: ""
@@ -208,21 +175,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:42 GMT
+      - Thu, 18 Jan 2024 13:00:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -232,7 +199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1ef5720-f780-4018-8cf7-b27146f5c5c1
+      - ed866878-e516-4698-9fc0-129bf22c5ede
     status: 200 OK
     code: 200
     duration: ""
@@ -241,21 +208,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:12 GMT
+      - Thu, 18 Jan 2024 13:00:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -265,7 +232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94c5f955-055f-4050-91c1-200fbe48f1f8
+      - 25e7f833-c884-44d9-bd7b-df9f2f2cc989
     status: 200 OK
     code: 200
     duration: ""
@@ -274,21 +241,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "915"
+      - "883"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:43 GMT
+      - Thu, 18 Jan 2024 13:01:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -298,7 +265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a9f1fc4-957f-4fa8-89fc-6eb4111d90c9
+      - 17310ec6-117c-4e13-801e-85aedb5a638a
     status: 200 OK
     code: 200
     duration: ""
@@ -307,21 +274,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1405"
+      - "1147"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 13:01:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -331,7 +298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ec38e0a-8391-403e-ba05-bfb98470a1d3
+      - 95425b78-6126-45b5-bcd2-2f51cc79a94d
     status: 200 OK
     code: 200
     duration: ""
@@ -340,21 +307,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWU1pMk53dXBxMkV1V3l4cXdGRHFPVVBkM24wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TkM0eE9UQXdIaGNOCk1qUXdNVEE1TVRjeU56VTJXaGNOTXpRd01UQTJNVGN5TnpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTBMakU1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUttSzRqVW0xMFpqNjUxRXdNK0c0eittM2J4YWJ3NXJFdFNTcEpZT3ZMVUhvNHRUM1AvWVo1WEEKTDd5dWJueVJCVktXUzV3b0VvV0hjS3BhVWlMN0ZXY0lvR0xqMXFxWEZtS1JGbEdwU2JvQ3FoL21CNmQ2bWt6VQpKQjNsS2hLQ25YakJNTitrVjVrSnRPS0M2UG5tUDdSUjBBWVZJVGlHU3hKcFJnbnRRVzlSeHpJelFMOWRBWGx6Cmxza2QwL0tLT25vMFNjYzdHVE9taExrcVc3SmYrMkNJRWwxWFBnVVhEeWN3Z0JHalhzQjJKTkVXWmFKdzB6UEUKZVZtcXZ6OTlncElna1lSRjBIWXdhdWxEYXpUTkQzQThZRVZqU3NZc2k1QVFYMXI2MGNVUngvN1R5RFhlK21pQwpXTEZTdDNwbHZvQXJaSUJHVEZkV1Byd1EwaWNaTnNFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qUXVNVGt3Z2p4eWR5MWxZall4WVRnM09DMDNOR1k0TFRRellqZ3RZV0UwTkMwNU1UZzQKWTJVeE5qWmxNekF1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU5DNHhPVENDUEhKMwpMV1ZpTmpGaE9EYzRMVGMwWmpndE5ETmlPQzFoWVRRMExUa3hPRGhqWlRFMk5tVXpNQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnl5Y29jRU01OFl2b2NFTTU4WXZqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVUJpdlBFcGxlK2NodlNIQTUyYnZBQkJXOUJuNU92cTkzVmxscWhPejJYdG95Q04yUUhWSi80UHpUSGRyTEgwYQpZSHB1OVAvTXBRaXluRDBGWTBnK3h6djZVWEMzcTFCalByM3FIOHo4WG93MkdRMGs1SFBERjl5R3ZGYmF0S3pkCmJxbVpxWWxLTC9ENk50SUZ6MlQva1V1OTNZNURDWEdlV3VUZkh0NnRBR09sdkJjMHZEQUNTQ2k5cmRKOUVEVW4KVG9mSzZybERIbng4RFpoUkRNVVBpSDNiN0xqNVpVbjNxbDZHZ2lVSHp0Q3RyRGl5VnR1d214ampxb2thclh2bQp4Z29DZjZIekg0RXlsSUViY1p2UlUwa0FmOEs3dytXOWpzTW9RWVlPUlFQWUFJYzN2YTRmeUZxNVVmNmtUUHRKCmlmZ29MZjRNUnRCYmpRZHQyN2U0dHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2009"
+      - "1358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 13:02:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -364,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe4f9aad-bec1-4d81-aba4-5137b97cfb60
+      - b01550d9-2791-466a-abbf-f507f7db6ce0
     status: 200 OK
     code: 200
     duration: ""
@@ -373,21 +340,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb61a878-74f8-43b8-aa44-9188ce166e30&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTi9uaHpRcUsrT0tQakFvOVpLaUpRR3RXRlB3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpFdU1UWXdNQjRYCkRUSTBNREV4T0RFek1ERTFObG9YRFRNME1ERXhOVEV6TURFMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekV1TVRZd01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVlT1hnaWp6UHo3WmhFTG9GQlFIbkpNNzBGamtkRUE1aVI3UzlYYWtuTHdsM3V3cHVLd3UKKzluZkE1TzFUVUV2VG9GaXdsdTFSZUFEMXo2RHpkdHhRRjlKZ0VVZ3RSS0w4em1HTzRVQkMwS2R5REhoTXRXYQpkbFIrdkN2dG1tZkM1eWE3RGZFS1hDR1d6c3ppemJLVHZnZ1lVYkk0OFpQSVFXTFRMeElRTXNjL2I5b3lId3h0CmJCbDlrdW1VTXp4RnBJWkdDbHpNd3kva1pIdnlPN01nM3pKRzNvWDhORFdGRS90SVhPSm9FeVRmSi9rNGF2T3QKMVRxQ05BMytSaFZBT0xjc2lObmxnczh1ZmR5bWNFK3hqTEtQOURwVk9WUENMMTZWS1haZ0paOGExaTZWNk1seApyZlhmMFdFSUhvVVJ2QUNJSysySUxVcjJkdmRLR1lCQ1ZRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOekV1TVRZd2dqeHlkeTB4TnpZeU1USXpaaTFrTURjNUxUUTVNR1F0T1RoaU9TMDMKTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOekV1TVRZdwpnanh5ZHkweE56WXlNVEl6Wmkxa01EYzVMVFE1TUdRdE9UaGlPUzAzTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3ZWeUhCTU9hUjZDSEJNT2FSNkF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDZW5hTDNKRmFXcUUyN1JjeFJZdS80TFkyWXRIZFFvRGt4RnhZUVBMWEhYQ21zYmFuVE0rM3R1R1c0bwpnT29mcWxTc3I5bVY1UWF3YmxPRTQzL2cxaUEvUitEQlNybE5oK1hma1U3bWxFeTJROE82aXY0ZmJvOFlsaVhZCitFNGQvbE56S0R4NkI4WmV3SWxLYUlkTHBOck1vZTI4QUcvcndmNnJIWCtDaTVwVm42Y0VnSDBzR3BGZ0tibmYKM1RlNm5mRWt4NjhxTXFzTitFcStnMWNpNlBadEdaMlBUNEMwVG9uSmd6S3MxemxKcmZQZXExVlpIZjZDTEVpWApDS2R2QzZ2d0wvd3UycUdXdmoweWdCamZOQTRranp2TmdxN1BCTkVoR3JzUjdjWDdXbldTeDBkU3RwOUJmZjVRCmtMZEdIbWd1MlVqd210MWdMMlAzLzJwZzJpST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 13:02:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c2e50bcb-6ccb-4c9e-a983-f5a4cdf837f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 13:02:21 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -397,32 +397,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3b76010-c704-4213-abd5-426a45631f86
+      - 9b450014-b0e3-4734-93cc-386a3bab1db1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","endpoint_spec":[{"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","ipam_config":{}}}],"same_zone":true}'
+    body: '{"instance_id":"1762123f-d079-490d-98b9-72966b1c204b","endpoint_spec":[{"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","ipam_config":{}}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "397"
+      - "388"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:14 GMT
+      - Thu, 18 Jan 2024 13:02:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2da13c8c-cb72-459e-a9ee-ebc0021544d6
+      - 0a78a7a1-60f8-4104-bfee-eda0f8ce30ab
     status: 200 OK
     code: 200
     duration: ""
@@ -441,21 +441,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "397"
+      - "388"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:15 GMT
+      - Thu, 18 Jan 2024 13:02:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -465,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baddf550-da7f-45ba-950d-2b5dfd602567
+      - 2aabbdae-40ea-4994-99f0-066ae36f07dd
     status: 200 OK
     code: 200
     duration: ""
@@ -474,21 +474,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "397"
+      - "388"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:45 GMT
+      - Thu, 18 Jan 2024 13:02:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -498,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7707fcb3-ff5c-4f99-9842-3e87fc1eaf10
+      - 5fe4fc4e-f88b-4e2e-8cb2-da28727db2b6
     status: 200 OK
     code: 200
     duration: ""
@@ -507,21 +507,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "397"
+      - "388"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:15 GMT
+      - Thu, 18 Jan 2024 13:03:22 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -531,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9c8f73c-b52f-440f-b4d7-7b99ff1312c7
+      - 163989fd-2921-44a2-bd3d-9d01a6108076
     status: 200 OK
     code: 200
     duration: ""
@@ -540,21 +540,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "397"
+      - "388"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:45 GMT
+      - Thu, 18 Jan 2024 13:03:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -564,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 740e2ac8-db86-424b-b6a7-ea2e8eaf5fc0
+      - d352c6b8-541a-4c49-bafd-78b641d2ba69
     status: 200 OK
     code: 200
     duration: ""
@@ -573,21 +573,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "397"
+      - "388"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:15 GMT
+      - Thu, 18 Jan 2024 13:04:23 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dcf0dc8-b052-4637-9208-5dcaa166116e
+      - 87e103ce-512f-45c5-9128-f0cca85316c5
     status: 200 OK
     code: 200
     duration: ""
@@ -606,21 +606,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "390"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 13:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -630,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91790592-9d32-4b85-913c-d42c923d4487
+      - b38ad3c9-f3ab-4e8a-b5bb-066d50da4ecd
     status: 200 OK
     code: 200
     duration: ""
@@ -639,21 +639,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "390"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 13:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -663,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51b1d09c-c433-4418-bfb6-4d3481c8f99e
+      - c816dfc3-db2b-41bd-b683-d1ec0dbf455c
     status: 200 OK
     code: 200
     duration: ""
@@ -672,21 +672,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "390"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 13:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -696,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4bcb707-fbb1-401b-99f5-179bf038b728
+      - 3c911f9c-a108-4ae6-9a1a-0b0ad0338a57
     status: 200 OK
     code: 200
     duration: ""
@@ -705,21 +705,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "726"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 13:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -729,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1da3c7f2-f5c7-4d18-a775-6b5ae0ff3c52
+      - 8773ba9e-8c79-491f-85bf-200bd883ac3d
     status: 200 OK
     code: 200
     duration: ""
@@ -738,21 +738,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -762,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1efbacdc-fbd3-40d5-ae9c-edc3b3d7eadd
+      - c73a3e8a-fe4a-4a5a-98fc-83e64a229552
     status: 200 OK
     code: 200
     duration: ""
@@ -771,21 +771,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1795"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -795,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6e9295b-74c5-4080-84bc-26f60c5eac26
+      - 12fda790-7d3c-492e-89be-8d9bd0c9ab16
     status: 200 OK
     code: 200
     duration: ""
@@ -804,21 +804,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWU1pMk53dXBxMkV1V3l4cXdGRHFPVVBkM24wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TkM0eE9UQXdIaGNOCk1qUXdNVEE1TVRjeU56VTJXaGNOTXpRd01UQTJNVGN5TnpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTBMakU1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUttSzRqVW0xMFpqNjUxRXdNK0c0eittM2J4YWJ3NXJFdFNTcEpZT3ZMVUhvNHRUM1AvWVo1WEEKTDd5dWJueVJCVktXUzV3b0VvV0hjS3BhVWlMN0ZXY0lvR0xqMXFxWEZtS1JGbEdwU2JvQ3FoL21CNmQ2bWt6VQpKQjNsS2hLQ25YakJNTitrVjVrSnRPS0M2UG5tUDdSUjBBWVZJVGlHU3hKcFJnbnRRVzlSeHpJelFMOWRBWGx6Cmxza2QwL0tLT25vMFNjYzdHVE9taExrcVc3SmYrMkNJRWwxWFBnVVhEeWN3Z0JHalhzQjJKTkVXWmFKdzB6UEUKZVZtcXZ6OTlncElna1lSRjBIWXdhdWxEYXpUTkQzQThZRVZqU3NZc2k1QVFYMXI2MGNVUngvN1R5RFhlK21pQwpXTEZTdDNwbHZvQXJaSUJHVEZkV1Byd1EwaWNaTnNFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qUXVNVGt3Z2p4eWR5MWxZall4WVRnM09DMDNOR1k0TFRRellqZ3RZV0UwTkMwNU1UZzQKWTJVeE5qWmxNekF1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU5DNHhPVENDUEhKMwpMV1ZpTmpGaE9EYzRMVGMwWmpndE5ETmlPQzFoWVRRMExUa3hPRGhqWlRFMk5tVXpNQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnl5Y29jRU01OFl2b2NFTTU4WXZqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVUJpdlBFcGxlK2NodlNIQTUyYnZBQkJXOUJuNU92cTkzVmxscWhPejJYdG95Q04yUUhWSi80UHpUSGRyTEgwYQpZSHB1OVAvTXBRaXluRDBGWTBnK3h6djZVWEMzcTFCalByM3FIOHo4WG93MkdRMGs1SFBERjl5R3ZGYmF0S3pkCmJxbVpxWWxLTC9ENk50SUZ6MlQva1V1OTNZNURDWEdlV3VUZkh0NnRBR09sdkJjMHZEQUNTQ2k5cmRKOUVEVW4KVG9mSzZybERIbng4RFpoUkRNVVBpSDNiN0xqNVpVbjNxbDZHZ2lVSHp0Q3RyRGl5VnR1d214ampxb2thclh2bQp4Z29DZjZIekg0RXlsSUViY1p2UlUwa0FmOEs3dytXOWpzTW9RWVlPUlFQWUFJYzN2YTRmeUZxNVVmNmtUUHRKCmlmZ29MZjRNUnRCYmpRZHQyN2U0dHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2009"
+      - "1739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -828,7 +828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65aafc5c-3ac1-468b-8707-b6cb0a3493f1
+      - b322d7f0-3d6d-48b6-9051-e848dbf1a497
     status: 200 OK
     code: 200
     duration: ""
@@ -837,21 +837,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb61a878-74f8-43b8-aa44-9188ce166e30&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b/certificate
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.8.2/22","created_at":"2024-01-09T17:28:14.695296Z","id":"8bc745bc-d79c-4666-b9f1-cf804080c8e8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"eb61a878-74f8-43b8-aa44-9188ce166e30","mac_address":"02:00:00:16:88:DC","name":"read-replica-606c6c28","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"19f74986-42c3-461c-975e-1f064e490e03"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-09T17:28:51.645204Z","zone":null}],"total_count":1}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTi9uaHpRcUsrT0tQakFvOVpLaUpRR3RXRlB3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpFdU1UWXdNQjRYCkRUSTBNREV4T0RFek1ERTFObG9YRFRNME1ERXhOVEV6TURFMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekV1TVRZd01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVlT1hnaWp6UHo3WmhFTG9GQlFIbkpNNzBGamtkRUE1aVI3UzlYYWtuTHdsM3V3cHVLd3UKKzluZkE1TzFUVUV2VG9GaXdsdTFSZUFEMXo2RHpkdHhRRjlKZ0VVZ3RSS0w4em1HTzRVQkMwS2R5REhoTXRXYQpkbFIrdkN2dG1tZkM1eWE3RGZFS1hDR1d6c3ppemJLVHZnZ1lVYkk0OFpQSVFXTFRMeElRTXNjL2I5b3lId3h0CmJCbDlrdW1VTXp4RnBJWkdDbHpNd3kva1pIdnlPN01nM3pKRzNvWDhORFdGRS90SVhPSm9FeVRmSi9rNGF2T3QKMVRxQ05BMytSaFZBT0xjc2lObmxnczh1ZmR5bWNFK3hqTEtQOURwVk9WUENMMTZWS1haZ0paOGExaTZWNk1seApyZlhmMFdFSUhvVVJ2QUNJSysySUxVcjJkdmRLR1lCQ1ZRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOekV1TVRZd2dqeHlkeTB4TnpZeU1USXpaaTFrTURjNUxUUTVNR1F0T1RoaU9TMDMKTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOekV1TVRZdwpnanh5ZHkweE56WXlNVEl6Wmkxa01EYzVMVFE1TUdRdE9UaGlPUzAzTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3ZWeUhCTU9hUjZDSEJNT2FSNkF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDZW5hTDNKRmFXcUUyN1JjeFJZdS80TFkyWXRIZFFvRGt4RnhZUVBMWEhYQ21zYmFuVE0rM3R1R1c0bwpnT29mcWxTc3I5bVY1UWF3YmxPRTQzL2cxaUEvUitEQlNybE5oK1hma1U3bWxFeTJROE82aXY0ZmJvOFlsaVhZCitFNGQvbE56S0R4NkI4WmV3SWxLYUlkTHBOck1vZTI4QUcvcndmNnJIWCtDaTVwVm42Y0VnSDBzR3BGZ0tibmYKM1RlNm5mRWt4NjhxTXFzTitFcStnMWNpNlBadEdaMlBUNEMwVG9uSmd6S3MxemxKcmZQZXExVlpIZjZDTEVpWApDS2R2QzZ2d0wvd3UycUdXdmoweWdCamZOQTRranp2TmdxN1BCTkVoR3JzUjdjWDdXbldTeDBkU3RwOUJmZjVRCmtMZEdIbWd1MlVqd210MWdMMlAzLzJwZzJpST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "547"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -861,7 +861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c6070b0-5cf0-42aa-a3c4-910ebc3c8e63
+      - 93608d69-62c2-486e-8678-518fd85c7316
     status: 200 OK
     code: 200
     duration: ""
@@ -870,21 +870,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "390"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -894,7 +894,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9916af61-d2d6-4016-b660-87169f24ae5d
+      - a15d32c3-9fe5-4ea6-9252-c4d16ab122bb
     status: 200 OK
     code: 200
     duration: ""
@@ -903,21 +903,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "726"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -927,7 +927,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45bd937c-772c-4390-b9a2-5361cf17dc69
+      - 5af57d5d-089c-4a81-97a2-2146a41fdc6d
     status: 200 OK
     code: 200
     duration: ""
@@ -936,21 +936,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1795"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -960,7 +960,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ca96d9c-0f41-4523-b050-b1612bc059d7
+      - 805d869c-1a8c-4f9b-a986-3aa4f2341ef0
     status: 200 OK
     code: 200
     duration: ""
@@ -969,21 +969,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWU1pMk53dXBxMkV1V3l4cXdGRHFPVVBkM24wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TkM0eE9UQXdIaGNOCk1qUXdNVEE1TVRjeU56VTJXaGNOTXpRd01UQTJNVGN5TnpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTBMakU1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUttSzRqVW0xMFpqNjUxRXdNK0c0eittM2J4YWJ3NXJFdFNTcEpZT3ZMVUhvNHRUM1AvWVo1WEEKTDd5dWJueVJCVktXUzV3b0VvV0hjS3BhVWlMN0ZXY0lvR0xqMXFxWEZtS1JGbEdwU2JvQ3FoL21CNmQ2bWt6VQpKQjNsS2hLQ25YakJNTitrVjVrSnRPS0M2UG5tUDdSUjBBWVZJVGlHU3hKcFJnbnRRVzlSeHpJelFMOWRBWGx6Cmxza2QwL0tLT25vMFNjYzdHVE9taExrcVc3SmYrMkNJRWwxWFBnVVhEeWN3Z0JHalhzQjJKTkVXWmFKdzB6UEUKZVZtcXZ6OTlncElna1lSRjBIWXdhdWxEYXpUTkQzQThZRVZqU3NZc2k1QVFYMXI2MGNVUngvN1R5RFhlK21pQwpXTEZTdDNwbHZvQXJaSUJHVEZkV1Byd1EwaWNaTnNFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qUXVNVGt3Z2p4eWR5MWxZall4WVRnM09DMDNOR1k0TFRRellqZ3RZV0UwTkMwNU1UZzQKWTJVeE5qWmxNekF1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU5DNHhPVENDUEhKMwpMV1ZpTmpGaE9EYzRMVGMwWmpndE5ETmlPQzFoWVRRMExUa3hPRGhqWlRFMk5tVXpNQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnl5Y29jRU01OFl2b2NFTTU4WXZqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVUJpdlBFcGxlK2NodlNIQTUyYnZBQkJXOUJuNU92cTkzVmxscWhPejJYdG95Q04yUUhWSi80UHpUSGRyTEgwYQpZSHB1OVAvTXBRaXluRDBGWTBnK3h6djZVWEMzcTFCalByM3FIOHo4WG93MkdRMGs1SFBERjl5R3ZGYmF0S3pkCmJxbVpxWWxLTC9ENk50SUZ6MlQva1V1OTNZNURDWEdlV3VUZkh0NnRBR09sdkJjMHZEQUNTQ2k5cmRKOUVEVW4KVG9mSzZybERIbng4RFpoUkRNVVBpSDNiN0xqNVpVbjNxbDZHZ2lVSHp0Q3RyRGl5VnR1d214ampxb2thclh2bQp4Z29DZjZIekg0RXlsSUViY1p2UlUwa0FmOEs3dytXOWpzTW9RWVlPUlFQWUFJYzN2YTRmeUZxNVVmNmtUUHRKCmlmZ29MZjRNUnRCYmpRZHQyN2U0dHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "2009"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -993,7 +993,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcc074b3-c354-4417-b3af-d9af00a7cdf6
+      - cf80aebd-5ad1-483e-9a28-3b13babedc7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1002,21 +1002,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb61a878-74f8-43b8-aa44-9188ce166e30&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.8.2/22","created_at":"2024-01-09T17:28:14.695296Z","id":"8bc745bc-d79c-4666-b9f1-cf804080c8e8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"eb61a878-74f8-43b8-aa44-9188ce166e30","mac_address":"02:00:00:16:88:DC","name":"read-replica-606c6c28","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"19f74986-42c3-461c-975e-1f064e490e03"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-09T17:28:51.645204Z","zone":null}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "547"
+      - "1739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1026,7 +1026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99a4fc8f-4e4f-483f-903b-ae7a2918c888
+      - 64677df6-8b10-4889-9e5b-3acf2f14bd0e
     status: 200 OK
     code: 200
     duration: ""
@@ -1035,21 +1035,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b/certificate
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTi9uaHpRcUsrT0tQakFvOVpLaUpRR3RXRlB3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpFdU1UWXdNQjRYCkRUSTBNREV4T0RFek1ERTFObG9YRFRNME1ERXhOVEV6TURFMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekV1TVRZd01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVlT1hnaWp6UHo3WmhFTG9GQlFIbkpNNzBGamtkRUE1aVI3UzlYYWtuTHdsM3V3cHVLd3UKKzluZkE1TzFUVUV2VG9GaXdsdTFSZUFEMXo2RHpkdHhRRjlKZ0VVZ3RSS0w4em1HTzRVQkMwS2R5REhoTXRXYQpkbFIrdkN2dG1tZkM1eWE3RGZFS1hDR1d6c3ppemJLVHZnZ1lVYkk0OFpQSVFXTFRMeElRTXNjL2I5b3lId3h0CmJCbDlrdW1VTXp4RnBJWkdDbHpNd3kva1pIdnlPN01nM3pKRzNvWDhORFdGRS90SVhPSm9FeVRmSi9rNGF2T3QKMVRxQ05BMytSaFZBT0xjc2lObmxnczh1ZmR5bWNFK3hqTEtQOURwVk9WUENMMTZWS1haZ0paOGExaTZWNk1seApyZlhmMFdFSUhvVVJ2QUNJSysySUxVcjJkdmRLR1lCQ1ZRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOekV1TVRZd2dqeHlkeTB4TnpZeU1USXpaaTFrTURjNUxUUTVNR1F0T1RoaU9TMDMKTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOekV1TVRZdwpnanh5ZHkweE56WXlNVEl6Wmkxa01EYzVMVFE1TUdRdE9UaGlPUzAzTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3ZWeUhCTU9hUjZDSEJNT2FSNkF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDZW5hTDNKRmFXcUUyN1JjeFJZdS80TFkyWXRIZFFvRGt4RnhZUVBMWEhYQ21zYmFuVE0rM3R1R1c0bwpnT29mcWxTc3I5bVY1UWF3YmxPRTQzL2cxaUEvUitEQlNybE5oK1hma1U3bWxFeTJROE82aXY0ZmJvOFlsaVhZCitFNGQvbE56S0R4NkI4WmV3SWxLYUlkTHBOck1vZTI4QUcvcndmNnJIWCtDaTVwVm42Y0VnSDBzR3BGZ0tibmYKM1RlNm5mRWt4NjhxTXFzTitFcStnMWNpNlBadEdaMlBUNEMwVG9uSmd6S3MxemxKcmZQZXExVlpIZjZDTEVpWApDS2R2QzZ2d0wvd3UycUdXdmoweWdCamZOQTRranp2TmdxN1BCTkVoR3JzUjdjWDdXbldTeDBkU3RwOUJmZjVRCmtMZEdIbWd1MlVqd210MWdMMlAzLzJwZzJpST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "390"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1059,7 +1059,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 857b8b1e-3286-4711-9d3e-4f846f13a012
+      - 89402079-816b-43d5-9f17-5f90c5c543b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1068,21 +1068,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "390"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:47 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1092,7 +1092,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93cbe059-aa1a-4fb2-af29-2f4eec873b97
+      - 1aa03c24-1066-458d-88b5-e43792e05449
     status: 200 OK
     code: 200
     duration: ""
@@ -1101,21 +1101,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "726"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:47 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1125,7 +1125,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a48c1c8a-6cd1-4bde-8d8e-b7fb8ee62c42
+      - db2f186f-f568-4afd-bf78-1813ff00dd22
     status: 200 OK
     code: 200
     duration: ""
@@ -1134,21 +1134,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "726"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:47 GMT
+      - Thu, 18 Jan 2024 13:04:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1158,7 +1158,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b4fde55-1f1f-4e9c-bd77-347f93b1647b
+      - 6782bdf9-a731-4735-9761-e564715f8f9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1167,21 +1167,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1795"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:47 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1191,7 +1191,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5bc077e-cea9-409d-8e81-b4332e8c4e4a
+      - 07ee6b7c-076d-4754-815d-408b93b443ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1200,21 +1200,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWU1pMk53dXBxMkV1V3l4cXdGRHFPVVBkM24wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TkM0eE9UQXdIaGNOCk1qUXdNVEE1TVRjeU56VTJXaGNOTXpRd01UQTJNVGN5TnpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTBMakU1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUttSzRqVW0xMFpqNjUxRXdNK0c0eittM2J4YWJ3NXJFdFNTcEpZT3ZMVUhvNHRUM1AvWVo1WEEKTDd5dWJueVJCVktXUzV3b0VvV0hjS3BhVWlMN0ZXY0lvR0xqMXFxWEZtS1JGbEdwU2JvQ3FoL21CNmQ2bWt6VQpKQjNsS2hLQ25YakJNTitrVjVrSnRPS0M2UG5tUDdSUjBBWVZJVGlHU3hKcFJnbnRRVzlSeHpJelFMOWRBWGx6Cmxza2QwL0tLT25vMFNjYzdHVE9taExrcVc3SmYrMkNJRWwxWFBnVVhEeWN3Z0JHalhzQjJKTkVXWmFKdzB6UEUKZVZtcXZ6OTlncElna1lSRjBIWXdhdWxEYXpUTkQzQThZRVZqU3NZc2k1QVFYMXI2MGNVUngvN1R5RFhlK21pQwpXTEZTdDNwbHZvQXJaSUJHVEZkV1Byd1EwaWNaTnNFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qUXVNVGt3Z2p4eWR5MWxZall4WVRnM09DMDNOR1k0TFRRellqZ3RZV0UwTkMwNU1UZzQKWTJVeE5qWmxNekF1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU5DNHhPVENDUEhKMwpMV1ZpTmpGaE9EYzRMVGMwWmpndE5ETmlPQzFoWVRRMExUa3hPRGhqWlRFMk5tVXpNQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnl5Y29jRU01OFl2b2NFTTU4WXZqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVUJpdlBFcGxlK2NodlNIQTUyYnZBQkJXOUJuNU92cTkzVmxscWhPejJYdG95Q04yUUhWSi80UHpUSGRyTEgwYQpZSHB1OVAvTXBRaXluRDBGWTBnK3h6djZVWEMzcTFCalByM3FIOHo4WG93MkdRMGs1SFBERjl5R3ZGYmF0S3pkCmJxbVpxWWxLTC9ENk50SUZ6MlQva1V1OTNZNURDWEdlV3VUZkh0NnRBR09sdkJjMHZEQUNTQ2k5cmRKOUVEVW4KVG9mSzZybERIbng4RFpoUkRNVVBpSDNiN0xqNVpVbjNxbDZHZ2lVSHp0Q3RyRGl5VnR1d214ampxb2thclh2bQp4Z29DZjZIekg0RXlsSUViY1p2UlUwa0FmOEs3dytXOWpzTW9RWVlPUlFQWUFJYzN2YTRmeUZxNVVmNmtUUHRKCmlmZ29MZjRNUnRCYmpRZHQyN2U0dHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "2009"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:47 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1224,7 +1224,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6653c1a-7b99-42c4-b17a-074d798fddb7
+      - ba0bd0ab-3098-4060-9776-335c3566c0e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1233,21 +1233,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb61a878-74f8-43b8-aa44-9188ce166e30&resource_type=rdb_instance
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.8.2/22","created_at":"2024-01-09T17:28:14.695296Z","id":"8bc745bc-d79c-4666-b9f1-cf804080c8e8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"eb61a878-74f8-43b8-aa44-9188ce166e30","mac_address":"02:00:00:16:88:DC","name":"read-replica-606c6c28","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"19f74986-42c3-461c-975e-1f064e490e03"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-09T17:28:51.645204Z","zone":null}],"total_count":1}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "547"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:47 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1257,7 +1257,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 712b1987-df44-46aa-83fe-d3fdd602b097
+      - cbf11d50-86bc-4633-b349-e3303bbe2913
     status: 200 OK
     code: 200
     duration: ""
@@ -1266,21 +1266,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "390"
+      - "1739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:47 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1290,7 +1290,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0564289a-f293-47d6-80d1-cdba639cce5a
+      - abe88b62-ec20-497e-b374-c323bec7a3f0
     status: 200 OK
     code: 200
     duration: ""
@@ -1299,21 +1299,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b/certificate
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTi9uaHpRcUsrT0tQakFvOVpLaUpRR3RXRlB3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpFdU1UWXdNQjRYCkRUSTBNREV4T0RFek1ERTFObG9YRFRNME1ERXhOVEV6TURFMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekV1TVRZd01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVlT1hnaWp6UHo3WmhFTG9GQlFIbkpNNzBGamtkRUE1aVI3UzlYYWtuTHdsM3V3cHVLd3UKKzluZkE1TzFUVUV2VG9GaXdsdTFSZUFEMXo2RHpkdHhRRjlKZ0VVZ3RSS0w4em1HTzRVQkMwS2R5REhoTXRXYQpkbFIrdkN2dG1tZkM1eWE3RGZFS1hDR1d6c3ppemJLVHZnZ1lVYkk0OFpQSVFXTFRMeElRTXNjL2I5b3lId3h0CmJCbDlrdW1VTXp4RnBJWkdDbHpNd3kva1pIdnlPN01nM3pKRzNvWDhORFdGRS90SVhPSm9FeVRmSi9rNGF2T3QKMVRxQ05BMytSaFZBT0xjc2lObmxnczh1ZmR5bWNFK3hqTEtQOURwVk9WUENMMTZWS1haZ0paOGExaTZWNk1seApyZlhmMFdFSUhvVVJ2QUNJSysySUxVcjJkdmRLR1lCQ1ZRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOekV1TVRZd2dqeHlkeTB4TnpZeU1USXpaaTFrTURjNUxUUTVNR1F0T1RoaU9TMDMKTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOekV1TVRZdwpnanh5ZHkweE56WXlNVEl6Wmkxa01EYzVMVFE1TUdRdE9UaGlPUzAzTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3ZWeUhCTU9hUjZDSEJNT2FSNkF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDZW5hTDNKRmFXcUUyN1JjeFJZdS80TFkyWXRIZFFvRGt4RnhZUVBMWEhYQ21zYmFuVE0rM3R1R1c0bwpnT29mcWxTc3I5bVY1UWF3YmxPRTQzL2cxaUEvUitEQlNybE5oK1hma1U3bWxFeTJROE82aXY0ZmJvOFlsaVhZCitFNGQvbE56S0R4NkI4WmV3SWxLYUlkTHBOck1vZTI4QUcvcndmNnJIWCtDaTVwVm42Y0VnSDBzR3BGZ0tibmYKM1RlNm5mRWt4NjhxTXFzTitFcStnMWNpNlBadEdaMlBUNEMwVG9uSmd6S3MxemxKcmZQZXExVlpIZjZDTEVpWApDS2R2QzZ2d0wvd3UycUdXdmoweWdCamZOQTRranp2TmdxN1BCTkVoR3JzUjdjWDdXbldTeDBkU3RwOUJmZjVRCmtMZEdIbWd1MlVqd210MWdMMlAzLzJwZzJpST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "726"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:47 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1323,7 +1323,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98d1b935-ca86-4261-ab81-87e43f345f5a
+      - 237da136-7631-4255-9a46-bd70cd846b23
     status: 200 OK
     code: 200
     duration: ""
@@ -1332,21 +1332,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1795"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:48 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1356,7 +1356,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb44d6d6-0f8d-4ad4-8d11-f670d486a1d0
+      - 1805decf-9e55-4001-8188-4c52a51a9f2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1365,21 +1365,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWU1pMk53dXBxMkV1V3l4cXdGRHFPVVBkM24wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TkM0eE9UQXdIaGNOCk1qUXdNVEE1TVRjeU56VTJXaGNOTXpRd01UQTJNVGN5TnpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTBMakU1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUttSzRqVW0xMFpqNjUxRXdNK0c0eittM2J4YWJ3NXJFdFNTcEpZT3ZMVUhvNHRUM1AvWVo1WEEKTDd5dWJueVJCVktXUzV3b0VvV0hjS3BhVWlMN0ZXY0lvR0xqMXFxWEZtS1JGbEdwU2JvQ3FoL21CNmQ2bWt6VQpKQjNsS2hLQ25YakJNTitrVjVrSnRPS0M2UG5tUDdSUjBBWVZJVGlHU3hKcFJnbnRRVzlSeHpJelFMOWRBWGx6Cmxza2QwL0tLT25vMFNjYzdHVE9taExrcVc3SmYrMkNJRWwxWFBnVVhEeWN3Z0JHalhzQjJKTkVXWmFKdzB6UEUKZVZtcXZ6OTlncElna1lSRjBIWXdhdWxEYXpUTkQzQThZRVZqU3NZc2k1QVFYMXI2MGNVUngvN1R5RFhlK21pQwpXTEZTdDNwbHZvQXJaSUJHVEZkV1Byd1EwaWNaTnNFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qUXVNVGt3Z2p4eWR5MWxZall4WVRnM09DMDNOR1k0TFRRellqZ3RZV0UwTkMwNU1UZzQKWTJVeE5qWmxNekF1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU5DNHhPVENDUEhKMwpMV1ZpTmpGaE9EYzRMVGMwWmpndE5ETmlPQzFoWVRRMExUa3hPRGhqWlRFMk5tVXpNQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnl5Y29jRU01OFl2b2NFTTU4WXZqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVUJpdlBFcGxlK2NodlNIQTUyYnZBQkJXOUJuNU92cTkzVmxscWhPejJYdG95Q04yUUhWSi80UHpUSGRyTEgwYQpZSHB1OVAvTXBRaXluRDBGWTBnK3h6djZVWEMzcTFCalByM3FIOHo4WG93MkdRMGs1SFBERjl5R3ZGYmF0S3pkCmJxbVpxWWxLTC9ENk50SUZ6MlQva1V1OTNZNURDWEdlV3VUZkh0NnRBR09sdkJjMHZEQUNTQ2k5cmRKOUVEVW4KVG9mSzZybERIbng4RFpoUkRNVVBpSDNiN0xqNVpVbjNxbDZHZ2lVSHp0Q3RyRGl5VnR1d214ampxb2thclh2bQp4Z29DZjZIekg0RXlsSUViY1p2UlUwa0FmOEs3dytXOWpzTW9RWVlPUlFQWUFJYzN2YTRmeUZxNVVmNmtUUHRKCmlmZ29MZjRNUnRCYmpRZHQyN2U0dHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "2009"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:48 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1389,7 +1389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82422bed-2252-453c-8b75-f93282d7eb52
+      - 32b11913-7443-466f-870e-d53966d9eb9b
     status: 200 OK
     code: 200
     duration: ""
@@ -1398,21 +1398,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb61a878-74f8-43b8-aa44-9188ce166e30&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.8.2/22","created_at":"2024-01-09T17:28:14.695296Z","id":"8bc745bc-d79c-4666-b9f1-cf804080c8e8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"eb61a878-74f8-43b8-aa44-9188ce166e30","mac_address":"02:00:00:16:88:DC","name":"read-replica-606c6c28","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"19f74986-42c3-461c-975e-1f064e490e03"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-09T17:28:51.645204Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "547"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:48 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1422,7 +1422,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73a2b75d-6d79-4c99-a6b3-644274f61b2a
+      - 49f81eb0-308c-4ede-a060-99c1259120cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1431,21 +1431,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "390"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:48 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1455,7 +1455,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e9d85c1-fb82-411d-9fad-5ae39e3d25c1
+      - 235ae5e5-4309-44da-ab33-7e1df2543234
     status: 200 OK
     code: 200
     duration: ""
@@ -1464,21 +1464,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "390"
+      - "1739"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:48 GMT
+      - Thu, 18 Jan 2024 13:04:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1488,7 +1488,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e540d44-282d-4122-a892-dcfc28b27bce
+      - eb5cd4d1-c8df-458b-9197-c89f7bfec704
     status: 200 OK
     code: 200
     duration: ""
@@ -1497,21 +1497,186 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTi9uaHpRcUsrT0tQakFvOVpLaUpRR3RXRlB3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpFdU1UWXdNQjRYCkRUSTBNREV4T0RFek1ERTFObG9YRFRNME1ERXhOVEV6TURFMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekV1TVRZd01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVlT1hnaWp6UHo3WmhFTG9GQlFIbkpNNzBGamtkRUE1aVI3UzlYYWtuTHdsM3V3cHVLd3UKKzluZkE1TzFUVUV2VG9GaXdsdTFSZUFEMXo2RHpkdHhRRjlKZ0VVZ3RSS0w4em1HTzRVQkMwS2R5REhoTXRXYQpkbFIrdkN2dG1tZkM1eWE3RGZFS1hDR1d6c3ppemJLVHZnZ1lVYkk0OFpQSVFXTFRMeElRTXNjL2I5b3lId3h0CmJCbDlrdW1VTXp4RnBJWkdDbHpNd3kva1pIdnlPN01nM3pKRzNvWDhORFdGRS90SVhPSm9FeVRmSi9rNGF2T3QKMVRxQ05BMytSaFZBT0xjc2lObmxnczh1ZmR5bWNFK3hqTEtQOURwVk9WUENMMTZWS1haZ0paOGExaTZWNk1seApyZlhmMFdFSUhvVVJ2QUNJSysySUxVcjJkdmRLR1lCQ1ZRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOekV1TVRZd2dqeHlkeTB4TnpZeU1USXpaaTFrTURjNUxUUTVNR1F0T1RoaU9TMDMKTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOekV1TVRZdwpnanh5ZHkweE56WXlNVEl6Wmkxa01EYzVMVFE1TUdRdE9UaGlPUzAzTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3ZWeUhCTU9hUjZDSEJNT2FSNkF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDZW5hTDNKRmFXcUUyN1JjeFJZdS80TFkyWXRIZFFvRGt4RnhZUVBMWEhYQ21zYmFuVE0rM3R1R1c0bwpnT29mcWxTc3I5bVY1UWF3YmxPRTQzL2cxaUEvUitEQlNybE5oK1hma1U3bWxFeTJROE82aXY0ZmJvOFlsaVhZCitFNGQvbE56S0R4NkI4WmV3SWxLYUlkTHBOck1vZTI4QUcvcndmNnJIWCtDaTVwVm42Y0VnSDBzR3BGZ0tibmYKM1RlNm5mRWt4NjhxTXFzTitFcStnMWNpNlBadEdaMlBUNEMwVG9uSmd6S3MxemxKcmZQZXExVlpIZjZDTEVpWApDS2R2QzZ2d0wvd3UycUdXdmoweWdCamZOQTRranp2TmdxN1BCTkVoR3JzUjdjWDdXbldTeDBkU3RwOUJmZjVRCmtMZEdIbWd1MlVqd210MWdMMlAzLzJwZzJpST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 13:04:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8b997dbb-2b85-4f18-b259-aa1dfc14ab48
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 13:04:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e35b9427-10cc-46a1-a0b6-d886af9b63fd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 13:04:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1921d880-4820-4764-b312-65387d4690d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T13:02:22.069042Z","id":"beda8870-5158-4fa7-995d-b08199fc68d5","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:17:4B:17","name":"read-replica-24cbe759","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:02:54.249705Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 13:04:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a96dae08-d805-4df6-b9ae-cb5e0866afb9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 13:04:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3bc6875-5fcf-4909-ada6-1a4a8e827e57
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "393"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:48 GMT
+      - Thu, 18 Jan 2024 13:04:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1521,7 +1686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1d753b1-add6-4c71-85b7-4a94e137b90b
+      - dba99d82-d731-46f2-8f55-8f52239002c4
     status: 200 OK
     code: 200
     duration: ""
@@ -1530,21 +1695,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"endpoints":[{"id":"63d8e4ed-781b-4b6d-bc4c-eb5138794c03","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"164ed3f4-f9e3-417d-802f-01090cbfb2a5","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "393"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:49 GMT
+      - Thu, 18 Jan 2024 13:04:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1554,7 +1719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d87cffa-020a-437b-a737-e59cb0eff82a
+      - e6e18d84-ee45-4636-b40c-5d951ec5d652
     status: 200 OK
     code: 200
     duration: ""
@@ -1563,12 +1728,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/606c6c28-0fd9-47f3-8029-bfc6749986d4
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/24cbe759-e982-4f92-b071-ce0d6956dcf8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"606c6c28-0fd9-47f3-8029-bfc6749986d4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"24cbe759-e982-4f92-b071-ce0d6956dcf8","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1577,7 +1742,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:19 GMT
+      - Thu, 18 Jan 2024 13:05:26 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1587,32 +1752,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 954d14e6-e5d9-4d2d-8c2f-1b5cc4d487ae
+      - db3b68e5-9463-4ab6-8a97-32c2e2a355bc
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","endpoint_spec":[{"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","ipam_config":{}}}],"same_zone":false}'
+    body: '{"instance_id":"1762123f-d079-490d-98b9-72966b1c204b","endpoint_spec":[{"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","ipam_config":{}}}],"same_zone":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "398"
+      - "389"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:20 GMT
+      - Thu, 18 Jan 2024 13:05:27 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1622,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9f096d7-3e09-48c4-944a-5f67905d1e8d
+      - 16acc365-a7ed-4fed-bde4-fc91c6aebfd6
     status: 200 OK
     code: 200
     duration: ""
@@ -1631,21 +1796,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "398"
+      - "389"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:20 GMT
+      - Thu, 18 Jan 2024 13:05:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1655,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14301ea1-e3f8-45a9-b3e8-09f747920435
+      - 5a060749-d647-46fd-bf77-e2decc09683f
     status: 200 OK
     code: 200
     duration: ""
@@ -1664,21 +1829,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "398"
+      - "389"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:50 GMT
+      - Thu, 18 Jan 2024 13:05:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1688,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c4d9432-5d94-44c8-af93-67fc07fc9007
+      - 82325a34-9cc0-447a-ad49-cbdf0de14a90
     status: 200 OK
     code: 200
     duration: ""
@@ -1697,21 +1862,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "398"
+      - "389"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:20 GMT
+      - Thu, 18 Jan 2024 13:06:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1721,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e4596d6-9378-4471-8b09-01f785354bdd
+      - 2923c766-78ee-4f67-9690-5718429f9bb1
     status: 200 OK
     code: 200
     duration: ""
@@ -1730,21 +1895,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"initializing"}'
     headers:
       Content-Length:
-      - "398"
+      - "389"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:54 GMT
+      - Thu, 18 Jan 2024 13:06:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1754,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3ad0064-a44d-4e75-881b-19574554db58
+      - f1f56188-29ef-46cc-b605-161c13710b9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1763,21 +1928,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "398"
+      - "382"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:33:24 GMT
+      - Thu, 18 Jan 2024 13:07:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1787,7 +1952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f9e785c-57f9-4f81-b986-88766a8bb896
+      - cd710756-fe81-47be-9767-3b815d06726b
     status: 200 OK
     code: 200
     duration: ""
@@ -1796,21 +1961,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "398"
+      - "382"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:33:54 GMT
+      - Thu, 18 Jan 2024 13:07:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1820,7 +1985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbfb66b5-d938-4510-9dd2-02c31f3d2046
+      - 0fe33d9a-2867-45e8-ae64-30eeac07c8d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1829,21 +1994,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"ips":[{"address":"172.16.24.3/22","created_at":"2024-01-18T13:05:27.694316Z","id":"f4c15a10-57c3-4eae-bc3c-7faa3ff61917","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:23:FC:D5","name":"read-replica-e3fc8e57","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:05:59.471956Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "398"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:24 GMT
+      - Thu, 18 Jan 2024 13:07:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1853,7 +2018,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9be6508c-4c54-4d16-a6b6-f200309516c2
+      - 2391ec11-f2e2-4967-a890-17b9601a8f4c
     status: 200 OK
     code: 200
     duration: ""
@@ -1862,21 +2027,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "391"
+      - "382"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:55 GMT
+      - Thu, 18 Jan 2024 13:07:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1886,7 +2051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bed87776-8667-4ba3-98dd-4c30302fccbb
+      - 8e3d312d-f1f2-45f9-9b2f-596218f1124c
     status: 200 OK
     code: 200
     duration: ""
@@ -1895,21 +2060,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "391"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:55 GMT
+      - Thu, 18 Jan 2024 13:07:28 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1919,7 +2084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07741aa3-3008-401e-8405-4b6209f566ca
+      - 994833f8-5222-4e46-9476-a356d62f37ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1928,21 +2093,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"created_at":"2024-01-18T12:59:19.242642Z","dhcp_enabled":true,"id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:59:19.242642Z","id":"688b82cd-178d-481a-a3c1-7d47ddf61d74","subnet":"172.16.24.0/22","updated_at":"2024-01-18T12:59:19.242642Z"},{"created_at":"2024-01-18T12:59:19.242642Z","id":"89bd07f5-1109-45bb-819e-a6039a202ded","subnet":"fd63:256c:45f7:65a8::/64","updated_at":"2024-01-18T12:59:19.242642Z"}],"tags":[],"updated_at":"2024-01-18T12:59:19.242642Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "391"
+      - "710"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:55 GMT
+      - Thu, 18 Jan 2024 13:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1952,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95682dc6-f67e-4bc7-832b-a42d6c937aad
+      - ce8c43f9-041f-431f-834e-8fd63628279b
     status: 200 OK
     code: 200
     duration: ""
@@ -1961,21 +2126,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "1740"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:55 GMT
+      - Thu, 18 Jan 2024 13:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1985,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5b1dd22-13ec-415b-8242-b2713267053c
+      - d593c701-c5ea-4939-bac7-5dd46fecd939
     status: 200 OK
     code: 200
     duration: ""
@@ -1994,21 +2159,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b/certificate
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.698727Z","dhcp_enabled":true,"id":"59a06b4b-913c-4680-9be4-4be8477ab22e","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.698727Z","id":"19f74986-42c3-461c-975e-1f064e490e03","subnet":"172.16.8.0/22","updated_at":"2024-01-09T17:25:11.698727Z"},{"created_at":"2024-01-09T17:25:11.698727Z","id":"aad6dd29-b45a-40e0-b0c1-ec2dbed93b72","subnet":"fd63:256c:45f7:45fd::/64","updated_at":"2024-01-09T17:25:11.698727Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.698727Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTi9uaHpRcUsrT0tQakFvOVpLaUpRR3RXRlB3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpFNU5TNHhOVFF1TnpFdU1UWXdNQjRYCkRUSTBNREV4T0RFek1ERTFObG9YRFRNME1ERXhOVEV6TURFMU5sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EakU1TlM0eE5UUXVOekV1TVRZd01JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXVlT1hnaWp6UHo3WmhFTG9GQlFIbkpNNzBGamtkRUE1aVI3UzlYYWtuTHdsM3V3cHVLd3UKKzluZkE1TzFUVUV2VG9GaXdsdTFSZUFEMXo2RHpkdHhRRjlKZ0VVZ3RSS0w4em1HTzRVQkMwS2R5REhoTXRXYQpkbFIrdkN2dG1tZkM1eWE3RGZFS1hDR1d6c3ppemJLVHZnZ1lVYkk0OFpQSVFXTFRMeElRTXNjL2I5b3lId3h0CmJCbDlrdW1VTXp4RnBJWkdDbHpNd3kva1pIdnlPN01nM3pKRzNvWDhORFdGRS90SVhPSm9FeVRmSi9rNGF2T3QKMVRxQ05BMytSaFZBT0xjc2lObmxnczh1ZmR5bWNFK3hqTEtQOURwVk9WUENMMTZWS1haZ0paOGExaTZWNk1seApyZlhmMFdFSUhvVVJ2QUNJSysySUxVcjJkdmRLR1lCQ1ZRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEakU1TlM0eE5UUXVOekV1TVRZd2dqeHlkeTB4TnpZeU1USXpaaTFrTURjNUxUUTVNR1F0T1RoaU9TMDMKTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEakU1TlM0eE5UUXVOekV1TVRZdwpnanh5ZHkweE56WXlNVEl6Wmkxa01EYzVMVFE1TUdRdE9UaGlPUzAzTWprMk5tSXhZekl3TkdJdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQktPc3ZWeUhCTU9hUjZDSEJNT2FSNkF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDZW5hTDNKRmFXcUUyN1JjeFJZdS80TFkyWXRIZFFvRGt4RnhZUVBMWEhYQ21zYmFuVE0rM3R1R1c0bwpnT29mcWxTc3I5bVY1UWF3YmxPRTQzL2cxaUEvUitEQlNybE5oK1hma1U3bWxFeTJROE82aXY0ZmJvOFlsaVhZCitFNGQvbE56S0R4NkI4WmV3SWxLYUlkTHBOck1vZTI4QUcvcndmNnJIWCtDaTVwVm42Y0VnSDBzR3BGZ0tibmYKM1RlNm5mRWt4NjhxTXFzTitFcStnMWNpNlBadEdaMlBUNEMwVG9uSmd6S3MxemxKcmZQZXExVlpIZjZDTEVpWApDS2R2QzZ2d0wvd3UycUdXdmoweWdCamZOQTRranp2TmdxN1BCTkVoR3JzUjdjWDdXbldTeDBkU3RwOUJmZjVRCmtMZEdIbWd1MlVqd210MWdMMlAzLzJwZzJpST0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "726"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:55 GMT
+      - Thu, 18 Jan 2024 13:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2018,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be668d48-ab55-4f0b-9930-f18b239aabb0
+      - dcc1bfed-ab9a-4174-94b0-4025e212a781
     status: 200 OK
     code: 200
     duration: ""
@@ -2027,21 +2192,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"ips":[{"address":"172.16.24.3/22","created_at":"2024-01-18T13:05:27.694316Z","id":"f4c15a10-57c3-4eae-bc3c-7faa3ff61917","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:23:FC:D5","name":"read-replica-e3fc8e57","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:05:59.471956Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1796"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:55 GMT
+      - Thu, 18 Jan 2024 13:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2051,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e844affc-b776-4b42-a264-8785e659721d
+      - 2cb2c107-425d-4b1d-87b7-37798526c967
     status: 200 OK
     code: 200
     duration: ""
@@ -2060,21 +2225,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWU1pMk53dXBxMkV1V3l4cXdGRHFPVVBkM24wd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TkM0eE9UQXdIaGNOCk1qUXdNVEE1TVRjeU56VTJXaGNOTXpRd01UQTJNVGN5TnpVMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTBMakU1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUttSzRqVW0xMFpqNjUxRXdNK0c0eittM2J4YWJ3NXJFdFNTcEpZT3ZMVUhvNHRUM1AvWVo1WEEKTDd5dWJueVJCVktXUzV3b0VvV0hjS3BhVWlMN0ZXY0lvR0xqMXFxWEZtS1JGbEdwU2JvQ3FoL21CNmQ2bWt6VQpKQjNsS2hLQ25YakJNTitrVjVrSnRPS0M2UG5tUDdSUjBBWVZJVGlHU3hKcFJnbnRRVzlSeHpJelFMOWRBWGx6Cmxza2QwL0tLT25vMFNjYzdHVE9taExrcVc3SmYrMkNJRWwxWFBnVVhEeWN3Z0JHalhzQjJKTkVXWmFKdzB6UEUKZVZtcXZ6OTlncElna1lSRjBIWXdhdWxEYXpUTkQzQThZRVZqU3NZc2k1QVFYMXI2MGNVUngvN1R5RFhlK21pQwpXTEZTdDNwbHZvQXJaSUJHVEZkV1Byd1EwaWNaTnNFQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qUXVNVGt3Z2p4eWR5MWxZall4WVRnM09DMDNOR1k0TFRRellqZ3RZV0UwTkMwNU1UZzQKWTJVeE5qWmxNekF1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU5DNHhPVENDUEhKMwpMV1ZpTmpGaE9EYzRMVGMwWmpndE5ETmlPQzFoWVRRMExUa3hPRGhqWlRFMk5tVXpNQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnl5Y29jRU01OFl2b2NFTTU4WXZqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKVUJpdlBFcGxlK2NodlNIQTUyYnZBQkJXOUJuNU92cTkzVmxscWhPejJYdG95Q04yUUhWSi80UHpUSGRyTEgwYQpZSHB1OVAvTXBRaXluRDBGWTBnK3h6djZVWEMzcTFCalByM3FIOHo4WG93MkdRMGs1SFBERjl5R3ZGYmF0S3pkCmJxbVpxWWxLTC9ENk50SUZ6MlQva1V1OTNZNURDWEdlV3VUZkh0NnRBR09sdkJjMHZEQUNTQ2k5cmRKOUVEVW4KVG9mSzZybERIbng4RFpoUkRNVVBpSDNiN0xqNVpVbjNxbDZHZ2lVSHp0Q3RyRGl5VnR1d214ampxb2thclh2bQp4Z29DZjZIekg0RXlsSUViY1p2UlUwa0FmOEs3dytXOWpzTW9RWVlPUlFQWUFJYzN2YTRmeUZxNVVmNmtUUHRKCmlmZ29MZjRNUnRCYmpRZHQyN2U0dHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "2009"
+      - "382"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:55 GMT
+      - Thu, 18 Jan 2024 13:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2084,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 092d193d-8483-488b-80ee-410d277ef170
+      - ac8c8e7c-84b2-4e88-a2ed-af005c777b80
     status: 200 OK
     code: 200
     duration: ""
@@ -2093,21 +2258,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb61a878-74f8-43b8-aa44-9188ce166e30&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1762123f-d079-490d-98b9-72966b1c204b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.8.3/22","created_at":"2024-01-09T17:31:19.944893Z","id":"35ea199b-4bfe-4ba2-ae54-051f3286a875","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"eb61a878-74f8-43b8-aa44-9188ce166e30","mac_address":"02:00:00:23:D3:BA","name":"read-replica-10f8d2ab","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"19f74986-42c3-461c-975e-1f064e490e03"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-09T17:31:51.365898Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.3/22","created_at":"2024-01-18T13:05:27.694316Z","id":"f4c15a10-57c3-4eae-bc3c-7faa3ff61917","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1762123f-d079-490d-98b9-72966b1c204b","mac_address":"02:00:00:23:FC:D5","name":"read-replica-e3fc8e57","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"688b82cd-178d-481a-a3c1-7d47ddf61d74"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T13:05:59.471956Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "547"
+      - "532"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:55 GMT
+      - Thu, 18 Jan 2024 13:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2117,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb659df9-03dd-461f-8d9d-1099b0b3a6a3
+      - 0752e1ae-519d-4255-8d2a-801759294d2a
     status: 200 OK
     code: 200
     duration: ""
@@ -2126,21 +2291,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
-      - "391"
+      - "382"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:56 GMT
+      - Thu, 18 Jan 2024 13:07:29 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2150,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22c47e14-2ba3-4e46-8f62-155941b8bae3
+      - 5fb05fd9-6484-47c7-b055-0cc5fd11534c
     status: 200 OK
     code: 200
     duration: ""
@@ -2159,54 +2324,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "391"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:34:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 080aaf6b-913e-4431-802c-5017d6761d6e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
-      - "394"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:57 GMT
+      - Thu, 18 Jan 2024 13:07:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2216,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5daa143e-4de8-4188-9bfd-56c6d0fe9283
+      - 5837c7d9-c911-4960-9c6c-ac02facd205f
     status: 200 OK
     code: 200
     duration: ""
@@ -2225,21 +2357,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"endpoints":[{"id":"24b6ddcf-6eac-4eef-9231-8dd1df48176a","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"59a06b4b-913c-4680-9be4-4be8477ab22e","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"10f8d2ab-dc15-4893-add7-e20662b95d02","instance_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"4d86d54c-7d17-4e11-97d8-11bfdb81a529","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"69d4c460-8ef9-4bc5-b235-8ddc767fec77","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","instance_id":"1762123f-d079-490d-98b9-72966b1c204b","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
-      - "394"
+      - "385"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:34:57 GMT
+      - Thu, 18 Jan 2024 13:07:30 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2249,7 +2381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a6a377a-4e42-4d12-88b7-cbda1d895cc2
+      - 0cbcfdcb-418e-4d47-b501-b23286e45432
     status: 200 OK
     code: 200
     duration: ""
@@ -2258,12 +2390,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"10f8d2ab-dc15-4893-add7-e20662b95d02","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -2272,7 +2404,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:35:27 GMT
+      - Thu, 18 Jan 2024 13:08:00 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2282,7 +2414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6a06052-d84d-4180-8dbd-663b1f5da10a
+      - 5a445df9-3d4f-4f99-a3fb-2bf3aec8b8dd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2291,75 +2423,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1405"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:35:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a947bde7-baf4-4352-b22a-f326ea38a828
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1408"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:35:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8c3863b0-11c4-4e51-a4cb-5e72e72b1b43
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/59a06b4b-913c-4680-9be4-4be8477ab22e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69d4c460-8ef9-4bc5-b235-8ddc767fec77
     method: DELETE
   response:
     body: ""
@@ -2369,7 +2435,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:35:28 GMT
+      - Thu, 18 Jan 2024 13:08:01 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2379,7 +2445,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7996418-fc65-491f-8416-b39c0d7eaa4e
+      - 3072f8cf-38cc-4177-9adf-a896ac1bac64
     status: 204 No Content
     code: 204
     duration: ""
@@ -2388,21 +2454,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.122414Z","endpoint":{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929},"endpoints":[{"id":"639b8347-0ecf-4796-93dd-8df941b75f17","ip":"51.159.24.190","load_balancer":{},"name":null,"port":3929}],"engine":"PostgreSQL-14","id":"eb61a878-74f8-43b8-aa44-9188ce166e30","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1408"
+      - "1358"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:35:28 GMT
+      - Thu, 18 Jan 2024 13:08:03 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2412,7 +2478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f40e42b1-8a30-4780-bcb9-459734cab583
+      - 971304db-7feb-4d10-8030-d332479d54de
     status: 200 OK
     code: 200
     duration: ""
@@ -2421,21 +2487,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1361"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:35:58 GMT
+      - Thu, 18 Jan 2024 13:08:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2445,30 +2511,30 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 588f031e-20a0-4b64-be63-d9ca58d02c11
-    status: 404 Not Found
-    code: 404
+      - 66a3cb0d-1bd9-4431-8410-9d84e2cd2516
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/eb61a878-74f8-43b8-aa44-9188ce166e30
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"eb61a878-74f8-43b8-aa44-9188ce166e30","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:59:19.505262Z","endpoint":{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972},"endpoints":[{"id":"d1a4e738-c025-4d48-8805-66211485cff6","ip":"195.154.71.160","load_balancer":{},"name":null,"port":13972}],"engine":"PostgreSQL-14","id":"1762123f-d079-490d-98b9-72966b1c204b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1361"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:35:58 GMT
+      - Thu, 18 Jan 2024 13:08:06 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2478,7 +2544,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e800e0bb-8d6a-4283-b534-a7d99889af04
+      - a26e8568-7141-487b-9f26-ca24c2361ddc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1762123f-d079-490d-98b9-72966b1c204b","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 13:08:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5567552f-dfa1-4935-8e1a-00751045eb43
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2487,12 +2586,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/10f8d2ab-dc15-4893-add7-e20662b95d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1762123f-d079-490d-98b9-72966b1c204b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"10f8d2ab-dc15-4893-add7-e20662b95d02","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1762123f-d079-490d-98b9-72966b1c204b","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 13:08:36 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0ea8fc7f-18c7-4026-844a-b88e9744da61
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/e3fc8e57-833f-43dc-8f3f-ef31d5efc72c
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"e3fc8e57-833f-43dc-8f3f-ef31d5efc72c","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -2501,7 +2633,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:35:58 GMT
+      - Thu, 18 Jan 2024 13:08:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2511,7 +2643,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b825514-9700-4969-adf1-b75eea68038c
+      - 84711447-b375-435f-a535-69e9edc75605
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:10 GMT
+      - Thu, 18 Jan 2024 12:42:35 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da1e1eec-5ed1-423a-9cb9-5407cef1d116
+      - 573bbcb6-6982-4ad4-bdcc-f01fc6802e77
     status: 200 OK
     code: 200
     duration: ""
@@ -339,21 +339,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 501c75b6-eb7c-456f-a170-02aef2973326
+      - da7a04b2-223a-4d84-b20f-dad88239b296
     status: 200 OK
     code: 200
     duration: ""
@@ -372,21 +372,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,32 +396,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3565dc68-4bab-42e8-b03a-7728ff933100
+      - b6077e04-b34d-4b88-9f08-ea79295572be
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-pensive-ardinghelli","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
+    body: '{"name":"tf-pn-trusting-carson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.779892Z","dhcp_enabled":true,"id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","name":"tf-pn-pensive-ardinghelli","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.779892Z","id":"40c32c59-d414-4942-b888-600d5a9f4131","subnet":"172.16.12.0/22","updated_at":"2024-01-09T17:25:11.779892Z"},{"created_at":"2024-01-09T17:25:11.779892Z","id":"67333a85-b742-4480-a193-b220257b2794","subnet":"fd63:256c:45f7:6165::/64","updated_at":"2024-01-09T17:25:11.779892Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.779892Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T12:42:35.967986Z","dhcp_enabled":true,"id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","name":"tf-pn-trusting-carson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:42:35.967986Z","id":"ba974b81-10d8-4844-aff4-7f344f98f022","subnet":"172.16.20.0/22","updated_at":"2024-01-18T12:42:35.967986Z"},{"created_at":"2024-01-18T12:42:35.967986Z","id":"38ac9e69-404b-43a9-b5f4-983996fbbfd3","subnet":"fd63:256c:45f7:95a7::/64","updated_at":"2024-01-18T12:42:35.967986Z"}],"tags":[],"updated_at":"2024-01-18T12:42:35.967986Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:13 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9beba940-2afa-4d83-8fb3-eb01164c7a03
+      - 7bd4208b-f6b3-49bf-b6f3-6e553df339cc
     status: 200 OK
     code: 200
     duration: ""
@@ -440,21 +440,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a8e475d-bb71-47fc-8f8a-49ca67144ee3
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7063d2ea-1b84-4ad3-8046-7edcbad3c805
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.779892Z","dhcp_enabled":true,"id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","name":"tf-pn-pensive-ardinghelli","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.779892Z","id":"40c32c59-d414-4942-b888-600d5a9f4131","subnet":"172.16.12.0/22","updated_at":"2024-01-09T17:25:11.779892Z"},{"created_at":"2024-01-09T17:25:11.779892Z","id":"67333a85-b742-4480-a193-b220257b2794","subnet":"fd63:256c:45f7:6165::/64","updated_at":"2024-01-09T17:25:11.779892Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.779892Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T12:42:35.967986Z","dhcp_enabled":true,"id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","name":"tf-pn-trusting-carson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:42:35.967986Z","id":"ba974b81-10d8-4844-aff4-7f344f98f022","subnet":"172.16.20.0/22","updated_at":"2024-01-18T12:42:35.967986Z"},{"created_at":"2024-01-18T12:42:35.967986Z","id":"38ac9e69-404b-43a9-b5f4-983996fbbfd3","subnet":"fd63:256c:45f7:95a7::/64","updated_at":"2024-01-18T12:42:35.967986Z"}],"tags":[],"updated_at":"2024-01-18T12:42:35.967986Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:13 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cacfffcb-f5c3-4ee4-9f55-f80e0e8efef5
+      - 74ea1ef0-bde6-415f-89c7-c9993d7645a5
     status: 200 OK
     code: 200
     duration: ""
@@ -473,21 +473,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:42 GMT
+      - Thu, 18 Jan 2024 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17faa8e3-0285-4170-9a28-71c48d76197a
+      - 8143d749-7ab2-48de-99f2-5af9b637e796
     status: 200 OK
     code: 200
     duration: ""
@@ -506,21 +506,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:12 GMT
+      - Thu, 18 Jan 2024 12:43:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2eb56633-0922-4563-9982-5d9a82009671
+      - 85827959-3724-4951-9ac3-9985cf29f464
     status: 200 OK
     code: 200
     duration: ""
@@ -539,21 +539,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:42 GMT
+      - Thu, 18 Jan 2024 12:44:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dd5e6a1-6eda-45f9-9bcd-65f080afaf60
+      - 967b04f4-eb9c-464f-a742-8a1349deeebf
     status: 200 OK
     code: 200
     duration: ""
@@ -572,21 +572,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "774"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:13 GMT
+      - Thu, 18 Jan 2024 12:44:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d292ed17-7001-482c-b7ab-1674ed72c613
+      - 8f975247-e2ba-4b54-9b9b-bca485f2a725
     status: 200 OK
     code: 200
     duration: ""
@@ -605,21 +605,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "803"
+      - "1038"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:43 GMT
+      - Thu, 18 Jan 2024 12:45:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 205b5e20-4475-4531-809f-1676d4ab7a54
+      - 24475ac5-d223-48d9-b9f6-8998aa25332f
     status: 200 OK
     code: 200
     duration: ""
@@ -638,21 +638,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114},"endpoints":[{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114}],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1078"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 12:45:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c14a1a8-182f-4713-9581-87c5c939d4f4
+      - 483efd82-20d7-4ec0-a679-baa9c0377dae
     status: 200 OK
     code: 200
     duration: ""
@@ -671,21 +671,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583},"endpoints":[{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583}],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVVk4vNkFXYStpUlpRa0dmTW0rWlNQWnFpV2VJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzQ1TGpFMk16QWVGdzB5Ck5EQXhNVGd4TWpRMU1UVmFGdzB6TkRBeE1UVXhNalExTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU9TNHhOak13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM5azVncjkvZE5GZ05QU1FyOVZzZHZyWk1rMGZJUjlwNkxyQVVWa3V3aU04MDhSSkNZYW44NVhQNGEKMnp2QWhncks3QVVDYS9PU0V0eWRsS1puV21tRFJKT0ZFY0pscytnMlVLdEt0dmpHOER0bEdpajF1VE14aXFLbwo3RHc4T29jNm5SZllOUHh2UDl6WVVKbUFIMHNMamEremtZN3o3Z0FsRUN4Mmordi9XUlVKenVwU1p3UEE3Mk5MCk1lTmF1b3lGWnFpTWgxYUhUblNiVGpFZDBoNU1jclNnVmQzQURDMGZCTmtETXlIeDVpUjBocDNPc203Y1JDanIKaDdmckxscC8wK2xZL0grQjdqQnhzT3Q1S0kwOTlONEpFV1hQTWdNOCt4MTZ2U2pzZXpVZDhDaExxZ1JUY08ycwppdytnZ2NrcHBWam1pYUgzUXRpdFAwd3NMSnVEQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU1TGprdU1UWXpnanh5ZHkwM00ySmhOelF4TlMxbE5tUm1MVFExTkRrdE9XTXhOeTFqTjJRMVpqbGoKTnpVM1l6a3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPUzQ1TGpFMk00SThjbmN0TnpOaQpZVGMwTVRVdFpUWmtaaTAwTlRRNUxUbGpNVGN0WXpka05XWTVZemMxTjJNNUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJMMWNod1F6bndtamh3UXpud21qTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBd2pIUmIKZzdVb3ZPVTgrTXBMdkJ4MmQxR1pQQ1pmQWdNOENJZkhUcmlrMzhYb3FsQXdDNkl0dll0TFZ5dTJhRTBFbTlOSApTNWhIYjY3NWNENDBPM1RDbmgxT1VueVlBZisrZEZldi9scGw0NzdQUGZDYjBoYUFjcnJrak1FWGNIRFB2QjFzCkZ5UEh1azJuOWFXUVhaNUdLaHYxR08vZ3lFQWFNVXBQSTFyRm1NR1oyOWlhc0NVV1BNamFNbEhZMUt5a2RBa3kKUUlMdmRTamtieFQzQm95NWxjbWkxOGlPd1ZZVGNaS3JxRUc4T0cxRHlYbm04STlwdXVEQXFWUnFWdlJxREl6RgpKOVYzanhHQlpPczRsMjFZUHBUZWpYZDE2ejBsN1RNdVR2OWVXNlRlZkw2cnNQdTBLS29RMVBXMXhIamppVEh0CnEvZUF1dlpKS2J1TGMxSmwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1297"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:43 GMT
+      - Thu, 18 Jan 2024 12:45:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 006af44a-eb75-42c3-ab3e-db426eba5545
+      - 562e246c-55bc-4717-afac-1c16cca0fa24
     status: 200 OK
     code: 200
     duration: ""
@@ -704,54 +704,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRmp0VjVrZDEyMGNiYUR0QkU2L0pDbkhHRmIwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqSTBPVEFlCkZ3MHlOREF4TURreE56STRNVEJhRncwek5EQXhNRFl4TnpJNE1UQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eU5Ea3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2RXSnNkdGNBTkd5MHRpTW5VT3F4aU14azRXMHRaQk02OHlJZENLWkpLdTlFSzBpS3kKMmRtNnpzSXJBSkRwNm5jR1lMTUFuNUgxQ2pJL1o2Qkw2allsREVOZjVVckN2c3ZGN2FmZ3VhclpXa0FoNERmRAorTWVZMWVhYTJCeGIydzFmdXJlbkdCL0pMUlJvdXB3L3VPQXM2alNpaXRaNE9qVUxkdU15RUxPaEJUS1pyQkhQCkVEcTI3STJaTlQ1RUVXaEVKQzNCanJNRWdHRGtNWUFlcFpsRkdPQnpPdEp6OC9xQnRRSkg0eVhZRjlWbU5UOXgKdDhxbFNSd1NxWU1Bb3NFaDUzK3pzbTB5c3VTRVBCNFJ0NVhscUYrK1BsMnhKbUR5N05kSHd4bEhBM2RKZ1FpVApXQ2ZoVzhKbmVNNG5XODdEZFh3a0d4WXpnK1F5VmI4dEt3MzlBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1qUTVnanh5ZHkwMk1HTTVaVEJqTWkwM1lUQm1MVFExTVRrdE9ESTQKT1MxaE1ERTROR1kzWmpSbFpEZ3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakkwT1lJOGNuY3ROakJqT1dVd1l6SXROMkV3WmkwME5URTVMVGd5T0RrdFlUQXhPRFJtTjJZMFpXUTRMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpENDBoaHdURG1zVDVod1REbXNUNU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNUN3NRSHpMVjB5eGRNc25pS2JSKzhPcGZsVnAyWGJTVkRUYUh4TjE1dUZFVG50Y2ltMkI3SAo0L2JkNnZERGRMaHpkSy85UG0zdGNaUkY4b1BWV0JVU2xGQ3RsTUhVTkpHQ09RYXo5WXhTbTkyVDFLMGpZYmEvCmU5cWZoeVJKMjdWNGlYcnQzMG5KTDRxR1BScUdtand4Qlh2TU03SC85bC9TbDNFTkRYbjlZak1VNjl0SWlvVGUKak5sQ2JydzdFN3RCTHdpQmtSL3ZWUHpHQlZvY1hVaFgxVWtxM05ZOW5TTmx3d0tVTElFeHdnSUcrS0ExTCt4Ygo5b2RuNlVHWHcxaUhxeWNSSFI2VzgyVHRxMUJKOEdzVWF2YnhWc0VuaHAyWG5mQk9iRU00akFFeWwzYnFiUlV2Cm45WlhMR0U0M21BZG1zNVFHYXRpa1dnbWpzR3dxajhKCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2017"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:28:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d5196174-bfb1-4a18-8ab5-8e064ad01521
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=60c9e0c2-7a0f-4519-8289-a0184f7f4ed8&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=73ba7415-e6df-4549-9c17-c7d5f9c757c9&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:43 GMT
+      - Thu, 18 Jan 2024 12:45:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,32 +728,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34f0be14-ea82-4808-a658-973272cc0fdc
+      - 0cc64a11-252f-4f09-bca1-50572367726d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
+    body: '{"instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:44 GMT
+      - Thu, 18 Jan 2024 12:45:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b853a79d-3005-428c-a2ac-c79542cb7d9c
+      - 9cbcc199-6f54-4ade-8d62-d5e79ae7f7fa
     status: 200 OK
     code: 200
     duration: ""
@@ -805,21 +772,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:44 GMT
+      - Thu, 18 Jan 2024 12:45:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d87e797-4a52-4218-ae50-0e7a1703e449
+      - a0f41b12-7842-4fdb-8937-f6b877643bec
     status: 200 OK
     code: 200
     duration: ""
@@ -838,21 +805,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:14 GMT
+      - Thu, 18 Jan 2024 12:46:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 378a90b5-2e43-45d9-b497-e60f4b3e31bb
+      - 9b4950e0-d1c1-402e-8dd7-9f11df380e07
     status: 200 OK
     code: 200
     duration: ""
@@ -871,21 +838,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "508"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:44 GMT
+      - Thu, 18 Jan 2024 12:46:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d14cb3ea-8cb6-4c63-8b66-e6069160bb04
+      - 333e1e51-7eb0-49b2-8a65-594610c5f68b
     status: 200 OK
     code: 200
     duration: ""
@@ -904,21 +871,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "508"
+      - "493"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:14 GMT
+      - Thu, 18 Jan 2024 12:47:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc7f5873-9637-4723-889f-cee406e16e64
+      - 4add1694-6e74-465c-b216-6143bcad6fbe
     status: 200 OK
     code: 200
     duration: ""
@@ -937,21 +904,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "508"
+      - "493"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:44 GMT
+      - Thu, 18 Jan 2024 12:47:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74b3b1f8-7591-4e70-b595-3078f23af27b
+      - 2748ff4c-1a69-4bfd-a85a-7a9476a5ee5f
     status: 200 OK
     code: 200
     duration: ""
@@ -970,21 +937,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "501"
+      - "486"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:14 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1395090b-6efc-4c33-a861-59079b8cebbb
+      - 2d4dfe3f-1c3c-4013-8ec3-5fd66243c907
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,21 +970,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "501"
+      - "486"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03560915-5139-4780-b2b4-4eaede0f7395
+      - 326b1220-5a4b-4a06-8387-e8143a1605e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,153 +1003,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "501"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7ca114e2-e412-476f-85d7-0b5feeafd513
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a8e475d-bb71-47fc-8f8a-49ca67144ee3
-    method: GET
-  response:
-    body: '{"created_at":"2024-01-09T17:25:11.779892Z","dhcp_enabled":true,"id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","name":"tf-pn-pensive-ardinghelli","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.779892Z","id":"40c32c59-d414-4942-b888-600d5a9f4131","subnet":"172.16.12.0/22","updated_at":"2024-01-09T17:25:11.779892Z"},{"created_at":"2024-01-09T17:25:11.779892Z","id":"67333a85-b742-4480-a193-b220257b2794","subnet":"fd63:256c:45f7:6165::/64","updated_at":"2024-01-09T17:25:11.779892Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.779892Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "726"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 80bb3d7f-d08e-46ab-b910-3a68af315c23
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583},"endpoints":[{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583}],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1798"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fb84fab9-c13e-4cd7-abc2-1d8e8ab5c151
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRmp0VjVrZDEyMGNiYUR0QkU2L0pDbkhHRmIwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrMkxqSTBPVEFlCkZ3MHlOREF4TURreE56STRNVEJhRncwek5EQXhNRFl4TnpJNE1UQmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tmk0eU5Ea3dnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ2RXSnNkdGNBTkd5MHRpTW5VT3F4aU14azRXMHRaQk02OHlJZENLWkpLdTlFSzBpS3kKMmRtNnpzSXJBSkRwNm5jR1lMTUFuNUgxQ2pJL1o2Qkw2allsREVOZjVVckN2c3ZGN2FmZ3VhclpXa0FoNERmRAorTWVZMWVhYTJCeGIydzFmdXJlbkdCL0pMUlJvdXB3L3VPQXM2alNpaXRaNE9qVUxkdU15RUxPaEJUS1pyQkhQCkVEcTI3STJaTlQ1RUVXaEVKQzNCanJNRWdHRGtNWUFlcFpsRkdPQnpPdEp6OC9xQnRRSkg0eVhZRjlWbU5UOXgKdDhxbFNSd1NxWU1Bb3NFaDUzK3pzbTB5c3VTRVBCNFJ0NVhscUYrK1BsMnhKbUR5N05kSHd4bEhBM2RKZ1FpVApXQ2ZoVzhKbmVNNG5XODdEZFh3a0d4WXpnK1F5VmI4dEt3MzlBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RZdU1qUTVnanh5ZHkwMk1HTTVaVEJqTWkwM1lUQm1MVFExTVRrdE9ESTQKT1MxaE1ERTROR1kzWmpSbFpEZ3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMgpMakkwT1lJOGNuY3ROakJqT1dVd1l6SXROMkV3WmkwME5URTVMVGd5T0RrdFlUQXhPRFJtTjJZMFpXUTRMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpENDBoaHdURG1zVDVod1REbXNUNU1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNUN3NRSHpMVjB5eGRNc25pS2JSKzhPcGZsVnAyWGJTVkRUYUh4TjE1dUZFVG50Y2ltMkI3SAo0L2JkNnZERGRMaHpkSy85UG0zdGNaUkY4b1BWV0JVU2xGQ3RsTUhVTkpHQ09RYXo5WXhTbTkyVDFLMGpZYmEvCmU5cWZoeVJKMjdWNGlYcnQzMG5KTDRxR1BScUdtand4Qlh2TU03SC85bC9TbDNFTkRYbjlZak1VNjl0SWlvVGUKak5sQ2JydzdFN3RCTHdpQmtSL3ZWUHpHQlZvY1hVaFgxVWtxM05ZOW5TTmx3d0tVTElFeHdnSUcrS0ExTCt4Ygo5b2RuNlVHWHcxaUhxeWNSSFI2VzgyVHRxMUJKOEdzVWF2YnhWc0VuaHAyWG5mQk9iRU00akFFeWwzYnFiUlV2Cm45WlhMR0U0M21BZG1zNVFHYXRpa1dnbWpzR3dxajhKCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2017"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f9f2eaf0-b053-4544-8a19-ef4947b45e6c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=60c9e0c2-7a0f-4519-8289-a0184f7f4ed8&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=73ba7415-e6df-4549-9c17-c7d5f9c757c9&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59cb385d-fc0d-4e44-898e-ddbca866edf6
+      - 370f5244-35cf-4955-8385-712bfca4033f
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,21 +1036,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "501"
+      - "486"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51ff142f-d1f0-4a47-ad5c-8a70481e8600
+      - ee2fa4fd-b58c-40a0-b8f9-7d6770ff40cb
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,21 +1069,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7063d2ea-1b84-4ad3-8046-7edcbad3c805
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2024-01-18T12:42:35.967986Z","dhcp_enabled":true,"id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","name":"tf-pn-trusting-carson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:42:35.967986Z","id":"ba974b81-10d8-4844-aff4-7f344f98f022","subnet":"172.16.20.0/22","updated_at":"2024-01-18T12:42:35.967986Z"},{"created_at":"2024-01-18T12:42:35.967986Z","id":"38ac9e69-404b-43a9-b5f4-983996fbbfd3","subnet":"fd63:256c:45f7:95a7::/64","updated_at":"2024-01-18T12:42:35.967986Z"}],"tags":[],"updated_at":"2024-01-18T12:42:35.967986Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "501"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 922e5451-7f85-45f0-8437-5628bc68f013
+      - e40fb9e8-14fa-42f8-9224-c045bec83122
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,21 +1102,219 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114},"endpoints":[{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114}],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1729"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 167d442d-61ae-4bfe-b4e0-019c14e96dea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQrRENDQXVDZ0F3SUJBZ0lVVk4vNkFXYStpUlpRa0dmTW0rWlNQWnFpV2VJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERVeExqRTFPUzQ1TGpFMk16QWVGdzB5Ck5EQXhNVGd4TWpRMU1UVmFGdzB6TkRBeE1UVXhNalExTVRWYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBdzFNUzR4TlRrdU9TNHhOak13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUM5azVncjkvZE5GZ05QU1FyOVZzZHZyWk1rMGZJUjlwNkxyQVVWa3V3aU04MDhSSkNZYW44NVhQNGEKMnp2QWhncks3QVVDYS9PU0V0eWRsS1puV21tRFJKT0ZFY0pscytnMlVLdEt0dmpHOER0bEdpajF1VE14aXFLbwo3RHc4T29jNm5SZllOUHh2UDl6WVVKbUFIMHNMamEremtZN3o3Z0FsRUN4Mmordi9XUlVKenVwU1p3UEE3Mk5MCk1lTmF1b3lGWnFpTWgxYUhUblNiVGpFZDBoNU1jclNnVmQzQURDMGZCTmtETXlIeDVpUjBocDNPc203Y1JDanIKaDdmckxscC8wK2xZL0grQjdqQnhzT3Q1S0kwOTlONEpFV1hQTWdNOCt4MTZ2U2pzZXpVZDhDaExxZ1JUY08ycwppdytnZ2NrcHBWam1pYUgzUXRpdFAwd3NMSnVEQWdNQkFBR2pnYnN3Z2Jnd2diVUdBMVVkRVFTQnJUQ0Jxb0lNCk5URXVNVFU1TGprdU1UWXpnanh5ZHkwM00ySmhOelF4TlMxbE5tUm1MVFExTkRrdE9XTXhOeTFqTjJRMVpqbGoKTnpVM1l6a3VjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRERVeExqRTFPUzQ1TGpFMk00SThjbmN0TnpOaQpZVGMwTVRVdFpUWmtaaTAwTlRRNUxUbGpNVGN0WXpka05XWTVZemMxTjJNNUxuSmtZaTVtY2kxd1lYSXVjMk4zCkxtTnNiM1ZraHdTanJMMWNod1F6bndtamh3UXpud21qTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBd2pIUmIKZzdVb3ZPVTgrTXBMdkJ4MmQxR1pQQ1pmQWdNOENJZkhUcmlrMzhYb3FsQXdDNkl0dll0TFZ5dTJhRTBFbTlOSApTNWhIYjY3NWNENDBPM1RDbmgxT1VueVlBZisrZEZldi9scGw0NzdQUGZDYjBoYUFjcnJrak1FWGNIRFB2QjFzCkZ5UEh1azJuOWFXUVhaNUdLaHYxR08vZ3lFQWFNVXBQSTFyRm1NR1oyOWlhc0NVV1BNamFNbEhZMUt5a2RBa3kKUUlMdmRTamtieFQzQm95NWxjbWkxOGlPd1ZZVGNaS3JxRUc4T0cxRHlYbm04STlwdXVEQXFWUnFWdlJxREl6RgpKOVYzanhHQlpPczRsMjFZUHBUZWpYZDE2ejBsN1RNdVR2OWVXNlRlZkw2cnNQdTBLS29RMVBXMXhIamppVEh0CnEvZUF1dlpKS2J1TGMxSmwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e4c570d7-f697-4b4c-8a93-79ec5f3840b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=73ba7415-e6df-4549-9c17-c7d5f9c757c9&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3904ef1c-a161-45dc-a970-ee3d8feecefa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "486"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4ec7f64f-e684-4388-aeb8-8476a5a9b18f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=73ba7415-e6df-4549-9c17-c7d5f9c757c9&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 64b11d02-b2b9-4402-9be2-38a6c0bd4013
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "486"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3eb842a0-de72-4b85-aa45-e9caeacf887d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "504"
+      - "489"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 12:48:10 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65876c3f-0197-4bf1-a48f-d5a44729eb5f
+      - b5f9e354-5d09-464f-849f-2826bcc4b810
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,21 +1333,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"endpoints":[{"id":"5feebff6-88d1-403d-b3a6-6f0ee7157cbc","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"8a8e475d-bb71-47fc-8f8a-49ca67144ee3","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"83ed4df2-6be8-4f30-98ce-ce79e2e52f34","ip":"51.15.250.2","name":null,"port":5432}],"id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","instance_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"1a577ed3-4050-48a5-946d-a96bd3544c4d","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"7063d2ea-1b84-4ad3-8046-7edcbad3c805","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"84043cc8-e31c-4e51-8722-317fb85b85ad","ip":"51.158.99.21","name":null,"port":5432}],"id":"58f36de3-f9af-4546-b75d-55379fee2603","instance_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "504"
+      - "489"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 12:48:11 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9438fa04-cbe4-4582-b982-833834a57737
+      - d6727f77-a3d6-4c00-af19-5ae3b7bde43d
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,12 +1366,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"58f36de3-f9af-4546-b75d-55379fee2603","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1347,7 +1380,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:46 GMT
+      - Thu, 18 Jan 2024 12:48:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e9cffd0-a7c7-4bd0-b276-6f941ec8f709
+      - 3c471b49-6617-4b09-9359-8a9001bdb893
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1366,108 +1399,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583},"endpoints":[{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583}],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1297"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9545d462-e15e-4911-ae06-2ecba4ad6f47
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583},"endpoints":[{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583}],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1300"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab6c8df2-2bbc-481d-8d3b-1d83d2106827
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.267983Z","endpoint":{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583},"endpoints":[{"id":"dee1f083-fa30-4a23-9840-2641c2562acb","ip":"195.154.196.249","load_balancer":{},"name":null,"port":6583}],"engine":"PostgreSQL-15","id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1300"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab80e985-dc26-411b-96b5-4e257b366179
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8a8e475d-bb71-47fc-8f8a-49ca67144ee3
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/7063d2ea-1b84-4ad3-8046-7edcbad3c805
     method: DELETE
   response:
     body: ""
@@ -1477,7 +1411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:47 GMT
+      - Thu, 18 Jan 2024 12:48:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3eafa802-7dfa-43b5-86dc-53421398bd4d
+      - b180c688-3d62-4c9a-9cc8-f33b503ef15a
     status: 204 No Content
     code: 204
     duration: ""
@@ -1496,21 +1430,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114},"endpoints":[{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114}],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1243"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:17 GMT
+      - Thu, 18 Jan 2024 12:48:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,30 +1454,30 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bea981f-3ac4-49ce-9ca1-d9edcef7152a
-    status: 404 Not Found
-    code: 404
+      - 842b4bdf-4ca7-4862-b97c-6fa4168f9e7e
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/60c9e0c2-7a0f-4519-8289-a0184f7f4ed8
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
+    method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"60c9e0c2-7a0f-4519-8289-a0184f7f4ed8","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114},"endpoints":[{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114}],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "129"
+      - "1246"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:17 GMT
+      - Thu, 18 Jan 2024 12:48:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1487,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79a9823a-4aae-4e78-845e-716d0fc628bd
+      - 500c3717-30a2-4d63-a896-c3ee2b37019f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.236374Z","endpoint":{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114},"endpoints":[{"id":"b591fc2f-be46-47f0-b5d3-507ef1d9d67c","ip":"51.159.9.163","load_balancer":{},"name":null,"port":3114}],"engine":"PostgreSQL-15","id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:48:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0aec8f3e-9ae7-482a-8325-617ade49857f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:49:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9787d3dc-0839-484f-bdf8-c05d30191092
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1562,12 +1562,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/afffb28d-d632-47ca-b013-c35cd5e8dd46
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/73ba7415-e6df-4549-9c17-c7d5f9c757c9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"afffb28d-d632-47ca-b013-c35cd5e8dd46","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"73ba7415-e6df-4549-9c17-c7d5f9c757c9","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:49:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d5539de-9bf5-4d82-8f35-b77ec9930879
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/58f36de3-f9af-4546-b75d-55379fee2603
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"58f36de3-f9af-4546-b75d-55379fee2603","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1576,7 +1609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:17 GMT
+      - Thu, 18 Jan 2024 12:49:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1586,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6dedd915-1b19-475c-a2c4-9c7746b3609f
+      - eda68ce3-ccf6-4178-ae42-186e5cf4cddc
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:08 GMT
+      - Thu, 18 Jan 2024 12:42:34 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f7bd823-a402-4051-8da2-a955c796bf19
+      - 0cc71836-dce6-4b05-84c2-dba2ab863d0d
     status: 200 OK
     code: 200
     duration: ""
@@ -339,21 +339,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 893cfc82-c387-4eb7-9471-a2e86f16f139
+      - 03b0ca8f-f101-4a80-b873-7916926b90ee
     status: 200 OK
     code: 200
     duration: ""
@@ -372,21 +372,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,32 +396,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 046f8c87-2937-4e54-9f89-877283844058
+      - cb7e6b70-2230-48bb-a68f-199493bbf24d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-relaxed-agnesi","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
+    body: '{"name":"tf-pn-jolly-mirzakhani","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.835441Z","dhcp_enabled":true,"id":"247d0827-61b8-4b70-be93-ad173f7d18de","name":"tf-pn-relaxed-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.835441Z","id":"da070b3e-d9ab-409b-8f5e-f2fd71a56d03","subnet":"172.16.0.0/22","updated_at":"2024-01-09T17:25:11.835441Z"},{"created_at":"2024-01-09T17:25:11.835441Z","id":"12381968-37cf-4d86-8845-e6b401675c43","subnet":"fd63:256c:45f7:fcba::/64","updated_at":"2024-01-09T17:25:11.835441Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.835441Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T12:42:36.140941Z","dhcp_enabled":true,"id":"239642f5-0a04-456a-9673-2b61119545a9","name":"tf-pn-jolly-mirzakhani","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:42:36.140941Z","id":"01541042-ead1-4345-a17f-de919c193f50","subnet":"172.16.16.0/22","updated_at":"2024-01-18T12:42:36.140941Z"},{"created_at":"2024-01-18T12:42:36.140941Z","id":"f359605e-3783-4fc8-843f-8fe502b53357","subnet":"fd63:256c:45f7:1345::/64","updated_at":"2024-01-18T12:42:36.140941Z"}],"tags":[],"updated_at":"2024-01-18T12:42:36.140941Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "706"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:13 GMT
+      - Thu, 18 Jan 2024 12:42:36 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -431,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c26797d-67a2-45ae-9f9b-ed17aae34cd3
+      - 422e77dc-cf49-4a0d-9523-84b3b0b6159d
     status: 200 OK
     code: 200
     duration: ""
@@ -440,21 +440,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/247d0827-61b8-4b70-be93-ad173f7d18de
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/239642f5-0a04-456a-9673-2b61119545a9
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.835441Z","dhcp_enabled":true,"id":"247d0827-61b8-4b70-be93-ad173f7d18de","name":"tf-pn-relaxed-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.835441Z","id":"da070b3e-d9ab-409b-8f5e-f2fd71a56d03","subnet":"172.16.0.0/22","updated_at":"2024-01-09T17:25:11.835441Z"},{"created_at":"2024-01-09T17:25:11.835441Z","id":"12381968-37cf-4d86-8845-e6b401675c43","subnet":"fd63:256c:45f7:fcba::/64","updated_at":"2024-01-09T17:25:11.835441Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.835441Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T12:42:36.140941Z","dhcp_enabled":true,"id":"239642f5-0a04-456a-9673-2b61119545a9","name":"tf-pn-jolly-mirzakhani","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:42:36.140941Z","id":"01541042-ead1-4345-a17f-de919c193f50","subnet":"172.16.16.0/22","updated_at":"2024-01-18T12:42:36.140941Z"},{"created_at":"2024-01-18T12:42:36.140941Z","id":"f359605e-3783-4fc8-843f-8fe502b53357","subnet":"fd63:256c:45f7:1345::/64","updated_at":"2024-01-18T12:42:36.140941Z"}],"tags":[],"updated_at":"2024-01-18T12:42:36.140941Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "706"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:13 GMT
+      - Thu, 18 Jan 2024 12:42:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -464,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b410ec85-7931-4445-9d61-ed5860fcc34a
+      - f2b8ee5b-afc0-4bc9-8f5e-38fed2582003
     status: 200 OK
     code: 200
     duration: ""
@@ -473,21 +473,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:42 GMT
+      - Thu, 18 Jan 2024 12:43:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d48c8d03-5659-42c5-a7d1-d707425b4a8f
+      - 88c4ff0e-89c1-4c0b-befd-223406832e91
     status: 200 OK
     code: 200
     duration: ""
@@ -506,21 +506,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:12 GMT
+      - Thu, 18 Jan 2024 12:43:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85573b3a-b479-4e0c-add1-8f09df5f7dae
+      - 0f6411b8-e0fa-49a2-9811-862d086d5252
     status: 200 OK
     code: 200
     duration: ""
@@ -539,21 +539,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:42 GMT
+      - Thu, 18 Jan 2024 12:44:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5d683be-6bed-498e-ab53-c02ad174a9ca
+      - 583d2c12-467a-440a-9b7c-cb64cd4a7e1f
     status: 200 OK
     code: 200
     duration: ""
@@ -572,21 +572,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "787"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:12 GMT
+      - Thu, 18 Jan 2024 12:44:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eeabaa49-4afe-4f9a-a0eb-9e6102497233
+      - be41ce48-2b33-4813-960b-0f64a3dbe95d
     status: 200 OK
     code: 200
     duration: ""
@@ -605,21 +605,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1062"
+      - "758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:43 GMT
+      - Thu, 18 Jan 2024 12:45:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d7a3a7b-493f-48f3-be8d-a9d7a1cf793e
+      - 88a1ff04-cc6e-4fcf-9ff2-e848c2f7b9b3
     status: 200 OK
     code: 200
     duration: ""
@@ -638,21 +638,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510},"endpoints":[{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510}],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1277"
+      - "1022"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 12:45:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3eba471-9b83-40b2-a981-f878fccad210
+      - 888fa6b1-1eab-48c5-b3c5-88be16d9df57
     status: 200 OK
     code: 200
     duration: ""
@@ -671,21 +671,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVYVNiV09VR2g4dW5PeTMrd2dveHd1NFJUR2hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TkM0eE9UQXdIaGNOCk1qUXdNVEE1TVRjeU56UTNXaGNOTXpRd01UQTJNVGN5TnpRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTBMakU1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5LbmJsbXBPWk5aaGtLbWpqdU1UMVc3S1oyUkU2OUR1bHI3VzlzRjlGdW1YbmJMTWw1ZmkrbnkKSlh2SG9FWjBLdzEvY3BuYjgrSDZlZENBSHJ1YUpUUThUUGgyZDZaZFZJYno0Y0ZoRXQ4a3M4ZzV6YkpGUVV6dApXVm8xU3BHRW1aaElYL0YxNldIUG0zVVFHQ1FrRk9VbWZnQTRna3VDR3VETFByK1YwQ2NReFJlYTZTeGs1cHhVClNMV0srZmdpQktSOU5wRjkzY2Y0WUdJWDRhRlhHOXd4dzg0U2VaNWduN09mTEhHME1Sb0psSlFsN1VaUlRQb0EKWTF0RndDN091S3lSOXZLUFFNM2JtKzgvMEFFWW9PZlQ5ZnJKTmd0TlJJcVNYUjY0Y0MrNTQ0Q0w1UHZaMjVjRApla0lwMm9iM09abkFEeXIvK1NuRUFXaTB6TlBRWnprQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qUXVNVGt3Z2p4eWR5MDFNemcwTWprNFpDMHlaVFpsTFRSaE1HUXRPVFF4TkMxaU5qWTAKWVRJNU1tWXpOR1l1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU5DNHhPVENDUEhKMwpMVFV6T0RReU9UaGtMVEpsTm1VdE5HRXdaQzA1TkRFMExXSTJOalJoTWpreVpqTTBaaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy9wMzRjRU01OFl2b2NFTTU4WXZqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWld6QUQ5YzlwT1owOUdFVG9ORzJ5bFU2UU11aEREQ2RFUnpLMFdRK1FmRlFsMmZvaWxUVzJGQithNENFTS8vcQpsOHhsdDFESlVtTjB6c1dmbDR4ODVCK2oxaUJaV2RlMmp3cVpXTE1ueXREODJFL0xoaGZkZDlaVFkrRmkzblRuCkJwYjFxckxvM01jTTZPVzJDWDRVRDN5eFIvbXdFV3FzQk5wU0lmSlp2SE1CZ2xyNURvU2ZDeHgvbk4xOVRxYlYKOTFhbzNQUVhPOFFlYkVXd0pTVjFiTG1yTDhmRHplTzFycHo1SU5nUk1RWnl6K2VBOHZTQjdkRHNtTkJzVG15egpYUUMxZUE5dHNoVDVlY0R2WnhaQzZIOVFsUkpXa2c4Q09MN3UxcUJGR0ZsSStXWXRFeCs1ZDJzbnVkNVhZYjZpCjZjTENNUktFMUFUQVJmelMvT0JTTmc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856},"endpoints":[{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856}],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2009"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 12:46:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 416e0973-0316-47f2-a5e1-fcbdeb06c8bf
+      - f52337c5-bc3e-4912-a098-1110a7c39f04
     status: 200 OK
     code: 200
     duration: ""
@@ -704,21 +704,54 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=5384298d-2e6e-4a0d-9414-b664a292f34f&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVZXk3K3RLMXhObWJwYk0zdEcyR0NzbUZHVFRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eE16WXdIaGNOCk1qUXdNVEU0TVRJME5UTXpXaGNOTXpRd01URTFNVEkwTlRNeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakV6TmpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5KNXhLUW1qaUtSOVFOekZTeHNoVmkxc3I5dCs0SEIya0xDRnVHV1VKZmFLZmxVTEl5RERUcXgKcFhORUtzS3lUVDlDaXN2UkhVZ3BMemdPUm5USE8wcXFlZ2dzUU9nSG1EdjZQMlNCQlpqdkw1UFAweEdXM3pNNwpncUQvUUs5SENEYmFwQlowT1gzQVlNdW5TbVdkdkVNc01NanRWUjJ5RHdKbCtIRnR0RzRGVWlkVlRCZS9wRTBRCnpQM2dHVWZIU0dJdUU1Unk4alhBR05iSFpxMmRYQy9xUHJGcUFOUU1QcVdLUDdCK0pScjAvcTJEajhPQmdkR1UKMitvK3FKcDZlMTBlc3hFRzNVK2IyZlFWUjZxSUN4Rm1ySm9XbWpndjdKd3dEalBTaFhtUUU5L2h5YXMyOXM5agpUOGQrM0xISXJVM290RThnMWZTL0JqTjI3SENJbkxrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU5UWXVNVE0yZ2p4eWR5MDNNRGd5T1RBMVpDMWlPV1pqTFRRNFkySXRPV0l4TXkxaE5tUTAKWmpZMU1qRmhORGd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0MU5pNHhNemFDUEhKMwpMVGN3T0RJNU1EVmtMV0k1Wm1NdE5EaGpZaTA1WWpFekxXRTJaRFJtTmpVeU1XRTBPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01NDRpSWNFTTU0NGlEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKaDVyV01ScXo5SEx1VEtmOTJFK0VnMUx1cUFFY0pKUnB6czdxenFOL3p4QzYyN09mdjhGenNabGRoaThMYUVtUQpPODhsMW9tWFlXcWRodlIrZ0VDZWtMcXRnQWM3WTNyS2RSTUJZSFB2MGZNK1lZWDJGQllNbC9GWU5ta3l4alRWCkNudG5rbnkzY01XbFlsMVY5cy96elZpMTVuL1Y5bUxkczcxMU1tVys3NldDNjFpWmpQK1lZRFdBZ2xGY09uUmkKWlVzUGVEMnUvNktqdWRqZUQ1MHlGSHZKNFJpd1phR2pMSDhZU0VJcjVLWm5Ccy8vTCtUbDJNelhWVHZucFlPZQpjOVVNNEh5YTRoSS8xTWF3R3gzcXh3YXlkT0ZtMlhNRFFkd2V6K3R4NmhZSUhBNmk5eXdCVFFHMTdlOXVVM25MCmRmRTA4TmYxR21pbGM3YWFqYmhHUEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:46:08 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ba1aa70b-d9e5-4dff-badd-6366956522ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=7082905d-b9fc-48cb-9b13-a6d4f6521a48&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 12:46:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -728,32 +761,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c526f6d-9a48-46b1-a6aa-d6079d390566
+      - 6d61d38c-2020-41a4-a7ea-b89a25947a10
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","endpoint_spec":[{"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
+    body: '{"instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","endpoint_spec":[{"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:14 GMT
+      - Thu, 18 Jan 2024 12:46:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -763,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aba31a87-a8a7-4e37-8239-bcd91732de12
+      - 7c4d90d5-3ad3-4711-a337-d3811d4f84a0
     status: 200 OK
     code: 200
     duration: ""
@@ -772,21 +805,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:14 GMT
+      - Thu, 18 Jan 2024 12:46:08 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -796,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d27f3c3e-b7cf-4051-b930-ba1f34adb7c7
+      - 3d6d7d0a-3631-4aa1-aaac-c7d56000d716
     status: 200 OK
     code: 200
     duration: ""
@@ -805,21 +838,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:44 GMT
+      - Thu, 18 Jan 2024 12:46:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -829,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 520c00bc-4f82-4717-84f2-08267e1cf2e2
+      - 98249d21-06ae-414c-bdd5-8e76c5b4ddd0
     status: 200 OK
     code: 200
     duration: ""
@@ -838,21 +871,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:14 GMT
+      - Thu, 18 Jan 2024 12:47:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -862,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fcad5c7-4a6f-44d7-ba50-795e7d24debe
+      - c7434463-765d-419f-ab0a-f54b25575970
     status: 200 OK
     code: 200
     duration: ""
@@ -871,21 +904,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:44 GMT
+      - Thu, 18 Jan 2024 12:47:39 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -895,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ff4b0f2-7a33-4183-a746-322f4db55303
+      - f87d6b62-e6ae-4035-97f7-f00f728920db
     status: 200 OK
     code: 200
     duration: ""
@@ -904,21 +937,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:14 GMT
+      - Thu, 18 Jan 2024 12:48:09 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -928,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2367dad-387e-4829-823c-4d775b24d2a4
+      - 8fe9a7fc-7916-46dc-bc8f-8484763f9f77
     status: 200 OK
     code: 200
     duration: ""
@@ -937,21 +970,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "388"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:44 GMT
+      - Thu, 18 Jan 2024 12:48:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -961,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cd7fe18-0fbb-474b-b9ff-592109cefa55
+      - 43c14401-736e-4c4d-8d78-f089ef9d6b01
     status: 200 OK
     code: 200
     duration: ""
@@ -970,21 +1003,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "388"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 12:49:13 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -994,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c791caa1-6357-4c3b-8229-7c350ff7b3d8
+      - db0d5b2b-7409-4dd3-96a3-46aef57b0aa7
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,21 +1036,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "388"
+      - "377"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 12:49:43 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1027,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96902abe-50bf-4a3f-9eaa-44bcc223b06d
+      - 3cdf2f95-8e67-467d-8820-810957379332
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,21 +1069,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/247d0827-61b8-4b70-be93-ad173f7d18de
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:25:11.835441Z","dhcp_enabled":true,"id":"247d0827-61b8-4b70-be93-ad173f7d18de","name":"tf-pn-relaxed-agnesi","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:25:11.835441Z","id":"da070b3e-d9ab-409b-8f5e-f2fd71a56d03","subnet":"172.16.0.0/22","updated_at":"2024-01-09T17:25:11.835441Z"},{"created_at":"2024-01-09T17:25:11.835441Z","id":"12381968-37cf-4d86-8845-e6b401675c43","subnet":"fd63:256c:45f7:fcba::/64","updated_at":"2024-01-09T17:25:11.835441Z"}],"tags":[],"updated_at":"2024-01-09T17:25:11.835441Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "720"
+      - "377"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 12:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1060,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 072a4224-925c-47cd-960b-a22f12f5ccc8
+      - fb1c52d9-7410-4aae-b52a-c8afa740d17a
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,87 +1102,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510},"endpoints":[{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510}],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1665"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2cd03aa9-7526-4028-a956-22e806ade793
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVYVNiV09VR2g4dW5PeTMrd2dveHd1NFJUR2hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TkM0eE9UQXdIaGNOCk1qUXdNVEE1TVRjeU56UTNXaGNOTXpRd01UQTJNVGN5TnpRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSTBMakU1TURDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5LbmJsbXBPWk5aaGtLbWpqdU1UMVc3S1oyUkU2OUR1bHI3VzlzRjlGdW1YbmJMTWw1ZmkrbnkKSlh2SG9FWjBLdzEvY3BuYjgrSDZlZENBSHJ1YUpUUThUUGgyZDZaZFZJYno0Y0ZoRXQ4a3M4ZzV6YkpGUVV6dApXVm8xU3BHRW1aaElYL0YxNldIUG0zVVFHQ1FrRk9VbWZnQTRna3VDR3VETFByK1YwQ2NReFJlYTZTeGs1cHhVClNMV0srZmdpQktSOU5wRjkzY2Y0WUdJWDRhRlhHOXd4dzg0U2VaNWduN09mTEhHME1Sb0psSlFsN1VaUlRQb0EKWTF0RndDN091S3lSOXZLUFFNM2JtKzgvMEFFWW9PZlQ5ZnJKTmd0TlJJcVNYUjY0Y0MrNTQ0Q0w1UHZaMjVjRApla0lwMm9iM09abkFEeXIvK1NuRUFXaTB6TlBRWnprQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qUXVNVGt3Z2p4eWR5MDFNemcwTWprNFpDMHlaVFpsTFRSaE1HUXRPVFF4TkMxaU5qWTAKWVRJNU1tWXpOR1l1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU5DNHhPVENDUEhKMwpMVFV6T0RReU9UaGtMVEpsTm1VdE5HRXdaQzA1TkRFMExXSTJOalJoTWpreVpqTTBaaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy9wMzRjRU01OFl2b2NFTTU4WXZqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWld6QUQ5YzlwT1owOUdFVG9ORzJ5bFU2UU11aEREQ2RFUnpLMFdRK1FmRlFsMmZvaWxUVzJGQithNENFTS8vcQpsOHhsdDFESlVtTjB6c1dmbDR4ODVCK2oxaUJaV2RlMmp3cVpXTE1ueXREODJFL0xoaGZkZDlaVFkrRmkzblRuCkJwYjFxckxvM01jTTZPVzJDWDRVRDN5eFIvbXdFV3FzQk5wU0lmSlp2SE1CZ2xyNURvU2ZDeHgvbk4xOVRxYlYKOTFhbzNQUVhPOFFlYkVXd0pTVjFiTG1yTDhmRHplTzFycHo1SU5nUk1RWnl6K2VBOHZTQjdkRHNtTkJzVG15egpYUUMxZUE5dHNoVDVlY0R2WnhaQzZIOVFsUkpXa2c4Q09MN3UxcUJGR0ZsSStXWXRFeCs1ZDJzbnVkNVhZYjZpCjZjTENNUktFMUFUQVJmelMvT0JTTmc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2009"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8424a2f3-21bf-4248-ac5c-e5ded93748d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=5384298d-2e6e-4a0d-9414-b664a292f34f&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=7082905d-b9fc-48cb-9b13-a6d4f6521a48&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 12:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1159,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8684a144-5c93-41a8-b7d7-f6f0454520ec
+      - 1609ab68-de32-4fd4-8edf-d915e69a51bc
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,21 +1135,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "388"
+      - "377"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 12:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1192,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 184e2d40-5dc1-419a-9664-3a9885607665
+      - e45a85ef-796f-4108-aa39-22f4fa25fd86
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,21 +1168,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/239642f5-0a04-456a-9673-2b61119545a9
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2024-01-18T12:42:36.140941Z","dhcp_enabled":true,"id":"239642f5-0a04-456a-9673-2b61119545a9","name":"tf-pn-jolly-mirzakhani","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T12:42:36.140941Z","id":"01541042-ead1-4345-a17f-de919c193f50","subnet":"172.16.16.0/22","updated_at":"2024-01-18T12:42:36.140941Z"},{"created_at":"2024-01-18T12:42:36.140941Z","id":"f359605e-3783-4fc8-843f-8fe502b53357","subnet":"fd63:256c:45f7:1345::/64","updated_at":"2024-01-18T12:42:36.140941Z"}],"tags":[],"updated_at":"2024-01-18T12:42:36.140941Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "388"
+      - "706"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:45 GMT
+      - Thu, 18 Jan 2024 12:49:44 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1225,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cce5e94a-d6ba-4ba8-9d07-b11bb1ead61e
+      - 51bee953-6881-4f54-8b56-bae9ebeaf93b
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,21 +1201,219 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856},"endpoints":[{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856}],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1608"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:49:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f7f5dfea-0c7e-4633-b922-65051f2bc691
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVZXk3K3RLMXhObWJwYk0zdEcyR0NzbUZHVFRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzQxTmk0eE16WXdIaGNOCk1qUXdNVEU0TVRJME5UTXpXaGNOTXpRd01URTFNVEkwTlRNeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqVTJMakV6TmpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5KNXhLUW1qaUtSOVFOekZTeHNoVmkxc3I5dCs0SEIya0xDRnVHV1VKZmFLZmxVTEl5RERUcXgKcFhORUtzS3lUVDlDaXN2UkhVZ3BMemdPUm5USE8wcXFlZ2dzUU9nSG1EdjZQMlNCQlpqdkw1UFAweEdXM3pNNwpncUQvUUs5SENEYmFwQlowT1gzQVlNdW5TbVdkdkVNc01NanRWUjJ5RHdKbCtIRnR0RzRGVWlkVlRCZS9wRTBRCnpQM2dHVWZIU0dJdUU1Unk4alhBR05iSFpxMmRYQy9xUHJGcUFOUU1QcVdLUDdCK0pScjAvcTJEajhPQmdkR1UKMitvK3FKcDZlMTBlc3hFRzNVK2IyZlFWUjZxSUN4Rm1ySm9XbWpndjdKd3dEalBTaFhtUUU5L2h5YXMyOXM5agpUOGQrM0xISXJVM290RThnMWZTL0JqTjI3SENJbkxrQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU5UWXVNVE0yZ2p4eWR5MDNNRGd5T1RBMVpDMWlPV1pqTFRRNFkySXRPV0l4TXkxaE5tUTAKWmpZMU1qRmhORGd1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0MU5pNHhNemFDUEhKMwpMVGN3T0RJNU1EVmtMV0k1Wm1NdE5EaGpZaTA1WWpFekxXRTJaRFJtTmpVeU1XRTBPQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01NDRpSWNFTTU0NGlEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKaDVyV01ScXo5SEx1VEtmOTJFK0VnMUx1cUFFY0pKUnB6czdxenFOL3p4QzYyN09mdjhGenNabGRoaThMYUVtUQpPODhsMW9tWFlXcWRodlIrZ0VDZWtMcXRnQWM3WTNyS2RSTUJZSFB2MGZNK1lZWDJGQllNbC9GWU5ta3l4alRWCkNudG5rbnkzY01XbFlsMVY5cy96elZpMTVuL1Y5bUxkczcxMU1tVys3NldDNjFpWmpQK1lZRFdBZ2xGY09uUmkKWlVzUGVEMnUvNktqdWRqZUQ1MHlGSHZKNFJpd1phR2pMSDhZU0VJcjVLWm5Ccy8vTCtUbDJNelhWVHZucFlPZQpjOVVNNEh5YTRoSS8xTWF3R3gzcXh3YXlkT0ZtMlhNRFFkd2V6K3R4NmhZSUhBNmk5eXdCVFFHMTdlOXVVM25MCmRmRTA4TmYxR21pbGM3YWFqYmhHUEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:49:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d27cc9ac-a6b8-4b2a-98a1-79885a247181
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=7082905d-b9fc-48cb-9b13-a6d4f6521a48&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:49:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 17e9288f-1875-4d34-adc7-1720829385e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:49:44 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 840197d1-89ff-4aeb-8f56-6e8f630e2814
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=7082905d-b9fc-48cb-9b13-a6d4f6521a48&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:49:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 46241620-6c40-4016-92b5-68d2affcb930
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 12:49:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4cfc2617-da69-4eeb-8f67-8427a4e30dd1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "391"
+      - "380"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 12:49:45 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1258,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8fe3bc65-ea14-4394-af16-af890793b1f7
+      - cc11ce35-11d7-4260-948d-8cedcaeb2354
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,21 +1432,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"endpoints":[{"id":"fc809e0f-5654-46d5-b479-ae5e9fe52a2c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"247d0827-61b8-4b70-be93-ad173f7d18de","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","instance_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"d0c36e81-6c83-403e-91d9-3212eec3195f","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"239642f5-0a04-456a-9673-2b61119545a9","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"ac636526-afc0-4872-b15d-7c3ef6fab100","instance_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "391"
+      - "380"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:46 GMT
+      - Thu, 18 Jan 2024 12:49:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1b4443c-c909-46e1-89bf-026c75cdf41c
+      - d69a5db1-2468-4ded-afc5-d3a121b508fe
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,12 +1465,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"ac636526-afc0-4872-b15d-7c3ef6fab100","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1314,7 +1479,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 12:50:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 574748ed-fe07-4a32-87f1-ab47006e442e
+      - 1f6f6cec-7778-44e7-afd5-9b7d562fc04d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1333,21 +1498,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510},"endpoints":[{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510}],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856},"endpoints":[{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856}],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1277"
+      - "1231"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 12:50:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0ecd5c9-7fa5-438b-90a0-7e56359c4363
+      - d4a17209-a8b8-4298-abad-c24740b412e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,21 +1531,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510},"endpoints":[{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510}],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856},"endpoints":[{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856}],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1280"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 12:50:16 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1390,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a10c5efe-6ffb-4a69-a74b-673a29df61ed
+      - 4602c322-a30a-4a09-a1be-22856ca7e4cb
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,21 +1564,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.017534Z","endpoint":{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510},"endpoints":[{"id":"f5be2b38-b749-40c4-933f-56ace764e4bb","ip":"51.159.24.190","load_balancer":{},"name":null,"port":9510}],"engine":"PostgreSQL-15","id":"5384298d-2e6e-4a0d-9414-b664a292f34f","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T12:42:36.277715Z","endpoint":{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856},"endpoints":[{"id":"7c74b051-1de5-46a1-8a56-6cbec2886bb8","ip":"51.158.56.136","load_balancer":{},"name":null,"port":20856}],"engine":"PostgreSQL-15","id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1280"
+      - "1234"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:17 GMT
+      - Thu, 18 Jan 2024 12:50:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1423,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56bbefef-f558-4312-8a41-6002ffd8d6db
+      - a58d5d75-f49b-432e-b62c-d72fc641520c
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,9 +1597,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/247d0827-61b8-4b70-be93-ad173f7d18de
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/239642f5-0a04-456a-9673-2b61119545a9
     method: DELETE
   response:
     body: ""
@@ -1444,7 +1609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:17 GMT
+      - Thu, 18 Jan 2024 12:50:17 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2dabb0d6-e431-4a9f-8e18-e97aa0426da3
+      - 2141559e-2c9e-486a-99b0-a702fd3ae687
     status: 204 No Content
     code: 204
     duration: ""
@@ -1463,12 +1628,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1477,7 +1642,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:47 GMT
+      - Thu, 18 Jan 2024 12:50:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1487,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d52297de-0690-489c-90bc-2ba1aa6640ff
+      - 2146ce71-6644-496c-b45c-30d19eb5989f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1496,12 +1661,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/5384298d-2e6e-4a0d-9414-b664a292f34f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/7082905d-b9fc-48cb-9b13-a6d4f6521a48
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"5384298d-2e6e-4a0d-9414-b664a292f34f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"7082905d-b9fc-48cb-9b13-a6d4f6521a48","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1510,7 +1675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:47 GMT
+      - Thu, 18 Jan 2024 12:50:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1520,7 +1685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ed7937b-7cb4-4eb9-bebe-305dfee0414b
+      - ffe3fa0b-addf-440b-8c78-6d38feb4dd07
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1529,12 +1694,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/affec1f5-d477-43ff-b926-1a8c8ee9830e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ac636526-afc0-4872-b15d-7c3ef6fab100
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"affec1f5-d477-43ff-b926-1a8c8ee9830e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"ac636526-afc0-4872-b15d-7c3ef6fab100","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1543,7 +1708,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:47 GMT
+      - Thu, 18 Jan 2024 12:50:47 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1553,7 +1718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d82fc06-7ff8-43f7-8e06-bbf3f0fc50e9
+      - 5c45a6d0-d224-48d4-b75f-8ca6059a47f0
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-update.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-update.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,7 +318,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:09 GMT
+      - Thu, 18 Jan 2024 14:28:46 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -328,7 +328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd71042e-d382-4efa-88b0-2bb343ee6737
+      - de950019-c236-46b4-b349-64baa4522562
     status: 200 OK
     code: 200
     duration: ""
@@ -339,21 +339,21 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 14:28:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dc31279-3594-4578-b632-1c20c17eb199
+      - c660aac8-0cc3-42b6-b16c-e011d2f160be
     status: 200 OK
     code: 200
     duration: ""
@@ -372,21 +372,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:12 GMT
+      - Thu, 18 Jan 2024 14:28:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36aec732-b9ea-4ea3-998c-5ffb2fffdf3a
+      - 43c6c465-d4b6-436c-b6ea-e0f7b4a06e1c
     status: 200 OK
     code: 200
     duration: ""
@@ -405,21 +405,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:25:42 GMT
+      - Thu, 18 Jan 2024 14:29:18 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee9a9f79-475b-40ec-8f6e-8e07a933fad6
+      - 3a6a3b36-e790-4b78-b627-6492b508aa0d
     status: 200 OK
     code: 200
     duration: ""
@@ -438,21 +438,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:12 GMT
+      - Thu, 18 Jan 2024 14:29:48 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43d405d1-a1d4-47f9-ad66-b6c536c029eb
+      - 9c2430e1-2d53-4c14-a94e-163c36d90470
     status: 200 OK
     code: 200
     duration: ""
@@ -471,21 +471,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:26:43 GMT
+      - Thu, 18 Jan 2024 14:30:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a9189cb-9793-44c8-949d-e840d98716aa
+      - da4e28b7-1969-4c01-aebe-f6731e2c852b
     status: 200 OK
     code: 200
     duration: ""
@@ -504,21 +504,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:13 GMT
+      - Thu, 18 Jan 2024 14:30:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56dd6e94-63f9-4a9f-9f04-c6cda37561ce
+      - 58515852-2df8-4bfa-aeae-1031b1e6f5d7
     status: 200 OK
     code: 200
     duration: ""
@@ -537,21 +537,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "1026"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:27:43 GMT
+      - Thu, 18 Jan 2024 14:31:19 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 041cdb48-c921-489a-baea-79d9e6bc278f
+      - 2e69bb98-71f2-47f6-a4a6-d85f96896571
     status: 200 OK
     code: 200
     duration: ""
@@ -570,21 +570,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "791"
+      - "1235"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:13 GMT
+      - Thu, 18 Jan 2024 14:31:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -594,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89727ac2-a4ca-4dc3-808f-aa3b2eab940f
+      - 297f082b-6b87-4fc1-870a-60c299e46630
     status: 200 OK
     code: 200
     duration: ""
@@ -603,21 +603,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1066"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:28:43 GMT
+      - Thu, 18 Jan 2024 14:31:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -627,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 007e9e0d-78ea-4f5d-a27f-876fe362c9be
+      - 59792e85-0262-4f22-895c-34341c063a07
     status: 200 OK
     code: 200
     duration: ""
@@ -636,87 +636,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471},"endpoints":[{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471}],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:29:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1d83f134-d0f8-494b-8256-37bf5e5965c7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRWlqMEFXbmJwSnpDaERESTZSZDhDOXFYMWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TURZdU5URXdIaGNOCk1qUXdNVEE1TVRjeU9ESTVXaGNOTXpRd01UQTJNVGN5T0RJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSXdOaTQxTVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9Ob0RSZU82SW53bE0xWUtSeG5IbUVSMzY1VjI3TElSa1JrdXNhcXNsaHd3MnBuSVZhZk9qb2gKcGtPMDcrUVRkRmJpb1MzOXdPNzQyejFDVDZjQjF2V3NrUk1ZUFhUYXVzdmoyYjNTVCsrVjBBdkY2YnRHNWNoMwpkMklva21QTzlJRStzMVFqWjhBWWc2QlZRUjlLRHdIV1YybzU3dlZlYWw1bGhhMGlTS2JxTThKY2ErME5CZllICldGSDVWWVo4eFppeWNOV3BBZDZaZTVLVnY3bTRYWGdVOHlsSVlkSXNJVjlHSG52V0JWSXlPc2pueE8xS3YrTDIKdnVZRTRQR2dTNDVXV3R0bVJjSFN0Y1ZCQkN2ZC9qYjNFTlluRGxXSC9xdzVBRGgyeW9WTEVvRzJsTERYL1BjUApWaENkbWx2WGFEYmFNYlY3RWxDRnp0YkphbGhVbHEwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qQTJMalV4Z2p4eWR5MHhZamxrTjJZeFlTMDNZV1kwTFRRNVl6Z3RZalpqWVMwMk9UZ3kKWXprMU5tRTVNMkV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU1EWXVOVEdDUEhKMwpMVEZpT1dRM1pqRmhMVGRoWmpRdE5EbGpPQzFpTm1OaExUWTVPREpqT1RVMllUa3pZUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy8yM0ljRU01L09NNGNFTTUvT016QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKcUMvZDVVL3Q5U21nQXhZYy9lc1FraExBbjArWnpwS1FjQkIreFFoc3lWUVZlZzBtT1Q1dlRleWluZ3B5ZjN1RgpyMmpLYkwxU3dCVTM0UWtqM0x6VnBzYysyOHJJVVNJcjJDNDdXQ0t5NE1ENzdnaS8xdFZVV0RmVWhOc29iNWowCktmMjdDMm15NzJSRUR2ZERtTzRtek9ONXBFbmw1V2RVZVJRcnh4VUZiakZGWEdBZWt1VzZ2bmV6eXI5Y2RZREMKSm41QlFNSk44TDBxNTlac05LSHBDR0lnTk1XOFdNYktqSjZzQnVvT0FSS3lZRGZ5V1V1MEN3QkdTdTIyUlorawoybWF5ZGczaWpoNHdLUkNmU1VlMnR5clVadFNVL0Z2bDRKS1ZGMjdvK2FaVzdGNTFIVkpGQ1p3azZMaEZNRHRvClJ5MGRhZFdqSmYraWN4QTRaUjRwOEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2009"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:29:13 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4698a3e1-5ccc-4dae-8f3c-980a1a63b22e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1b9d7f1a-7af4-49c8-b6ca-6982c956a93a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:13 GMT
+      - Thu, 18 Jan 2024 14:31:49 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -726,32 +660,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f18b0f6-1164-4094-8d07-867fd3988a41
+      - 64ec5abb-9d81-4b72-be1f-07a7573a6837
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
+    body: '{"instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "177"
+      - "172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:14 GMT
+      - Thu, 18 Jan 2024 14:31:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -761,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db8926f2-42f7-4b35-9a68-10c320e41098
+      - 69236084-7cb8-4fa2-aa94-e579c4f0a96b
     status: 200 OK
     code: 200
     duration: ""
@@ -770,21 +704,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "177"
+      - "172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:14 GMT
+      - Thu, 18 Jan 2024 14:31:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -794,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f4bdd7f-a6af-4353-809c-af1410dffde3
+      - 644da142-b54e-4d1d-b983-2dc3611d155f
     status: 200 OK
     code: 200
     duration: ""
@@ -803,21 +737,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "177"
+      - "172"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:29:44 GMT
+      - Thu, 18 Jan 2024 14:32:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -827,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27870f2f-25ac-4c99-8e16-2bd0b3ee6d92
+      - d91aa567-035b-445c-bd85-fa57dad7fa68
     status: 200 OK
     code: 200
     duration: ""
@@ -836,21 +770,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "289"
+      - "280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:14 GMT
+      - Thu, 18 Jan 2024 14:32:50 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -860,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62680cc6-f155-4a4d-8c49-f390c1bfa64e
+      - 495260e6-3303-4552-ab08-0d99e834f1f7
     status: 200 OK
     code: 200
     duration: ""
@@ -869,21 +803,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "289"
+      - "280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:30:44 GMT
+      - Thu, 18 Jan 2024 14:33:20 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -893,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3ddc212-ec2f-4361-be40-8e1e0e2a582a
+      - fc86d557-483a-416e-bbf9-9e2442e65471
     status: 200 OK
     code: 200
     duration: ""
@@ -902,21 +836,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "282"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:14 GMT
+      - Thu, 18 Jan 2024 14:33:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -926,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e99f9c4e-3579-4a4b-a36c-ff2dd8196f70
+      - 52bc6208-e6f8-4c5d-b917-81b5641aeefb
     status: 200 OK
     code: 200
     duration: ""
@@ -935,21 +869,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "282"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
+      - Thu, 18 Jan 2024 14:33:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -959,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6780aa5-5faa-4024-a63b-f0a3ea6ae323
+      - 75d0dd38-ce34-49a1-9b62-a10c4a080cbb
     status: 200 OK
     code: 200
     duration: ""
@@ -968,120 +902,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
-    method: GET
-  response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "282"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b98de98a-c67f-4795-a711-6f081b6f9f6d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471},"endpoints":[{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471}],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1565"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2ca5e92-8a1a-403f-94d1-4010c738c8a0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRWlqMEFXbmJwSnpDaERESTZSZDhDOXFYMWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TURZdU5URXdIaGNOCk1qUXdNVEE1TVRjeU9ESTVXaGNOTXpRd01UQTJNVGN5T0RJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSXdOaTQxTVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9Ob0RSZU82SW53bE0xWUtSeG5IbUVSMzY1VjI3TElSa1JrdXNhcXNsaHd3MnBuSVZhZk9qb2gKcGtPMDcrUVRkRmJpb1MzOXdPNzQyejFDVDZjQjF2V3NrUk1ZUFhUYXVzdmoyYjNTVCsrVjBBdkY2YnRHNWNoMwpkMklva21QTzlJRStzMVFqWjhBWWc2QlZRUjlLRHdIV1YybzU3dlZlYWw1bGhhMGlTS2JxTThKY2ErME5CZllICldGSDVWWVo4eFppeWNOV3BBZDZaZTVLVnY3bTRYWGdVOHlsSVlkSXNJVjlHSG52V0JWSXlPc2pueE8xS3YrTDIKdnVZRTRQR2dTNDVXV3R0bVJjSFN0Y1ZCQkN2ZC9qYjNFTlluRGxXSC9xdzVBRGgyeW9WTEVvRzJsTERYL1BjUApWaENkbWx2WGFEYmFNYlY3RWxDRnp0YkphbGhVbHEwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qQTJMalV4Z2p4eWR5MHhZamxrTjJZeFlTMDNZV1kwTFRRNVl6Z3RZalpqWVMwMk9UZ3kKWXprMU5tRTVNMkV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU1EWXVOVEdDUEhKMwpMVEZpT1dRM1pqRmhMVGRoWmpRdE5EbGpPQzFpTm1OaExUWTVPREpqT1RVMllUa3pZUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy8yM0ljRU01L09NNGNFTTUvT016QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKcUMvZDVVL3Q5U21nQXhZYy9lc1FraExBbjArWnpwS1FjQkIreFFoc3lWUVZlZzBtT1Q1dlRleWluZ3B5ZjN1RgpyMmpLYkwxU3dCVTM0UWtqM0x6VnBzYysyOHJJVVNJcjJDNDdXQ0t5NE1ENzdnaS8xdFZVV0RmVWhOc29iNWowCktmMjdDMm15NzJSRUR2ZERtTzRtek9ONXBFbmw1V2RVZVJRcnh4VUZiakZGWEdBZWt1VzZ2bmV6eXI5Y2RZREMKSm41QlFNSk44TDBxNTlac05LSHBDR0lnTk1XOFdNYktqSjZzQnVvT0FSS3lZRGZ5V1V1MEN3QkdTdTIyUlorawoybWF5ZGczaWpoNHdLUkNmU1VlMnR5clVadFNVL0Z2bDRKS1ZGMjdvK2FaVzdGNTFIVkpGQ1p3azZMaEZNRHRvClJ5MGRhZFdqSmYraWN4QTRaUjRwOEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2009"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f4de8982-2eb3-4035-9786-b1d58891e8b3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1b9d7f1a-7af4-49c8-b6ca-6982c956a93a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
+      - Thu, 18 Jan 2024 14:33:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1091,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c893850e-ed75-44bb-91bd-083d8de47ae2
+      - b9b1c2ce-d1da-4de0-8a07-ddfd7aa10716
     status: 200 OK
     code: 200
     duration: ""
@@ -1100,21 +935,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "282"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
+      - Thu, 18 Jan 2024 14:33:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1124,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a41b24f-834d-493a-9447-518705475fec
+      - f4715f96-6f0d-4a9f-b71a-ac995d76c8c1
     status: 200 OK
     code: 200
     duration: ""
@@ -1133,21 +968,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471},"endpoints":[{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471}],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1565"
+      - "1508"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:15 GMT
+      - Thu, 18 Jan 2024 14:33:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1157,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 525ad5f0-332e-4bfd-92eb-46b7f5a1b91e
+      - eff41799-9c7d-4151-92f3-0346fff2fbcf
     status: 200 OK
     code: 200
     duration: ""
@@ -1166,21 +1001,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRWlqMEFXbmJwSnpDaERESTZSZDhDOXFYMWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TURZdU5URXdIaGNOCk1qUXdNVEE1TVRjeU9ESTVXaGNOTXpRd01UQTJNVGN5T0RJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSXdOaTQxTVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9Ob0RSZU82SW53bE0xWUtSeG5IbUVSMzY1VjI3TElSa1JrdXNhcXNsaHd3MnBuSVZhZk9qb2gKcGtPMDcrUVRkRmJpb1MzOXdPNzQyejFDVDZjQjF2V3NrUk1ZUFhUYXVzdmoyYjNTVCsrVjBBdkY2YnRHNWNoMwpkMklva21QTzlJRStzMVFqWjhBWWc2QlZRUjlLRHdIV1YybzU3dlZlYWw1bGhhMGlTS2JxTThKY2ErME5CZllICldGSDVWWVo4eFppeWNOV3BBZDZaZTVLVnY3bTRYWGdVOHlsSVlkSXNJVjlHSG52V0JWSXlPc2pueE8xS3YrTDIKdnVZRTRQR2dTNDVXV3R0bVJjSFN0Y1ZCQkN2ZC9qYjNFTlluRGxXSC9xdzVBRGgyeW9WTEVvRzJsTERYL1BjUApWaENkbWx2WGFEYmFNYlY3RWxDRnp0YkphbGhVbHEwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qQTJMalV4Z2p4eWR5MHhZamxrTjJZeFlTMDNZV1kwTFRRNVl6Z3RZalpqWVMwMk9UZ3kKWXprMU5tRTVNMkV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU1EWXVOVEdDUEhKMwpMVEZpT1dRM1pqRmhMVGRoWmpRdE5EbGpPQzFpTm1OaExUWTVPREpqT1RVMllUa3pZUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy8yM0ljRU01L09NNGNFTTUvT016QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKcUMvZDVVL3Q5U21nQXhZYy9lc1FraExBbjArWnpwS1FjQkIreFFoc3lWUVZlZzBtT1Q1dlRleWluZ3B5ZjN1RgpyMmpLYkwxU3dCVTM0UWtqM0x6VnBzYysyOHJJVVNJcjJDNDdXQ0t5NE1ENzdnaS8xdFZVV0RmVWhOc29iNWowCktmMjdDMm15NzJSRUR2ZERtTzRtek9ONXBFbmw1V2RVZVJRcnh4VUZiakZGWEdBZWt1VzZ2bmV6eXI5Y2RZREMKSm41QlFNSk44TDBxNTlac05LSHBDR0lnTk1XOFdNYktqSjZzQnVvT0FSS3lZRGZ5V1V1MEN3QkdTdTIyUlorawoybWF5ZGczaWpoNHdLUkNmU1VlMnR5clVadFNVL0Z2bDRKS1ZGMjdvK2FaVzdGNTFIVkpGQ1p3azZMaEZNRHRvClJ5MGRhZFdqSmYraWN4QTRaUjRwOEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2009"
+      - "2007"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 14:33:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1190,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea29684a-ee5f-4481-88e0-a935a1ff8649
+      - 90e263e2-bd0b-46ed-8dd1-bcf5aea6da3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1199,21 +1034,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1b9d7f1a-7af4-49c8-b6ca-6982c956a93a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 14:33:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1223,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2df4ee9-1eec-44cd-9139-3e8523234cae
+      - a9c248d9-c005-473e-b4a4-76e31e43b657
     status: 200 OK
     code: 200
     duration: ""
@@ -1232,21 +1067,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "282"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:16 GMT
+      - Thu, 18 Jan 2024 14:33:51 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1256,32 +1091,230 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 659639b1-d348-46d7-9c1f-647697bb7c95
+      - fa852d44-6593-4af7-936a-67091465d135
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-gallant-feistel","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:33:51 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 94bccb4c-8d59-4a29-9e8b-1054593a20c7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1508"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:33:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06f1cc81-f106-4f83-98e9-a2e2ba1d6b36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:33:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cd257bbb-099f-4ef2-bfdc-d66698b0f059
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:33:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d927f6b0-44d7-402f-bb9f-45a05fec70ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "273"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:33:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a81be86a-d1bf-4249-a55b-de15a206d0ef
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:33:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7401e584-3651-4c50-90cd-b9136441c156
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-pn-admiring-golick","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-01-09T17:31:16.465777Z","dhcp_enabled":true,"id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","name":"tf-pn-gallant-feistel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:31:16.465777Z","id":"16d1e630-e9d7-42db-963e-85d84198822f","subnet":"172.16.28.0/22","updated_at":"2024-01-09T17:31:16.465777Z"},{"created_at":"2024-01-09T17:31:16.465777Z","id":"c0c043f3-d344-43cb-a61a-8b0f718922c4","subnet":"fd63:256c:45f7:2b88::/64","updated_at":"2024-01-09T17:31:16.465777Z"}],"tags":[],"updated_at":"2024-01-09T17:31:16.465777Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:17 GMT
+      - Thu, 18 Jan 2024 14:33:53 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1291,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3980e780-1f69-42eb-97a0-659b435b9275
+      - 1c444312-cae1-43b7-aed9-f7199d91693c
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,21 +1333,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/91f591ca-9c37-4bf7-89de-f2d16348ced1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
     method: GET
   response:
-    body: '{"created_at":"2024-01-09T17:31:16.465777Z","dhcp_enabled":true,"id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","name":"tf-pn-gallant-feistel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:31:16.465777Z","id":"16d1e630-e9d7-42db-963e-85d84198822f","subnet":"172.16.28.0/22","updated_at":"2024-01-09T17:31:16.465777Z"},{"created_at":"2024-01-09T17:31:16.465777Z","id":"c0c043f3-d344-43cb-a61a-8b0f718922c4","subnet":"fd63:256c:45f7:2b88::/64","updated_at":"2024-01-09T17:31:16.465777Z"}],"tags":[],"updated_at":"2024-01-09T17:31:16.465777Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:17 GMT
+      - Thu, 18 Jan 2024 14:33:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1324,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a33616e-95f9-4754-8cda-d389b171e662
+      - 19f82294-9f13-4cb0-bad3-463861fb167a
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,21 +1366,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c","ip":"51.158.66.38","name":null,"port":5432}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "282"
+      - "273"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:17 GMT
+      - Thu, 18 Jan 2024 14:33:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1357,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b304e496-3ec3-4573-aab6-f51ca1eb4a69
+      - 3bc0e0dc-4b42-4593-a6b2-c6531fada083
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,9 +1399,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/0e7ea9fe-7e58-425e-a3fc-583d5ad41b09
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/e6f80ed6-2c9e-4978-ba53-c9ca02f2a51c
     method: DELETE
   response:
     body: ""
@@ -1378,7 +1411,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:17 GMT
+      - Thu, 18 Jan 2024 14:33:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1388,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d910f27-ea5f-4fbf-bb3e-fe1fe29f4e06
+      - 75beb096-895b-4f69-90de-f48822b6e800
     status: 204 No Content
     code: 204
     duration: ""
@@ -1397,21 +1430,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"0e7ea9fe-7e58-425e-a3fc-583d5ad41b09","ip":"51.158.96.96","name":null,"port":5432}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
-      - "288"
+      - "171"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:17 GMT
+      - Thu, 18 Jan 2024 14:33:54 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1421,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29374fe0-9494-4581-8298-4f644f1bc6e1
+      - ee68d6f2-1d2b-41e1-9ddb-aa299959a368
     status: 200 OK
     code: 200
     duration: ""
@@ -1430,21 +1463,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "170"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:47 GMT
+      - Thu, 18 Jan 2024 14:34:24 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1454,32 +1487,98 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2a7ad62-7ce0-4af3-8a33-ca5ae674076a
+      - 7f699ab5-8457-42a4-a81e-8ae28c9c753b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20"}}]}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 344b46e0-a8e4-4a42-b40c-59be7290616c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:24 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea7c3369-2fff-4e6b-8fd5-0459b237d05a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20"}}]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:48 GMT
+      - Thu, 18 Jan 2024 14:34:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1489,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51e98985-a64f-497f-a5de-1e4a27830dd2
+      - c8a9e061-3734-431d-9c2d-9b6b116cf096
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,21 +1597,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "395"
+      - "384"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:31:48 GMT
+      - Thu, 18 Jan 2024 14:34:25 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1522,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7980237b-4016-46c6-b228-9f2d4a06fa15
+      - 4f8c479f-1b70-41d5-872a-b7cfef73070b
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,21 +1630,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "388"
+      - "377"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:18 GMT
+      - Thu, 18 Jan 2024 14:34:55 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1555,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f61811c-bb04-4ff0-95bd-7cca4692f01b
+      - f4c6789c-49f0-472f-878e-04cb86346320
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,21 +1663,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "388"
+      - "377"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:18 GMT
+      - Thu, 18 Jan 2024 14:34:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1588,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e0c5fb0-2699-4366-8d42-e8271dda644d
+      - e65005ed-c958-46c0-b501-3bfb74b0d1c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,153 +1696,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "388"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d809d687-06e3-4b68-ada7-dfa01774310e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/91f591ca-9c37-4bf7-89de-f2d16348ced1
-    method: GET
-  response:
-    body: '{"created_at":"2024-01-09T17:31:16.465777Z","dhcp_enabled":true,"id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","name":"tf-pn-gallant-feistel","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-09T17:31:16.465777Z","id":"16d1e630-e9d7-42db-963e-85d84198822f","subnet":"172.16.28.0/22","updated_at":"2024-01-09T17:31:16.465777Z"},{"created_at":"2024-01-09T17:31:16.465777Z","id":"c0c043f3-d344-43cb-a61a-8b0f718922c4","subnet":"fd63:256c:45f7:2b88::/64","updated_at":"2024-01-09T17:31:16.465777Z"}],"tags":[],"updated_at":"2024-01-09T17:31:16.465777Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a2d1dbab-7e3f-45bc-97f7-669399398f60
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471},"endpoints":[{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471}],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1671"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c260ed18-917d-48ab-9a3e-69ee1ae8dcda
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVRWlqMEFXbmJwSnpDaERESTZSZDhDOXFYMWxRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR5TURZdU5URXdIaGNOCk1qUXdNVEE1TVRjeU9ESTVXaGNOTXpRd01UQTJNVGN5T0RJNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqSXdOaTQxTVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU9Ob0RSZU82SW53bE0xWUtSeG5IbUVSMzY1VjI3TElSa1JrdXNhcXNsaHd3MnBuSVZhZk9qb2gKcGtPMDcrUVRkRmJpb1MzOXdPNzQyejFDVDZjQjF2V3NrUk1ZUFhUYXVzdmoyYjNTVCsrVjBBdkY2YnRHNWNoMwpkMklva21QTzlJRStzMVFqWjhBWWc2QlZRUjlLRHdIV1YybzU3dlZlYWw1bGhhMGlTS2JxTThKY2ErME5CZllICldGSDVWWVo4eFppeWNOV3BBZDZaZTVLVnY3bTRYWGdVOHlsSVlkSXNJVjlHSG52V0JWSXlPc2pueE8xS3YrTDIKdnVZRTRQR2dTNDVXV3R0bVJjSFN0Y1ZCQkN2ZC9qYjNFTlluRGxXSC9xdzVBRGgyeW9WTEVvRzJsTERYL1BjUApWaENkbWx2WGFEYmFNYlY3RWxDRnp0YkphbGhVbHEwQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1qQTJMalV4Z2p4eWR5MHhZamxrTjJZeFlTMDNZV1kwTFRRNVl6Z3RZalpqWVMwMk9UZ3kKWXprMU5tRTVNMkV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eU1EWXVOVEdDUEhKMwpMVEZpT1dRM1pqRmhMVGRoWmpRdE5EbGpPQzFpTm1OaExUWTVPREpqT1RVMllUa3pZUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy8yM0ljRU01L09NNGNFTTUvT016QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKcUMvZDVVL3Q5U21nQXhZYy9lc1FraExBbjArWnpwS1FjQkIreFFoc3lWUVZlZzBtT1Q1dlRleWluZ3B5ZjN1RgpyMmpLYkwxU3dCVTM0UWtqM0x6VnBzYysyOHJJVVNJcjJDNDdXQ0t5NE1ENzdnaS8xdFZVV0RmVWhOc29iNWowCktmMjdDMm15NzJSRUR2ZERtTzRtek9ONXBFbmw1V2RVZVJRcnh4VUZiakZGWEdBZWt1VzZ2bmV6eXI5Y2RZREMKSm41QlFNSk44TDBxNTlac05LSHBDR0lnTk1XOFdNYktqSjZzQnVvT0FSS3lZRGZ5V1V1MEN3QkdTdTIyUlorawoybWF5ZGczaWpoNHdLUkNmU1VlMnR5clVadFNVL0Z2bDRKS1ZGMjdvK2FaVzdGNTFIVkpGQ1p3azZMaEZNRHRvClJ5MGRhZFdqSmYraWN4QTRaUjRwOEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2009"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7934d567-89b9-41dd-a775-0db12cad77b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1b9d7f1a-7af4-49c8-b6ca-6982c956a93a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "27"
+      - "26"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:19 GMT
+      - Thu, 18 Jan 2024 14:34:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1753,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 600ed892-b1e5-4981-ab8e-4011026ad5c5
+      - f7849448-febf-4621-b70e-a33ae12bbb9f
     status: 200 OK
     code: 200
     duration: ""
@@ -1762,21 +1729,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "388"
+      - "377"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:19 GMT
+      - Thu, 18 Jan 2024 14:34:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1786,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ff17708-bfc5-40c8-be1d-b4cbfef4ba89
+      - d2e50b88-9a87-4dc0-b8ec-61d7a241d199
     status: 200 OK
     code: 200
     duration: ""
@@ -1795,21 +1762,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
     method: GET
   response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "388"
+      - "705"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:19 GMT
+      - Thu, 18 Jan 2024 14:34:56 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1819,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b30a9722-2e2f-4354-9034-1e4da629d9e4
+      - efaa8432-dcd7-4391-b24f-dbb85fecd778
     status: 200 OK
     code: 200
     duration: ""
@@ -1828,21 +1795,415 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1612"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 880efd81-8fd6-4379-8362-d28499138b86
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a5deb942-ff93-4104-889b-ad589c742fd1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c07cd9a8-de08-4329-bd0f-6cb90e43a871
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9a2cef3-1544-45c6-92e8-f257c4ed2f7f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:56 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54be2510-5892-483e-853b-38c012eed4d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "705"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 87bccae5-c915-4e06-a83c-03e599ec8f5d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1612"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 530d6c69-31b5-437c-931c-9e314ebe52bd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 099a1941-98e7-46bb-9ca3-f0b86abf8f11
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 67a0cd8a-e8fc-4c17-a7d4-8a015f3ec9e2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e6493ba9-4c2c-4c9f-9daf-c89560169b36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6db08e58-9682-466a-925c-4a055516d5cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:57 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8b36bf16-b0ee-4fec-bece-2b19d73064c8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/b0753a4e-b880-424f-9e16-ad792781c005
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: ""
     headers:
-      Content-Length:
-      - "391"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:20 GMT
+      - Thu, 18 Jan 2024 14:34:58 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -1852,137 +2213,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32b61212-e0c2-4c6b-a33a-399d73064819
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"b3ce7d4b-377b-4898-8cc0-1339647a8a59","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"91f591ca-9c37-4bf7-89de-f2d16348ced1","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","instance_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","region":"fr-par","same_zone":true,"status":"deleting"}'
-    headers:
-      Content-Length:
-      - "391"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c828d769-7305-4aed-852d-d4a5b3310dd3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "133"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9a772421-7bc8-4164-bb55-b12f4e851c3b
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471},"endpoints":[{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471}],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7268aa89-24cd-49b9-859c-a84c4d7404ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/91f591ca-9c37-4bf7-89de-f2d16348ced1
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 09 Jan 2024 17:32:51 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c45acaa9-13a3-4ddc-abdc-5102b2cd3389
+      - b73232bb-6f69-404e-a225-03daab94a0b1
     status: 204 No Content
     code: 204
     duration: ""
@@ -1991,21 +2222,815 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b0753a4e-b880-424f-9e16-ad792781c005","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"configuring"}'
+    headers:
+      Content-Length:
+      - "383"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:34:58 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 61a752c1-6a03-4971-b717-a11f42872424
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:35:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 64acc451-be85-42c2-83d2-35e18836d319
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:35:28 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bd764739-09de-4094-85d0-80cc60c655f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","ipam_config":{}}}]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201/endpoints
+    method: POST
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "388"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:35:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0efd7c29-2bde-4df4-9ecf-2d90f68091bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "388"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:35:29 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44294ab2-902c-4eb6-a76a-4a961d3710e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:35:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 07ce7dec-d567-418c-9a42-cd851b1958e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:35:59 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d7a57e7e-24ec-497b-820b-658a78f13bfd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.28.3/22","created_at":"2024-01-18T14:35:29.039945Z","id":"1a51e77e-45b4-4007-b181-2b8c0666b6cd","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:24","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:35:30.705280Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:00 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eade3762-897c-4668-ad46-6f527942c9cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:04 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5546d12f-d701-472a-ad66-958a9830a09a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "705"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c5ccad52-ae79-446e-a9b5-40dfc4e882ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - adb8f245-2e8a-47ff-a77f-6077ab4ff702
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a4772172-f450-4375-a7e7-34dbe22394bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.28.3/22","created_at":"2024-01-18T14:35:29.039945Z","id":"1a51e77e-45b4-4007-b181-2b8c0666b6cd","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:24","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:35:30.705280Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c1c220a0-b213-494c-913d-31f5c230a275
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 307ff278-a898-498b-add9-4f2eafa47a08
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.28.3/22","created_at":"2024-01-18T14:35:29.039945Z","id":"1a51e77e-45b4-4007-b181-2b8c0666b6cd","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:24","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:35:30.705280Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 894c1a1b-6f04-4236-b28b-215702a9cdf5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "705"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 51eb2735-005d-4fcd-acab-3c7a56979bf9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c63a91b-fd03-4a33-aba2-e8e53a21c7f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 55ceeafc-084f-4cc0-9415-9d6a248b038c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.28.3/22","created_at":"2024-01-18T14:35:29.039945Z","id":"1a51e77e-45b4-4007-b181-2b8c0666b6cd","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:24","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:35:30.705280Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ab1a24d4-d426-4e26-9fc5-bf931e7b0792
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:05 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 47a95454-bb24-4fb2-b429-303e0c6d315b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.28.3/22","created_at":"2024-01-18T14:35:29.039945Z","id":"1a51e77e-45b4-4007-b181-2b8c0666b6cd","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:24","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:35:30.705280Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db9522a6-0c73-4d84-b369-2cf0f98076d3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-pn-objective-sanderson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":null,"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-01-18T14:36:06.255325Z","dhcp_enabled":true,"id":"cd085b89-df3d-493a-9374-6baa34f2e345","name":"tf-pn-objective-sanderson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:36:06.255325Z","id":"576e5418-8b24-4870-ab7c-e07347c9f6dd","subnet":"172.16.24.0/22","updated_at":"2024-01-18T14:36:06.255325Z"},{"created_at":"2024-01-18T14:36:06.255325Z","id":"e6a431ee-f544-47aa-9135-02e0f5a9688d","subnet":"fd63:256c:45f7:b9cd::/64","updated_at":"2024-01-18T14:36:06.255325Z"}],"tags":[],"updated_at":"2024-01-18T14:36:06.255325Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "709"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:06 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 062d8e33-5379-4d00-98b7-d80a9a9aef58
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd085b89-df3d-493a-9374-6baa34f2e345
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:36:06.255325Z","dhcp_enabled":true,"id":"cd085b89-df3d-493a-9374-6baa34f2e345","name":"tf-pn-objective-sanderson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:36:06.255325Z","id":"576e5418-8b24-4870-ab7c-e07347c9f6dd","subnet":"172.16.24.0/22","updated_at":"2024-01-18T14:36:06.255325Z"},{"created_at":"2024-01-18T14:36:06.255325Z","id":"e6a431ee-f544-47aa-9135-02e0f5a9688d","subnet":"fd63:256c:45f7:b9cd::/64","updated_at":"2024-01-18T14:36:06.255325Z"}],"tags":[],"updated_at":"2024-01-18T14:36:06.255325Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "709"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 21040dc9-1222-44e7-b417-5d3259edbe1b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6d8286cd-bef5-4415-af3d-00e21398bed3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471},"endpoints":[{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471}],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: ""
     headers:
-      Content-Length:
-      - "1286"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:54 GMT
+      - Thu, 18 Jan 2024 14:36:07 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2015,7 +3040,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4136df5b-c81c-4a07-b483-8201455c0e00
+      - b1e5835f-1d26-4a0b-a553-5658d9dcca2d
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"1a0dfa62-e2a5-4e01-af9c-cb86d61b95d9","ip":"172.16.28.3","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"172.16.28.3/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"configuring"}'
+    headers:
+      Content-Length:
+      - "387"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:07 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9e52a881-9e55-4e39-8953-5b54c475844b
     status: 200 OK
     code: 200
     duration: ""
@@ -2024,21 +3082,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-09T17:25:12.364057Z","endpoint":{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471},"endpoints":[{"id":"9f738042-9cf9-4bab-b7da-99c92df98859","ip":"51.159.206.51","load_balancer":{},"name":null,"port":24471}],"engine":"PostgreSQL-15","id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1286"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:32:57 GMT
+      - Thu, 18 Jan 2024 14:36:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2048,7 +3106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b22f766c-6815-4a70-ad67-a92ec3c385d7
+      - 60b12dc9-bb77-409f-bf15-ff9cbbbf501d
     status: 200 OK
     code: 200
     duration: ""
@@ -2057,21 +3115,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","type":"not_found"}'
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "129"
+      - "165"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:33:27 GMT
+      - Thu, 18 Jan 2024 14:36:37 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2081,30 +3139,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a7a90f9-5724-49f1-af84-4eff6b43c21d
-    status: 404 Not Found
-    code: 404
+      - b014187d-e938-4003-a43b-89809b5166fd
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","ipam_config":{}}}]}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1b9d7f1a-7af4-49c8-b6ca-6982c956a93a
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201/endpoints
+    method: POST
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"1b9d7f1a-7af4-49c8-b6ca-6982c956a93a","type":"not_found"}'
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "129"
+      - "388"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:33:27 GMT
+      - Thu, 18 Jan 2024 14:36:38 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2114,21 +3174,2197 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95e5d2df-4d33-4c31-9bed-ac841658d980
-    status: 404 Not Found
-    code: 404
+      - c1bdcbea-1486-4203-b7bc-878057e53888
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/9f8bf570-6a23-4c7f-93d4-184e2f5dd454
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"9f8bf570-6a23-4c7f-93d4-184e2f5dd454","type":"not_found"}'
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "388"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:36:38 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d330be26-6a35-409e-ac6a-4f35f8701f83
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bcedbbcc-4258-4395-afc0-4b855ef556f3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7d230af-05d5-4852-bd40-a31a0beea169
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T14:36:38.542356Z","id":"fea090cd-9ae2-4ee9-98e3-8402a87ee6a8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:2B","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"576e5418-8b24-4870-ab7c-e07347c9f6dd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:36:39.804370Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 97f1e50e-2a10-4dd4-b78e-bc957a6d5bae
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 421925dc-b485-467f-8457-97f0d056266b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd085b89-df3d-493a-9374-6baa34f2e345
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:36:06.255325Z","dhcp_enabled":true,"id":"cd085b89-df3d-493a-9374-6baa34f2e345","name":"tf-pn-objective-sanderson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:36:06.255325Z","id":"576e5418-8b24-4870-ab7c-e07347c9f6dd","subnet":"172.16.24.0/22","updated_at":"2024-01-18T14:36:06.255325Z"},{"created_at":"2024-01-18T14:36:06.255325Z","id":"e6a431ee-f544-47aa-9135-02e0f5a9688d","subnet":"fd63:256c:45f7:b9cd::/64","updated_at":"2024-01-18T14:36:06.255325Z"}],"tags":[],"updated_at":"2024-01-18T14:36:06.255325Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "709"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54249fef-40c3-4ad0-9332-fd8418b692b6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "705"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - be9fc505-b56e-4292-bc24-a13e4d7c3598
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:09 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 58b81171-2215-4dfa-852e-8d3dbbb72a11
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56ae2955-dadd-45ce-961a-10d6ee4bd4b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T14:36:38.542356Z","id":"fea090cd-9ae2-4ee9-98e3-8402a87ee6a8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:2B","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"576e5418-8b24-4870-ab7c-e07347c9f6dd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:36:39.804370Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 940d3be5-3f07-4357-9acc-892aca81c620
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 965b0464-d4dd-4d0a-92f0-41698949f1ce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T14:36:38.542356Z","id":"fea090cd-9ae2-4ee9-98e3-8402a87ee6a8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:2B","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"576e5418-8b24-4870-ab7c-e07347c9f6dd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:36:39.804370Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a64fd134-8fa8-4982-9562-a442fad61277
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd085b89-df3d-493a-9374-6baa34f2e345
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:36:06.255325Z","dhcp_enabled":true,"id":"cd085b89-df3d-493a-9374-6baa34f2e345","name":"tf-pn-objective-sanderson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:36:06.255325Z","id":"576e5418-8b24-4870-ab7c-e07347c9f6dd","subnet":"172.16.24.0/22","updated_at":"2024-01-18T14:36:06.255325Z"},{"created_at":"2024-01-18T14:36:06.255325Z","id":"e6a431ee-f544-47aa-9135-02e0f5a9688d","subnet":"fd63:256c:45f7:b9cd::/64","updated_at":"2024-01-18T14:36:06.255325Z"}],"tags":[],"updated_at":"2024-01-18T14:36:06.255325Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "709"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ad42a99-2f7c-4095-93eb-c5370f8fee96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "705"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e18cbdd-c5fb-46f5-9225-f0ac1aa824b8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1616"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e38f2bd1-466c-4c07-b8bc-323929383622
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9d20a08c-5d15-415c-a29e-6df265dfa924
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T14:36:38.542356Z","id":"fea090cd-9ae2-4ee9-98e3-8402a87ee6a8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:2B","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"576e5418-8b24-4870-ab7c-e07347c9f6dd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:36:39.804370Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca6b35c0-ab14-49eb-b0d6-ad39e5a8354b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 23940dbb-faa7-4f39-8855-aab114df0167
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-01-18T14:36:38.542356Z","id":"fea090cd-9ae2-4ee9-98e3-8402a87ee6a8","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","mac_address":"02:00:00:17:4C:2B","name":"read-replica-eb41f7fe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"576e5418-8b24-4870-ab7c-e07347c9f6dd"},"tags":["managed","scwdbaas"],"updated_at":"2024-01-18T14:36:39.804370Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:10 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 523ac9dc-8b49-40e1-8d3d-8a824ad84d80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 33d8dd28-c7dc-4ceb-a156-65098d4539ff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/b10950df-2b77-4933-8584-60b3bbff6ee2
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2dfb65e1-4729-4d17-a35e-76bfb3911f19
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"b10950df-2b77-4933-8584-60b3bbff6ee2","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"configuring"}'
+    headers:
+      Content-Length:
+      - "387"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:11 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 45b23db1-9154-48c2-96be-554882c0e570
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:43 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5696109a-491c-4889-990b-1ff9fe855757
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:45 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2d686a94-fc3f-4936-ab01-6e2888ad63fb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20"}}]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201/endpoints
+    method: POST
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "384"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:46 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6ec1ccd4-ae41-44f2-8e49-fecc1225a5fb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "384"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:37:47 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 50583d82-230e-4001-a985-3837e42b4b27
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 28f94d5f-0b72-4eb7-b3e0-3fabe8503c90
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 49898737-675c-421f-bddf-9f18a8d79828
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74fae151-1f9d-454c-b997-5e7d6f00856a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6df58a28-aabf-48f6-add1-b7ca87827d21
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd085b89-df3d-493a-9374-6baa34f2e345
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:36:06.255325Z","dhcp_enabled":true,"id":"cd085b89-df3d-493a-9374-6baa34f2e345","name":"tf-pn-objective-sanderson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:36:06.255325Z","id":"576e5418-8b24-4870-ab7c-e07347c9f6dd","subnet":"172.16.24.0/22","updated_at":"2024-01-18T14:36:06.255325Z"},{"created_at":"2024-01-18T14:36:06.255325Z","id":"e6a431ee-f544-47aa-9135-02e0f5a9688d","subnet":"fd63:256c:45f7:b9cd::/64","updated_at":"2024-01-18T14:36:06.255325Z"}],"tags":[],"updated_at":"2024-01-18T14:36:06.255325Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "709"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea9a6074-f196-4d5a-abca-9e2fb482bcaf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "705"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25aba417-cc2f-4d8f-903f-f692fdcb5993
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1612"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 26d2fec7-3798-4a7c-be50-1322bb96dfcb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:17 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c389bbf7-63b0-464c-8da1-5425eb409905
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 299c7ed2-4c5c-48f6-a6bd-3e5019442d8b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2163ade1-9aa5-417d-8d50-5fdc4653c017
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 41896f03-bef9-4ebd-abad-6bc92a330483
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd085b89-df3d-493a-9374-6baa34f2e345
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:36:06.255325Z","dhcp_enabled":true,"id":"cd085b89-df3d-493a-9374-6baa34f2e345","name":"tf-pn-objective-sanderson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:36:06.255325Z","id":"576e5418-8b24-4870-ab7c-e07347c9f6dd","subnet":"172.16.24.0/22","updated_at":"2024-01-18T14:36:06.255325Z"},{"created_at":"2024-01-18T14:36:06.255325Z","id":"e6a431ee-f544-47aa-9135-02e0f5a9688d","subnet":"fd63:256c:45f7:b9cd::/64","updated_at":"2024-01-18T14:36:06.255325Z"}],"tags":[],"updated_at":"2024-01-18T14:36:06.255325Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "709"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b91058c5-57e3-4e51-88c7-8d97ee32df83
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "705"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 067f496b-97b4-4b84-8b4a-e605d7aee8af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1612"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 515e5d41-3086-4403-900f-18a30d2ae629
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6c5d9655-3715-46e1-b941-10a2245e7995
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 19d62fd8-bf13-4f05-b3fd-71d9703abefc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a86e0ff5-677c-4996-b978-b35b2733be51
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:18 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 04368122-f5dc-440b-bbf6-d00b66bd352c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2faab8e9-1019-4190-a632-0b5ecc8c4c34
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/fbdf3661-2630-4f82-8d63-5d680004eced
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0278e8e8-1e8a-42d9-b59c-b33f3e3e59c0
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"fbdf3661-2630-4f82-8d63-5d680004eced","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"cd085b89-df3d-493a-9374-6baa34f2e345","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"configuring"}'
+    headers:
+      Content-Length:
+      - "383"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:19 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a175ba4-ce89-4ac3-b42f-b4edcfd8c8c2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d48f12ef-3fcc-46f6-8e74-4e7c1d8a5243
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "165"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:49 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b1e2d54-ed06-4c2b-be76-844fc95e1fd3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20"}}]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201/endpoints
+    method: POST
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "384"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 30bcf901-9ebb-4b23-a838-6b852eb9d925
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "384"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:38:50 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fa0b7839-914d-4690-a44a-e187f25ba531
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a78524bb-f9fb-4137-9e11-0f73651e2761
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 49a01375-f312-45ed-9955-db7d3e1aa29d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:20 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 53f7e2f8-cbd4-4fff-ab7a-8ae54277a0ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3ea5be7d-e0f5-4a86-a610-009c3dd10d21
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:33:52.923255Z","dhcp_enabled":true,"id":"9891e8ee-4789-4c99-8519-4987d6183702","name":"tf-pn-admiring-golick","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:33:52.923255Z","id":"d977f3a3-ef8c-487e-b2ff-974ab5ef2ccd","subnet":"172.16.28.0/22","updated_at":"2024-01-18T14:33:52.923255Z"},{"created_at":"2024-01-18T14:33:52.923255Z","id":"3a095965-7d7e-4d9e-8804-7f0253335e32","subnet":"fd63:256c:45f7:8f42::/64","updated_at":"2024-01-18T14:33:52.923255Z"}],"tags":[],"updated_at":"2024-01-18T14:33:52.923255Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "705"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b3b3924-9aef-4845-b93b-a2b809862ed5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd085b89-df3d-493a-9374-6baa34f2e345
+    method: GET
+  response:
+    body: '{"created_at":"2024-01-18T14:36:06.255325Z","dhcp_enabled":true,"id":"cd085b89-df3d-493a-9374-6baa34f2e345","name":"tf-pn-objective-sanderson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-01-18T14:36:06.255325Z","id":"576e5418-8b24-4870-ab7c-e07347c9f6dd","subnet":"172.16.24.0/22","updated_at":"2024-01-18T14:36:06.255325Z"},{"created_at":"2024-01-18T14:36:06.255325Z","id":"e6a431ee-f544-47aa-9135-02e0f5a9688d","subnet":"fd63:256c:45f7:b9cd::/64","updated_at":"2024-01-18T14:36:06.255325Z"}],"tags":[],"updated_at":"2024-01-18T14:36:06.255325Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "709"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 81453794-e850-4d04-a662-a820dbd03670
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1612"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d10e4898-575a-402c-ad45-2c16e0a92534
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVVFp4M2psU1N0Z3Zyc3QxZVNjL3pCTFpqT2ZRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TVM0eE16VXdIaGNOCk1qUXdNVEU0TVRRek1USTJXaGNOTXpRd01URTFNVFF6TVRJMldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXhMakV6TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtsUFZKNHdrZFRHNHp1S1ZUdE1GUmc2TUVsYnZmOTI5R1h2Z3ZoTzdqbFl2UFhkNkcrVDZYWlcKTEJ4ZllYZ1lFMEFueTR3dTljSXNzeHI1NE5KYkw0eXFjSEFqVmJnSVlVK3VXTlo5dmRKUHU5OVluRlB2dldYMwphdnZxZDQzbGJmTFY2bWpPWEI0bGtVL0Q2NWdyVm85aUxpZzYxaWtwbkVCK3pCZWczQVVOTzhja00vYXdVM2pyCmYvTi9hVHdiMU1ITjVjeWpqem9ybmJvelFsb3MwSDlGcGs2MklNSXZuWjJmZUhpbWtVMkpvdXVET3NTOXhMTGgKaGV2SGZrZC8xVWthMHpkZnVkakNQMkcrRjlTa01rN2tMNVRvNjFKTUFWWHZ1dVhLNmMrdWhxZVNtWGxhNXVvYQprMGVKamdJTzlBeGdyWS9OczlrdlMzQkExV3IzMExNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1URXVNVE0xZ2p4eWR5MWpPVFkwWldNM1l5MHlOelF5TFRSaU1qWXRZVGRrTkMwNFlqaGgKWlRBelpETTNOREV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1TNHhNeldDUEhKMwpMV001TmpSbFl6ZGpMVEkzTkRJdE5HSXlOaTFoTjJRMExUaGlPR0ZsTUROa016YzBNUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VNNTVtYzRjRU01OExoNGNFTTU4TGh6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKbUltekEvTUluN1dZMys5VHZhdU50aERlNzZwS1BqZ1pKRzQvNkI1UTY3dHl2WjdKQzlhWXRUZ3RwNVZ2WHo5ZQovSnR2OTNFbTF4TUNvdFFiQytBa1dWTGhwN09zWEdJaGw3UHlsWXhwMGJuRE5nQ1ZvRE9qWlliZ0xRS2VabFhiCmx3UDhuSEptYXJ3MVI3N2xTWWZRKzQyakhMUWpRNVhWdW52ektESGE2OXRWRTFVWEhSUnRlQTdFcXE0aGRQbVcKcUZrU3Y4czhYY3pRTzA2UWhYR2JISml5VUswOXZsU1Y5Vi9VTmlVdEk0cFIwelc2MHprNTlmcXlRdnJHaWZYTgo4ZnVmSHFvbjFvekl5aVZobG9MNC9HcXN6OFJyUEJVL2xPUENOa1dwU0ZOc1N3YTNjQmpzT1BtQUw2UTJlZlVhCm43NmJDSk9OcjkybDVrTlpqeGNQaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7303d87b-19c2-4578-b2de-ee3c822b5e5b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5cc24d19-7e80-45d8-a397-14da0f9a89fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 12aed0e5-1df0-4b3e-8962-746989c8922b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=c964ec7c-2742-4b26-a7d4-8b8ae03d3741&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "26"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 312195e6-4131-473d-829d-32ee92c22acd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "377"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:21 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35ebc03f-1434-4cfd-ae80-bfaa2a047cbb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: DELETE
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"deleting"}'
+    headers:
+      Content-Length:
+      - "380"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 238e6438-a28b-439f-a1ef-7fea4a2f43a9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"ac886384-3701-4412-a8ce-c84e24dac68b","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"9891e8ee-4789-4c99-8519-4987d6183702","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"eb41f7fe-6315-4070-983d-46018088b201","instance_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","region":"fr-par","same_zone":true,"status":"deleting"}'
+    headers:
+      Content-Length:
+      - "380"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1adba835-4bc6-4f15-b128-012d6109f802
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cd085b89-df3d-493a-9374-6baa34f2e345
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:22 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8bc532d-1af5-4a25-8096-2a1e506035f6
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"eb41f7fe-6315-4070-983d-46018088b201","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -2137,7 +5373,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 09 Jan 2024 17:33:27 GMT
+      - Thu, 18 Jan 2024 14:39:52 GMT
       Server:
       - Scaleway API-Gateway
       Strict-Transport-Security:
@@ -2147,7 +5383,236 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3025dcc-dee6-45a3-8a6b-fc0bfeb07fd1
+      - 43988de1-6e3c-44cd-a72f-b8b2cc214358
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1235"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:52 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 99388d7d-6923-4529-b720-7c869bac7e8e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1238"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 154ffca2-bb01-4f41-bbf9-f7669aa9ae4f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/9891e8ee-4789-4c99-8519-4987d6183702
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 44f219b8-2d37-413c-88d5-87a7832d5717
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-01-18T14:28:48.007236Z","endpoint":{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671},"endpoints":[{"id":"9c5be62c-7df4-47d2-8b6f-4a96106ae643","ip":"51.159.11.135","load_balancer":{},"name":null,"port":23671}],"engine":"PostgreSQL-15","id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1238"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:39:53 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0529e479-bac8-46c2-95df-a0c28781a831
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:40:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 55804fcb-5772-4196-80f2-6f5d3a4ba669
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/c964ec7c-2742-4b26-a7d4-8b8ae03d3741
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"c964ec7c-2742-4b26-a7d4-8b8ae03d3741","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:40:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 423a1086-60b8-4aec-b47b-d7fc79c28856
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/eb41f7fe-6315-4070-983d-46018088b201
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"eb41f7fe-6315-4070-983d-46018088b201","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "133"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Jan 2024 14:40:23 GMT
+      Server:
+      - Scaleway API-Gateway
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8348b166-6742-414a-aa54-676419ddc403
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
This PR follows up #2308 (which updates the handling of endpoints for instances) and update endpoint management in read replicas.