### PR TITLE
fix(rdb): explicit choice for endpoint IP configuration in Read Replica and Instance

### DIFF
--- a/docs/resources/rdb_instance.md
+++ b/docs/resources/rdb_instance.md
@@ -79,7 +79,7 @@ resource "scaleway_rdb_instance" "main" {
   private_network {
     pn_id  = scaleway_vpc_private_network.pn.id
     ip_net = "172.16.20.4/22"   # IP address within a given IP network
-    (enable_ipam = false)
+    # enable_ipam = false
   }
 }
 ```
@@ -94,7 +94,7 @@ resource "scaleway_rdb_instance" "main" {
   engine         = "PostgreSQL-11"
   private_network {
     pn_id = scaleway_vpc_private_network.pn.id
-    (enable_ipam = true)
+    enable_ipam = true
   }
   load_balancer {}
 }
@@ -179,8 +179,8 @@ Please consult the [GoDoc](https://pkg.go.dev/github.com/scaleway/scaleway-sdk-g
 
     - `pn_id` - (Required) The ID of the private network.
     - `enable_ipam` - (Optional) Whether the endpoint should be configured with IPAM. Defaults to `false` if `ip_net` is defined, `true` otherwise.
-    - `ip_net` - (Optional) The IP network address within the private subnet. This must be an IPv4 address with a CIDR notation.
-    The IP network address within the private subnet is determined by the IP Address Management (IPAM) service if not set.
+    - `ip_net` - (Optional) The IP network address within the private subnet. This must be an IPv4 address with a CIDR notation. If not set, The IP network address within the private subnet is determined by the IP Address Management (IPAM) service.
+    - `enable_ipam` - (Optional) If true, the IP network address within the private subnet is determined by the IP Address Management (IPAM) service.
   
 ~> **NOTE:** Please calculate your host IP using [cidrhost](https://developer.hashicorp.com/terraform/language/functions/cidrhost). Otherwise, let IPAM service
 handle the host IP on the network.

--- a/docs/resources/rdb_read_replica.md
+++ b/docs/resources/rdb_read_replica.md
@@ -30,7 +30,7 @@ resource scaleway_rdb_read_replica "replica" {
 }
 ```
 
-### Private network
+### Private network with static endpoint
 
 ```terraform
 resource "scaleway_rdb_instance" "instance" {
@@ -49,7 +49,32 @@ resource "scaleway_rdb_read_replica" "replica" {
   instance_id = scaleway_rdb_instance.instance.id
   private_network {
     private_network_id = scaleway_vpc_private_network.pn.id
-    service_ip         = "192.168.1.254/24" // omit this attribute if private IP is determined by the IP Address Management (IPAM)
+    service_ip         = "192.168.1.254/24"
+    # enable_ipam = false
+  }
+}
+```
+
+### Private network with IPAM
+
+```terraform
+resource "scaleway_rdb_instance" "instance" {
+  name           = "rdb_instance"
+  node_type      = "db-dev-s"
+  engine         = "PostgreSQL-14"
+  is_ha_cluster  = false
+  disable_backup = true
+  user_name      = "my_initial_user"
+  password       = "thiZ_is_v&ry_s3cret"
+}
+
+resource "scaleway_vpc_private_network" "pn" {}
+
+resource "scaleway_rdb_read_replica" "replica" {
+  instance_id = scaleway_rdb_instance.instance.id
+  private_network {
+    private_network_id = scaleway_vpc_private_network.pn.id
+    enable_ipam = true
   }
 }
 ```
@@ -66,9 +91,8 @@ The following arguments are supported:
 
 - `private_network` - (Optional) Create an endpoint in a private network.
     - `private_network_id` - (Required) UUID of the private network to be connected to the read replica.
-    - `service_ip` - (Optional) The IP network address within the private subnet. This must be an IPv4 address with a
-      CIDR notation. The IP network address within the private subnet is determined by the IP Address Management (IPAM)
-      service if not set.
+    - `service_ip` - (Optional) The IP network address within the private subnet. This must be an IPv4 address with a CIDR notation. If not set, The IP network address within the private subnet is determined by the IP Address Management (IPAM) service.
+    - `enable_ipam` - (Optional) If true, the IP network address within the private subnet is determined by the IP Address Management (IPAM) service.
 
 - `same_zone` - (Defaults to `true`) Defines whether to create the replica in the same availability zone as the main instance nodes or not.
 
@@ -96,6 +120,7 @@ they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-11111
     - `port` - TCP port of the endpoint.
     - `name` - Name of the endpoint.
     - `hostname` - Hostname of the endpoint. Only one of ip and hostname may be set.
+    - `enable_ipam` - Indicates whether the IP is managed by IPAM.
 
 ## Import
 

--- a/scaleway/data_source_ipam_ip_test.go
+++ b/scaleway/data_source_ipam_ip_test.go
@@ -151,6 +151,7 @@ func TestAccScalewayDataSourceIPAMIP_RDB(t *testing.T) {
 						volume_size_in_gb = 10
 						private_network {
 							pn_id = "${scaleway_vpc_private_network.main.id}"
+							enable_ipam = true
 						}
 					}
 

--- a/scaleway/resource_rdb_instance_test.go
+++ b/scaleway/resource_rdb_instance_test.go
@@ -519,6 +519,7 @@ func TestAccScalewayRdbInstance_PrivateNetworkUpdate(t *testing.T) {
 						volume_size_in_gb = 10
 						private_network {
 							pn_id = "${scaleway_vpc_private_network.pn01.id}"
+							enable_ipam = true
 						}
 					}
 				`, latestEngineVersion),
@@ -553,6 +554,7 @@ func TestAccScalewayRdbInstance_PrivateNetworkUpdate(t *testing.T) {
 						volume_size_in_gb = 10
 						private_network {
 							pn_id = "${scaleway_vpc_private_network.pn02.id}"
+							enable_ipam = true
 						}
 					}
 				`, latestEngineVersion),
@@ -664,13 +666,14 @@ func TestAccScalewayRdbInstance_PrivateNetworkUpdate(t *testing.T) {
 						volume_size_in_gb = 10`, latestEngineVersion) + `
 						private_network {
 							pn_id  = scaleway_vpc_private_network.pn01.id
+							enable_ipam = true
 						}
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScalewayVPCPrivateNetworkExists(tt, "scaleway_vpc_private_network.pn01"),
 					testAccCheckScalewayRdbExists(tt, "scaleway_rdb_instance.main"),
 					resource.TestCheckResourceAttr("scaleway_rdb_instance.main", "private_network.#", "1"),
-					resource.TestCheckResourceAttr("scaleway_rdb_instance.main", "private_network.0.enable_ipam", "false"),
+					resource.TestCheckResourceAttr("scaleway_rdb_instance.main", "private_network.0.enable_ipam", "true"),
 					resource.TestCheckResourceAttrPair("scaleway_rdb_instance.main", "private_network.0.pn_id", "scaleway_vpc_private_network.pn01", "id"),
 				),
 			},
@@ -1023,6 +1026,7 @@ func TestAccScalewayRdbInstance_Endpoints(t *testing.T) {
 						tags = [ "terraform-test", "scaleway_rdb_instance", "test_endpoints" ]
 						private_network {
 							pn_id = scaleway_vpc_private_network.test_endpoints.id
+							enable_ipam = true
 						}
 					}
 				`, latestEngineVersion),
@@ -1054,6 +1058,7 @@ func TestAccScalewayRdbInstance_Endpoints(t *testing.T) {
 						tags = [ "terraform-test", "scaleway_rdb_instance", "test_endpoints" ]
 						private_network {
 							pn_id = scaleway_vpc_private_network.test_endpoints.id
+							enable_ipam = true
 						}
 						load_balancer {}
 					}

--- a/scaleway/resource_rdb_read_replica_test.go
+++ b/scaleway/resource_rdb_read_replica_test.go
@@ -488,6 +488,104 @@ func TestAccScalewayRdbReadReplica_DifferentZone(t *testing.T) {
 	})
 }
 
+func TestAccScalewayRdbReadReplica_WithInstanceAlsoInPrivateNetwork(t *testing.T) {
+	tt := NewTestTools(t)
+	defer tt.Cleanup()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckScalewayRdbInstanceDestroy(tt),
+			testAccCheckScalewayRdbReadReplicaDestroy(tt),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource "scaleway_vpc_private_network" "pn1" {
+						name = "test-rdb-rr-instance-in-pn1"
+					}
+					resource "scaleway_vpc_private_network" "pn2" {
+						name = "test-rdb-rr-instance-in-pn2"
+					}
+
+					resource scaleway_rdb_instance instance {
+						name = "test-rdb-rr-instance-in-pn"
+						node_type = "db-dev-s"
+						engine = "PostgreSQL-15"
+						is_ha_cluster = false
+						disable_backup = true
+						user_name = "my_initial_user"
+						password = "thiZ_is_v&ry_s3cret"
+						tags = [ "terraform-test", "scaleway_rdb_read_replica", "instance-also-in-pn" ]
+						private_network {
+							pn_id = scaleway_vpc_private_network.pn1.id
+							enable_ipam = true
+						}
+					}
+
+					resource "scaleway_rdb_read_replica" "replica" {
+						instance_id = scaleway_rdb_instance.instance.id
+						private_network {
+							private_network_id = scaleway_vpc_private_network.pn1.id
+							enable_ipam = true
+						}
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdbReadReplicaExists(tt, "scaleway_rdb_read_replica.replica"),
+					resource.TestCheckResourceAttrPair("scaleway_rdb_read_replica.replica", "instance_id", "scaleway_rdb_instance.instance", "id"),
+					resource.TestCheckResourceAttr("scaleway_rdb_read_replica.replica", "direct_access.#", "0"),
+					resource.TestCheckResourceAttr("scaleway_rdb_read_replica.replica", "private_network.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_rdb_read_replica.replica", "private_network.0.private_network_id", "scaleway_vpc_private_network.pn1", "id"),
+					resource.TestCheckResourceAttr("scaleway_rdb_read_replica.replica", "private_network.0.enable_ipam", "true"),
+					resource.TestCheckResourceAttrPair("scaleway_rdb_instance.instance", "private_network.0.pn_id", "scaleway_vpc_private_network.pn1", "id"),
+					resource.TestCheckResourceAttr("scaleway_rdb_instance.instance", "private_network.0.enable_ipam", "true"),
+				),
+			},
+			{
+				Config: `
+					resource "scaleway_vpc_private_network" "pn1" {
+						name = "test-rdb-rr-instance-in-pn1"
+					}
+					resource "scaleway_vpc_private_network" "pn2" {
+						name = "test-rdb-rr-instance-in-pn2"
+					}
+			
+					resource scaleway_rdb_instance instance {
+						name = "test-rdb-rr-instance-in-pn"
+						node_type = "db-dev-s"
+						engine = "PostgreSQL-15"
+						is_ha_cluster = false
+						disable_backup = true
+						user_name = "my_initial_user"
+						password = "thiZ_is_v&ry_s3cret"
+						tags = [ "terraform-test", "scaleway_rdb_read_replica", "instance-also-in-pn" ]
+						private_network {
+							pn_id = scaleway_vpc_private_network.pn2.id
+							enable_ipam = true
+						}
+					}
+			
+					resource "scaleway_rdb_read_replica" "replica" {
+						instance_id = scaleway_rdb_instance.instance.id
+						private_network {
+							private_network_id = scaleway_vpc_private_network.pn2.id
+							enable_ipam = true
+						}
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdbReadReplicaExists(tt, "scaleway_rdb_read_replica.replica"),
+					resource.TestCheckResourceAttrPair("scaleway_rdb_read_replica.replica", "instance_id", "scaleway_rdb_instance.instance", "id"),
+					resource.TestCheckResourceAttr("scaleway_rdb_read_replica.replica", "direct_access.#", "0"),
+					resource.TestCheckResourceAttr("scaleway_rdb_read_replica.replica", "private_network.#", "1"),
+					resource.TestCheckResourceAttrPair("scaleway_rdb_read_replica.replica", "private_network.0.private_network_id", "scaleway_vpc_private_network.pn2", "id"),
+					resource.TestCheckResourceAttr("scaleway_rdb_read_replica.replica", "private_network.0.enable_ipam", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRdbReadReplicaExists(tt *TestTools, readReplica string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		readReplicaResource, ok := state.RootModule().Resources[readReplica]

--- a/scaleway/testdata/data-source-ipamiprdb.cassette.yaml
+++ b/scaleway/testdata/data-source-ipamiprdb.cassette.yaml
@@ -2,29 +2,29 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-rdb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-rdb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T12:46:03.378119Z","id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-12-18T12:46:03.378119Z"}'
+    body: '{"created_at":"2024-02-19T16:52:54.632380Z","id":"431c4e3b-1920-42a5-9c1b-74328ab04684","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2024-02-19T16:52:54.632380Z"}'
     headers:
       Content-Length:
-      - "354"
+      - "363"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:46:03 GMT
+      - Mon, 19 Feb 2024 16:52:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c4184c9-4a4e-4376-b97e-bca5160e9021
+      - 3d0aeeee-a5be-4d76-8356-2359e1bb9d4a
     status: 200 OK
     code: 200
     duration: ""
@@ -41,23 +41,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/42a964fd-008a-4389-9d1d-1e60f3ed22bc
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/431c4e3b-1920-42a5-9c1b-74328ab04684
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T12:46:03.378119Z","id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-12-18T12:46:03.378119Z"}'
+    body: '{"created_at":"2024-02-19T16:52:54.632380Z","id":"431c4e3b-1920-42a5-9c1b-74328ab04684","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":0,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2024-02-19T16:52:54.632380Z"}'
     headers:
       Content-Length:
-      - "354"
+      - "363"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:46:03 GMT
+      - Mon, 19 Feb 2024 16:52:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -65,34 +65,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da0696c2-c040-4dec-b4a1-8f9a42f8aed4
+      - dc1460b4-556b-43b5-a95c-1899db52f9b6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-rdb","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":["172.16.0.0/22"],"vpc_id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc"}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-rdb","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":["172.16.0.0/22"],"vpc_id":"431c4e3b-1920-42a5-9c1b-74328ab04684"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T12:46:03.672007Z","dhcp_enabled":true,"id":"6f74ab79-2409-4233-a401-b7877b374a49","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:46:03.672007Z","id":"49a10f5a-c23a-4410-8958-f170775c7f2f","subnet":"172.16.0.0/22","updated_at":"2023-12-18T12:46:03.672007Z"},{"created_at":"2023-12-18T12:46:03.672007Z","id":"107c89b2-1bac-4527-962e-74b829800374","subnet":"fd5f:519c:6d46:34f4::/64","updated_at":"2023-12-18T12:46:03.672007Z"}],"tags":[],"updated_at":"2023-12-18T12:46:03.672007Z","vpc_id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc"}'
+    body: '{"created_at":"2024-02-19T16:52:54.857540Z","dhcp_enabled":true,"id":"250242a9-6b31-4bb7-9251-0244501aa469","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-19T16:52:54.857540Z","id":"ff9b3f58-6386-4d36-b129-d15893f4a12a","subnet":"172.16.0.0/22","updated_at":"2024-02-19T16:52:54.857540Z"},{"created_at":"2024-02-19T16:52:54.857540Z","id":"174c5668-9de8-469c-b32e-3fc254b19fef","subnet":"fd63:256c:45f7:b644::/64","updated_at":"2024-02-19T16:52:54.857540Z"}],"tags":[],"updated_at":"2024-02-19T16:52:54.857540Z","vpc_id":"431c4e3b-1920-42a5-9c1b-74328ab04684"}'
     headers:
       Content-Length:
-      - "714"
+      - "731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:46:04 GMT
+      - Mon, 19 Feb 2024 16:52:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f98b1b5-9e4c-4dc3-953c-d1a3c8f1b28c
+      - 3bbd0b70-0d9f-46c6-abc3-255e1313d365
     status: 200 OK
     code: 200
     duration: ""
@@ -109,23 +109,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6f74ab79-2409-4233-a401-b7877b374a49
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/250242a9-6b31-4bb7-9251-0244501aa469
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T12:46:03.672007Z","dhcp_enabled":true,"id":"6f74ab79-2409-4233-a401-b7877b374a49","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:46:03.672007Z","id":"49a10f5a-c23a-4410-8958-f170775c7f2f","subnet":"172.16.0.0/22","updated_at":"2023-12-18T12:46:03.672007Z"},{"created_at":"2023-12-18T12:46:03.672007Z","id":"107c89b2-1bac-4527-962e-74b829800374","subnet":"fd5f:519c:6d46:34f4::/64","updated_at":"2023-12-18T12:46:03.672007Z"}],"tags":[],"updated_at":"2023-12-18T12:46:03.672007Z","vpc_id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc"}'
+    body: '{"created_at":"2024-02-19T16:52:54.857540Z","dhcp_enabled":true,"id":"250242a9-6b31-4bb7-9251-0244501aa469","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-19T16:52:54.857540Z","id":"ff9b3f58-6386-4d36-b129-d15893f4a12a","subnet":"172.16.0.0/22","updated_at":"2024-02-19T16:52:54.857540Z"},{"created_at":"2024-02-19T16:52:54.857540Z","id":"174c5668-9de8-469c-b32e-3fc254b19fef","subnet":"fd63:256c:45f7:b644::/64","updated_at":"2024-02-19T16:52:54.857540Z"}],"tags":[],"updated_at":"2024-02-19T16:52:54.857540Z","vpc_id":"431c4e3b-1920-42a5-9c1b-74328ab04684"}'
     headers:
       Content-Length:
-      - "714"
+      - "731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:46:05 GMT
+      - Mon, 19 Feb 2024 16:52:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -133,34 +133,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be89a3d9-f688-4b09-9f38-5cf6c0b47bbb
+      - d3105b4f-59a2-4628-aec2-10d625631508
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-ipam-ip-rdb","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","ipam_config":{}}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-ipam-ip-rdb","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","ipam_config":{}}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1085"
+      - "1124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:46:06 GMT
+      - Mon, 19 Feb 2024 16:52:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -168,7 +168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be964aed-de80-432d-9949-60fc145a3332
+      - e451c8b7-193f-4fdb-9b9c-f20369f78e51
     status: 200 OK
     code: 200
     duration: ""
@@ -177,23 +177,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1085"
+      - "1124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:46:06 GMT
+      - Mon, 19 Feb 2024 16:52:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -201,7 +201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b609cada-71cb-49be-99b2-666321a16d62
+      - d6154d5a-aa24-4380-ab4a-3b862dff1f1b
     status: 200 OK
     code: 200
     duration: ""
@@ -210,23 +210,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1085"
+      - "1124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:46:37 GMT
+      - Mon, 19 Feb 2024 16:53:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -234,7 +234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22ef2b35-74a7-407d-952d-9476f1b92855
+      - feb5b913-5eaa-4cda-abc6-639daafc887f
     status: 200 OK
     code: 200
     duration: ""
@@ -243,23 +243,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1085"
+      - "1124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:47:07 GMT
+      - Mon, 19 Feb 2024 16:53:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -267,7 +267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62e9fe33-3a6e-4c6e-8117-fb0aa3b6f1b2
+      - cacc7454-e407-4bc5-80ba-58d7483ed1b6
     status: 200 OK
     code: 200
     duration: ""
@@ -276,23 +276,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1085"
+      - "1124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:47:37 GMT
+      - Mon, 19 Feb 2024 16:54:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -300,7 +300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d4cb243-1a1e-467e-86f6-5c1ac4d46a6d
+      - 61cbff0e-da12-43bb-a4af-1103b1b1bf52
     status: 200 OK
     code: 200
     duration: ""
@@ -309,23 +309,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1085"
+      - "1124"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:48:07 GMT
+      - Mon, 19 Feb 2024 16:54:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -333,7 +333,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59222eda-d273-4335-a0e7-8f554dddea87
+      - 23f8cf54-e80b-436e-9651-7a020a0b5ed3
     status: 200 OK
     code: 200
     duration: ""
@@ -342,23 +342,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1085"
+      - "1392"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:48:37 GMT
+      - Mon, 19 Feb 2024 16:55:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -366,7 +366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b10295a-722a-43bf-98b0-bc37da7bf5ce
+      - 80aecb3e-1a9d-4916-8bb3-9baf7c3ccd22
     status: 200 OK
     code: 200
     duration: ""
@@ -375,23 +375,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYVENDQWtXZ0F3SUJBZ0lVS2JpWXI1aGJpZGpuMDlDUWwveTlpSWlGMmFVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTR3TGpJd0hoY05NalF3Ck1qRTVNVFkxTkRBd1doY05NelF3TWpFMk1UWTFOREF3V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpBdU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFLMVFHdTRZcmlqb1VGenNQdS92Wm1pU0diMWw1NUZQRENPWVBGTnRNZktmNzI2ZWlTV1F0M0xsblIvWDNuV24KTk5jQ3lQUmdlSFcvcVdaekx6cFBtS0lrLzVTTktLbUhFZTlEU3ZNT3NESGExakVRTnM2Znd4RXJpTTlPekhYQgpzTmt0cDh0TzZXSTlTUlRNN3l6K2pFbzg1SE9ONkRGVDBkQ2xhUkF0TkM5cWJSN0hYMHpVa2ZRVjkzM05NZnhkCk9nNW1YT3FyODJkVTBGN2pDaGk0bHowblNrOW16QnY4MHo1eDl3WCt2UnVmV09DK1FtSXFrb0hXb0xyL0JBYWoKZ3Y2TU1uNWU2MTZ5NDVTVC9uYzBPS1kvL0twamV4SGIwTDVCQitFaHVCc0xzZFFUcWNPR2xRaTZEd2dCYjQ5dQpGSExjcjZGN0ZBdG8rZUYvb3hFMDVha0NBd0VBQWFNbE1DTXdJUVlEVlIwUkJCb3dHSUlLTVRjeUxqRTJMakF1Ck1vY0VNNTVMMW9jRXJCQUFBakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBanR2d2pwZm11dUlTU3NSZER5aEYKM1MzRVVJNk1rYUJtZjdBdktZcmhpZ2FUWEhENEpZVzAvZk5vT2lXczhaejNWVVNaVHM0QkxjZ3ZZek5Gd0ZVMQpUSkRMRVB0MTYzd2hzNDMyaEQ4ZjhBQXlTMHIzdjdYRGs4L2NCdzlyWkV1eE9wd3VNQ2tBUThMUS9HclMySXNrCnJ0a2MyTENGSnNyT0RveTJvTWUwaytjM2IycWg5U0hBNDQrSDkwaUYxandFaDF1RUNvcHREckRRemZuV1dXRDUKSDMwU2JMQ25vb2NoN0ZYT3NxK0lXNDU4K2pWb3EwWHIrK1l2Y2pScGNhbGpuWHlqTU4wKzRsZW5FL0s0L0lwSgpVZXI1RHZlTXNnaGtRWm9GdFBXSGVaT1hRMkdTUnViRFV2MHJTL1RnZVZzTXpxS2lLa3dnWDd4T0tQN0R4cWhqClVRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1342"
+      - "1721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:08 GMT
+      - Mon, 19 Feb 2024 16:55:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -399,7 +399,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b67cdee-28f7-4e66-a9eb-4ddc9961c525
+      - e6215c95-7490-4122-8df8-bd900be544cc
     status: 200 OK
     code: 200
     duration: ""
@@ -408,23 +408,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=2a378d73-f50b-411b-bba4-1b7aca9bb371&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYVENDQWtXZ0F3SUJBZ0lVVW4zZWc3T3YydCs0Wm5laHp5VFk5UU55S0xnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTR3TGpJd0hoY05Nak14Ck1qRTRNVEkwTnpJd1doY05Nek14TWpFMU1USTBOekl3V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpBdU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFQT2U3ei9RWThnM0NVSHVBSnFPY2xDVjY4aVVYWU10RFRHY0hCMGZCSUo2UkdzQUdSQm5zUlhtWS95RzlTZVAKUDEwSU15QTFWZHlRZHhVMVhCaXhjVVROa1haNFdWR3M2a0dRblRNVmVONzRhL2lJdWN4QnZXaWtPckROVG41NAowWFdsWTJnQjNDYUF5ZkxBQ1g4V1J3NnNRM3JDRnl3Z1pwWTA0My9TMkpqZWRqVHhEaFZRcTRRaHlFMWsxY3NPCjhWMjR2VUJwdVdvc055TWliWGt1V28vbDFMS2paQ2hjcFUvU0VGZ3EwdFd1S0QrRVdmcXMzaUxqczh5N3hPcUYKZVZHMFhWQXN2REZCclFZckptQ3B5ZEkxL21ZL3ZlY1NoaFZwUTZlTU1hdE1jSWg5RUlnR1BQa0hUUTNUWUQ5aQpqbSt1eGF1b3ZNam1lTGpYUlZHdFRFVUNBd0VBQWFNbE1DTXdJUVlEVlIwUkJCb3dHSUlLTVRjeUxqRTJMakF1Ck1vY0VNdytNa0ljRXJCQUFBakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBbnZGeW0vMDlVY3RkdnByeXJabkgKMllTK1ZXWmhEYkRRMnh3TjZwUHo5Nm13Qmpka0owU0Ivb3Q2UWR2OUxuUmFtQmJIdk5yZmxhZ3FTZkxtQmNENgpjVGtweG5SaGYrdHRiODQ4NzZCMkhhR3IyWHZDM2QwbjdkQ2tjbGVpUFR0OVluNk9PcWhOSHU2NXg3MEgzbUhZCllYQjF2TXdkUVVoNStxbWVBQjE5N1puc0ZSQWpqWDBEUWdpcWEveXVqTjhsLzJCUFZzWHJwbVprdUNNNGk3dDkKZGh5QTlmYVd3dEkyUzF2SUdvZmdia3FJS2VsS0dWdEM4amF1Y09lV1NQMXlSSXE1S2ZRTG1VekNJbWhQVnVGawpVYm5LQkRQTGlpS0tPYytrd28yV2FIMElFRVQxWU9FQ1drUnA3OHlvWUQrMXAxVXp2UnV4MkszeGNPUFRKNFlYCi9nPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2024-02-19T16:52:56.106802Z","id":"5733d293-c580-473b-8c7c-d26ec182110c","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","mac_address":"02:00:00:18:7E:2F","name":"test-ipam-ip-rdb","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ff9b3f58-6386-4d36-b129-d15893f4a12a"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-19T16:53:28.369571Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1719"
+      - "542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:08 GMT
+      - Mon, 19 Feb 2024 16:55:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8514a20a-75c2-4815-b256-7e8e21ae7446
+      - 05e44225-a077-4c76-accd-f5390bd11f65
     status: 200 OK
     code: 200
     duration: ""
@@ -441,56 +441,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "512"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 12:49:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ecb4f360-d940-43b0-b6ae-2284aa9a3d63
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-ipam-ip-rdb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2024-02-19T16:52:56.106802Z","id":"5733d293-c580-473b-8c7c-d26ec182110c","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","mac_address":"02:00:00:18:7E:2F","name":"test-ipam-ip-rdb","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ff9b3f58-6386-4d36-b129-d15893f4a12a"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-19T16:53:28.369571Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "512"
+      - "542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:08 GMT
+      - Mon, 19 Feb 2024 16:55:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -498,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2a69ebf-0bc2-4dc7-af0c-c4d7856cf8dd
+      - baa119d3-c56d-4831-8b06-7f18f693c1b3
     status: 200 OK
     code: 200
     duration: ""
@@ -507,23 +474,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-ipam-ip-rdb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2024-02-19T16:52:56.106802Z","id":"5733d293-c580-473b-8c7c-d26ec182110c","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","mac_address":"02:00:00:18:7E:2F","name":"test-ipam-ip-rdb","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ff9b3f58-6386-4d36-b129-d15893f4a12a"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-19T16:53:28.369571Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "512"
+      - "542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:08 GMT
+      - Mon, 19 Feb 2024 16:55:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -531,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 810923e8-09dc-421c-8c89-560acdd0b4be
+      - 8a78505f-6cc3-4b45-8529-6546876ece70
     status: 200 OK
     code: 200
     duration: ""
@@ -540,23 +507,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/42a964fd-008a-4389-9d1d-1e60f3ed22bc
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/431c4e3b-1920-42a5-9c1b-74328ab04684
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T12:46:03.378119Z","id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2023-12-18T12:46:03.378119Z"}'
+    body: '{"created_at":"2024-02-19T16:52:54.632380Z","id":"431c4e3b-1920-42a5-9c1b-74328ab04684","is_default":false,"name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","private_network_count":1,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","tags":[],"updated_at":"2024-02-19T16:52:54.632380Z"}'
     headers:
       Content-Length:
-      - "354"
+      - "363"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:09 GMT
+      - Mon, 19 Feb 2024 16:55:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -564,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5507977e-fe93-4ee0-9505-f94aeeccca90
+      - 17d20953-69a6-434c-8cba-27061943bce6
     status: 200 OK
     code: 200
     duration: ""
@@ -573,23 +540,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6f74ab79-2409-4233-a401-b7877b374a49
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/250242a9-6b31-4bb7-9251-0244501aa469
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T12:46:03.672007Z","dhcp_enabled":true,"id":"6f74ab79-2409-4233-a401-b7877b374a49","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T12:46:03.672007Z","id":"49a10f5a-c23a-4410-8958-f170775c7f2f","subnet":"172.16.0.0/22","updated_at":"2023-12-18T12:46:03.672007Z"},{"created_at":"2023-12-18T12:46:03.672007Z","id":"107c89b2-1bac-4527-962e-74b829800374","subnet":"fd5f:519c:6d46:34f4::/64","updated_at":"2023-12-18T12:46:03.672007Z"}],"tags":[],"updated_at":"2023-12-18T12:46:03.672007Z","vpc_id":"42a964fd-008a-4389-9d1d-1e60f3ed22bc"}'
+    body: '{"created_at":"2024-02-19T16:52:54.857540Z","dhcp_enabled":true,"id":"250242a9-6b31-4bb7-9251-0244501aa469","name":"tf-tests-ipam-ip-datasource-rdb","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-19T16:52:54.857540Z","id":"ff9b3f58-6386-4d36-b129-d15893f4a12a","subnet":"172.16.0.0/22","updated_at":"2024-02-19T16:52:54.857540Z"},{"created_at":"2024-02-19T16:52:54.857540Z","id":"174c5668-9de8-469c-b32e-3fc254b19fef","subnet":"fd63:256c:45f7:b644::/64","updated_at":"2024-02-19T16:52:54.857540Z"}],"tags":[],"updated_at":"2024-02-19T16:52:54.857540Z","vpc_id":"431c4e3b-1920-42a5-9c1b-74328ab04684"}'
     headers:
       Content-Length:
-      - "714"
+      - "731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:09 GMT
+      - Mon, 19 Feb 2024 16:55:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -597,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 005e6628-4a29-4b32-8101-1dd62feb8b94
+      - 0a96734d-83e2-4fc1-95ab-43f30d38f13a
     status: 200 OK
     code: 200
     duration: ""
@@ -606,23 +573,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1342"
+      - "1392"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:09 GMT
+      - Mon, 19 Feb 2024 16:55:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -630,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d55da51-6b1c-45f9-aed3-1f3d9e650243
+      - a512cf9b-5a98-4d2f-aacf-0e3616ee410a
     status: 200 OK
     code: 200
     duration: ""
@@ -639,23 +606,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYVENDQWtXZ0F3SUJBZ0lVVW4zZWc3T3YydCs0Wm5laHp5VFk5UU55S0xnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTR3TGpJd0hoY05Nak14Ck1qRTRNVEkwTnpJd1doY05Nek14TWpFMU1USTBOekl3V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpBdU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFQT2U3ei9RWThnM0NVSHVBSnFPY2xDVjY4aVVYWU10RFRHY0hCMGZCSUo2UkdzQUdSQm5zUlhtWS95RzlTZVAKUDEwSU15QTFWZHlRZHhVMVhCaXhjVVROa1haNFdWR3M2a0dRblRNVmVONzRhL2lJdWN4QnZXaWtPckROVG41NAowWFdsWTJnQjNDYUF5ZkxBQ1g4V1J3NnNRM3JDRnl3Z1pwWTA0My9TMkpqZWRqVHhEaFZRcTRRaHlFMWsxY3NPCjhWMjR2VUJwdVdvc055TWliWGt1V28vbDFMS2paQ2hjcFUvU0VGZ3EwdFd1S0QrRVdmcXMzaUxqczh5N3hPcUYKZVZHMFhWQXN2REZCclFZckptQ3B5ZEkxL21ZL3ZlY1NoaFZwUTZlTU1hdE1jSWg5RUlnR1BQa0hUUTNUWUQ5aQpqbSt1eGF1b3ZNam1lTGpYUlZHdFRFVUNBd0VBQWFNbE1DTXdJUVlEVlIwUkJCb3dHSUlLTVRjeUxqRTJMakF1Ck1vY0VNdytNa0ljRXJCQUFBakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBbnZGeW0vMDlVY3RkdnByeXJabkgKMllTK1ZXWmhEYkRRMnh3TjZwUHo5Nm13Qmpka0owU0Ivb3Q2UWR2OUxuUmFtQmJIdk5yZmxhZ3FTZkxtQmNENgpjVGtweG5SaGYrdHRiODQ4NzZCMkhhR3IyWHZDM2QwbjdkQ2tjbGVpUFR0OVluNk9PcWhOSHU2NXg3MEgzbUhZCllYQjF2TXdkUVVoNStxbWVBQjE5N1puc0ZSQWpqWDBEUWdpcWEveXVqTjhsLzJCUFZzWHJwbVprdUNNNGk3dDkKZGh5QTlmYVd3dEkyUzF2SUdvZmdia3FJS2VsS0dWdEM4amF1Y09lV1NQMXlSSXE1S2ZRTG1VekNJbWhQVnVGawpVYm5LQkRQTGlpS0tPYytrd28yV2FIMElFRVQxWU9FQ1drUnA3OHlvWUQrMXAxVXp2UnV4MkszeGNPUFRKNFlYCi9nPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURYVENDQWtXZ0F3SUJBZ0lVS2JpWXI1aGJpZGpuMDlDUWwveTlpSWlGMmFVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RXpBUkJnTlZCQU1NQ2pFM01pNHhOaTR3TGpJd0hoY05NalF3Ck1qRTVNVFkxTkRBd1doY05NelF3TWpFMk1UWTFOREF3V2pCVk1Rc3dDUVlEVlFRR0V3SkdVakVPTUF3R0ExVUUKQ0F3RlVHRnlhWE14RGpBTUJnTlZCQWNNQlZCaGNtbHpNUkV3RHdZRFZRUUtEQWhUWTJGc1pYZGhlVEVUTUJFRwpBMVVFQXd3S01UY3lMakUyTGpBdU1qQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCCkFLMVFHdTRZcmlqb1VGenNQdS92Wm1pU0diMWw1NUZQRENPWVBGTnRNZktmNzI2ZWlTV1F0M0xsblIvWDNuV24KTk5jQ3lQUmdlSFcvcVdaekx6cFBtS0lrLzVTTktLbUhFZTlEU3ZNT3NESGExakVRTnM2Znd4RXJpTTlPekhYQgpzTmt0cDh0TzZXSTlTUlRNN3l6K2pFbzg1SE9ONkRGVDBkQ2xhUkF0TkM5cWJSN0hYMHpVa2ZRVjkzM05NZnhkCk9nNW1YT3FyODJkVTBGN2pDaGk0bHowblNrOW16QnY4MHo1eDl3WCt2UnVmV09DK1FtSXFrb0hXb0xyL0JBYWoKZ3Y2TU1uNWU2MTZ5NDVTVC9uYzBPS1kvL0twamV4SGIwTDVCQitFaHVCc0xzZFFUcWNPR2xRaTZEd2dCYjQ5dQpGSExjcjZGN0ZBdG8rZUYvb3hFMDVha0NBd0VBQWFNbE1DTXdJUVlEVlIwUkJCb3dHSUlLTVRjeUxqRTJMakF1Ck1vY0VNNTVMMW9jRXJCQUFBakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBanR2d2pwZm11dUlTU3NSZER5aEYKM1MzRVVJNk1rYUJtZjdBdktZcmhpZ2FUWEhENEpZVzAvZk5vT2lXczhaejNWVVNaVHM0QkxjZ3ZZek5Gd0ZVMQpUSkRMRVB0MTYzd2hzNDMyaEQ4ZjhBQXlTMHIzdjdYRGs4L2NCdzlyWkV1eE9wd3VNQ2tBUThMUS9HclMySXNrCnJ0a2MyTENGSnNyT0RveTJvTWUwaytjM2IycWg5U0hBNDQrSDkwaUYxandFaDF1RUNvcHREckRRemZuV1dXRDUKSDMwU2JMQ25vb2NoN0ZYT3NxK0lXNDU4K2pWb3EwWHIrK1l2Y2pScGNhbGpuWHlqTU4wKzRsZW5FL0s0L0lwSgpVZXI1RHZlTXNnaGtRWm9GdFBXSGVaT1hRMkdTUnViRFV2MHJTL1RnZVZzTXpxS2lLa3dnWDd4T0tQN0R4cWhqClVRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1719"
+      - "1721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:09 GMT
+      - Mon, 19 Feb 2024 16:55:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -663,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0453534-6c01-4165-96ae-4e5ba7ffcb4a
+      - a770735f-04be-44bd-be2d-df33baaa51cd
     status: 200 OK
     code: 200
     duration: ""
@@ -672,23 +639,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=2a378d73-f50b-411b-bba4-1b7aca9bb371&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2024-02-19T16:52:56.106802Z","id":"5733d293-c580-473b-8c7c-d26ec182110c","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","mac_address":"02:00:00:18:7E:2F","name":"test-ipam-ip-rdb","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ff9b3f58-6386-4d36-b129-d15893f4a12a"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-19T16:53:28.369571Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "512"
+      - "542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:09 GMT
+      - Mon, 19 Feb 2024 16:55:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -696,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a537215e-ccab-4009-ac12-f8cb72724ce7
+      - 1803b331-a8f4-453b-9ee4-062f4ea477f3
     status: 200 OK
     code: 200
     duration: ""
@@ -705,23 +672,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-ipam-ip-rdb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2024-02-19T16:52:56.106802Z","id":"5733d293-c580-473b-8c7c-d26ec182110c","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","mac_address":"02:00:00:18:7E:2F","name":"test-ipam-ip-rdb","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ff9b3f58-6386-4d36-b129-d15893f4a12a"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-19T16:53:28.369571Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "512"
+      - "542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:09 GMT
+      - Mon, 19 Feb 2024 16:55:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -729,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5b334e8-f5d3-455b-bc84-b461cc2e65a6
+      - d67943f8-04ae-41d1-8334-bc190ce28e65
     status: 200 OK
     code: 200
     duration: ""
@@ -738,23 +705,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_name=test-ipam-ip-rdb&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2023-12-18T12:46:05.811361Z","id":"4ff1153d-85f1-4f0e-a44e-3ac1bc475ec4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","mac_address":"02:00:00:15:A9:CF","name":"test-ipam-ip-rdb","type":"rdb_instance"},"source":{"subnet_id":"49a10f5a-c23a-4410-8958-f170775c7f2f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T12:46:48.039822Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.0.2/22","created_at":"2024-02-19T16:52:56.106802Z","id":"5733d293-c580-473b-8c7c-d26ec182110c","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","mac_address":"02:00:00:18:7E:2F","name":"test-ipam-ip-rdb","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ff9b3f58-6386-4d36-b129-d15893f4a12a"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-19T16:53:28.369571Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "512"
+      - "542"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:10 GMT
+      - Mon, 19 Feb 2024 16:55:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -762,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d37c15bd-675c-4604-a61b-b03818466141
+      - eba84667-843d-434d-96d5-19af823ad2dc
     status: 200 OK
     code: 200
     duration: ""
@@ -771,23 +738,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1342"
+      - "1392"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:10 GMT
+      - Mon, 19 Feb 2024 16:55:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -795,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0547a1a3-4def-4176-916b-558246aec9b4
+      - 10012e44-947f-46e5-ad41-f401468408b6
     status: 200 OK
     code: 200
     duration: ""
@@ -804,23 +771,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1345"
+      - "1395"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:10 GMT
+      - Mon, 19 Feb 2024 16:55:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -828,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98b18d7a-4f84-4240-bff4-b823653bcf35
+      - a4064783-53e2-4120-86ad-bbfb77b51821
     status: 200 OK
     code: 200
     duration: ""
@@ -837,23 +804,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T12:46:05.393376Z","endpoint":null,"endpoints":[{"id":"8892b635-fdc4-4314-ac84-ebec2028721b","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"6f74ab79-2409-4233-a401-b7877b374a49","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"764c6bb3-2f1c-4f1a-bfd5-82c540ac435c","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-19T16:52:55.739028Z","endpoint":null,"endpoints":[{"id":"262db9e4-99d2-47d6-a53b-09111a7c6bf8","ip":"172.16.0.2","name":null,"port":5432,"private_network":{"private_network_id":"250242a9-6b31-4bb7-9251-0244501aa469","service_ip":"172.16.0.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-14","id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-ipam-ip-rdb","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[{"id":"01ea6b82-47cd-4237-892d-0a882e686223","minor_version":"15.5","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1345"
+      - "1395"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:10 GMT
+      - Mon, 19 Feb 2024 16:55:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -861,7 +828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb92c769-c018-4ce1-b52b-95fef0b6d0ca
+      - b7de53ba-c3bc-4795-99a7-16856f908240
     status: 200 OK
     code: 200
     duration: ""
@@ -870,12 +837,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -884,9 +851,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:41 GMT
+      - Mon, 19 Feb 2024 16:56:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -894,7 +861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbc78e10-c72c-4ea0-8819-c105208de5c9
+      - 087268bb-91b7-4ce1-b3a7-a4cb04200626
     status: 404 Not Found
     code: 404
     duration: ""
@@ -903,9 +870,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6f74ab79-2409-4233-a401-b7877b374a49
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/250242a9-6b31-4bb7-9251-0244501aa469
     method: DELETE
   response:
     body: ""
@@ -915,9 +882,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:41 GMT
+      - Mon, 19 Feb 2024 16:56:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -925,7 +892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6a1c9a2-6d64-43c4-a905-9838e8110790
+      - 43a1deed-4249-4407-9af3-7d3fa07190d6
     status: 204 No Content
     code: 204
     duration: ""
@@ -934,9 +901,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/42a964fd-008a-4389-9d1d-1e60f3ed22bc
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/431c4e3b-1920-42a5-9c1b-74328ab04684
     method: DELETE
   response:
     body: ""
@@ -946,9 +913,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:42 GMT
+      - Mon, 19 Feb 2024 16:56:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -956,7 +923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca264044-9b8c-420a-bce5-e8fa160d6846
+      - 23466d05-bcd4-4db7-ba85-739bb9ce23c0
     status: 204 No Content
     code: 204
     duration: ""
@@ -965,12 +932,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/2a378d73-f50b-411b-bba4-1b7aca9bb371
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"f4d179bd-9d92-4d5b-9dc3-85fe28ad02b2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"2a378d73-f50b-411b-bba4-1b7aca9bb371","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -979,9 +946,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:49:42 GMT
+      - Mon, 19 Feb 2024 16:56:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-1;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -989,7 +956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8633a68c-bd18-437d-a352-e08d32104422
+      - 65b22082-92db-4e51-af89-d31da100e32e
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-endpoints.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-endpoints.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,9 +318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:05 GMT
+      - Tue, 20 Feb 2024 14:07:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,34 +328,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61ddc428-7202-4133-9469-5729b47b260c
+      - c96429d1-0513-4309-8b2d-f398d36f5cf3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-rdb-endpoints","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"test-rdb-endpoints","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:16 GMT
+      - Tue, 20 Feb 2024 14:07:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e328114-8914-4c44-b1df-67afadf05030
+      - 33c4a2dc-77dd-4dc6-b7f2-a9c6d5255b29
     status: 200 OK
     code: 200
     duration: ""
@@ -372,23 +372,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:16 GMT
+      - Tue, 20 Feb 2024 14:07:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -396,34 +396,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7871c9fa-5a6e-4490-8c7f-51b9233e8e4a
+      - d42054c0-b0a3-4d80-893e-1d6d67889563
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","ipam_config":{}}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","ipam_config":{}}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "983"
+      - "1016"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:17 GMT
+      - Tue, 20 Feb 2024 14:07:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -431,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48591651-2f7a-4f56-b713-f2649c49d8d8
+      - c64253e8-0b45-4f53-b962-8f4b6ca86f1c
     status: 200 OK
     code: 200
     duration: ""
@@ -440,23 +440,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "983"
+      - "1016"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:18 GMT
+      - Tue, 20 Feb 2024 14:07:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -464,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01758275-ff9b-4517-b9d0-dac1bc983039
+      - cd4f664b-769c-4654-a1af-990a5f196d82
     status: 200 OK
     code: 200
     duration: ""
@@ -473,23 +473,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "983"
+      - "1016"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:48 GMT
+      - Tue, 20 Feb 2024 14:08:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27b6a23a-5b0c-478c-bcad-1a476cf98e9b
+      - 10823150-c69f-4db4-9d84-64392af5c342
     status: 200 OK
     code: 200
     duration: ""
@@ -506,23 +506,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "983"
+      - "1016"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:18 GMT
+      - Tue, 20 Feb 2024 14:08:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a97e3cfe-29a0-4c6c-a629-dce372e968a3
+      - b0007a2e-f050-419d-aa10-7e5df989efd5
     status: 200 OK
     code: 200
     duration: ""
@@ -539,23 +539,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "983"
+      - "1016"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:52 GMT
+      - Tue, 20 Feb 2024 14:09:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ca8b82c-11b4-4e48-b922-c90fec8138c7
+      - 0c8bdba7-04aa-4bbb-abbf-982b246b591d
     status: 200 OK
     code: 200
     duration: ""
@@ -572,23 +572,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "983"
+      - "1016"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Tue, 20 Feb 2024 14:09:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df7b6570-0076-4de9-b4a1-7221921ca98f
+      - ddc84cee-9bc6-42a2-983d-f6648fb119f4
     status: 200 OK
     code: 200
     duration: ""
@@ -605,23 +605,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "983"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:53 GMT
+      - Tue, 20 Feb 2024 14:10:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b4933f6-e283-462a-8ecb-174026859bbc
+      - 897e3f8f-3372-448e-a6d4-edfa2de6d716
     status: 200 OK
     code: 200
     duration: ""
@@ -638,23 +638,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVWlJiaitWeDBoMjdHV0plMFZnOVRGYy9WT3hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEkwCk1ESXlNREUwTURnME4xb1hEVE0wTURJeE56RTBNRGcwTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFvSzNKZnBTM21LTjYzZU9JRlJCNnN3WDRoeEx2a1djaDM1Y3RHbUJOVkdvakt2NEJtQjdwVVptdFJhMEYKRGRBMEZ5NmFUazBOS3ZObXh3L2Z2dnlxUjNOOHBTbWtzc0NFdE53d3NmZXJLR1l5S0Y4STRtb3lhKythQldPRApDbTNqcEhEcjVRUTBIbU9Lb2p4QlVBZG1MR3BGMnUxYmprMDBqNTV0TnJEQnk4eWRNRWlYUmhaVEtlcmVCcUpqCm54UEFFOTBmelR2Ukx0K0xuQ2RIakNuZnl0WUJkK3ZNSW52U0U0dmQ5Y1NFYWFRTDFoemFBVEFZTkdPMSt3RDUKV0xpdzJoTGh1QWJ1T1Y5YS9IdGVJQWVheTJLcnRtVWJsY1p5MjFOWEVxWnRMUmtKaFExVXVoWE9PU0t6cTdUTwpwRDRjUHg4VHQza2V2V0ptL3JKNysxK3Zud0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qUXVNb2NFTTU1K3lJY0VyQkFZQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpXSlh4ZmJTbGFXeTNEMGQKblU5VUlLTnR4RExFdmhqWnd3VlB6cnowNWZ0RXBXZUFwcUhrTVhsRTU3ZU85RmtzdUcwZFN2bnd6cDgzUmVQSQprSzBVVndtMUNxM0xCUGg2N2FmYWJoK1U1V3B6WWx5cUI2dmgzMll4SGFiRlRjeE1QSUZuQ1VpTGpKR2JSOEJpClNwRjVYaExHMndzSzVoRmIrTkVPd3NsSEprM2oxcStNV255REhra0g4VEJWYVJma2w4QlNRRnhLSjhSTUpFSUwKcnR5Ym5BVitLMUFaSjhQVUE3VUYrRkJNeGZhZzZ5WVBPYXR0N3FiZCtXdWhFb0Npa3hRSHZHRlViQnhLbXR5ZQpVNGUrbGpOS1RQbEM4N2VzWk9DcTRCYlk5NU5OODFvY3V2R216YlBCY1NFYjJDVS9HREprQVY3ZHVpM21nV052Cmc5RnhxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1240"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:23 GMT
+      - Tue, 20 Feb 2024 14:10:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6017e57-bae3-4769-ac1e-0e77ba88ea80
+      - 763b10e6-3eab-47ba-9691-831dc95a47bf
     status: 200 OK
     code: 200
     duration: ""
@@ -671,23 +671,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f5d5030c-716e-4800-b495-c39be3c06b66&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-20T14:07:43.689923Z","id":"a1f3843d-a3d1-4399-a128-a714772842d1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"f5d5030c-716e-4800-b495-c39be3c06b66","mac_address":"02:00:00:18:83:50","name":"test-rdb-endpoints","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:15.420365Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1731"
+      - "545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:23 GMT
+      - Tue, 20 Feb 2024 14:10:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 986c10bf-305f-470c-84f4-cf0419981552
+      - ab9693f7-cc10-4412-8c43-9a9c1c0560a9
     status: 200 OK
     code: 200
     duration: ""
@@ -704,23 +704,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "516"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:23 GMT
+      - Tue, 20 Feb 2024 14:10:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74803641-69be-41dc-8895-266fd6c0efd9
+      - af362db4-12ea-49c2-96ef-4dbda2dd19e6
     status: 200 OK
     code: 200
     duration: ""
@@ -737,23 +737,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1240"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:24 GMT
+      - Tue, 20 Feb 2024 14:10:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62c468a1-a20a-4513-b6fa-267aad4654c1
+      - 145af33b-6a81-46ef-a2f0-7794cc243e9b
     status: 200 OK
     code: 200
     duration: ""
@@ -770,23 +770,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:24 GMT
+      - Tue, 20 Feb 2024 14:10:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09283d10-bf04-4e04-821d-cddf556a1797
+      - 03807612-fdef-4f4c-ad46-11e8291d8efa
     status: 200 OK
     code: 200
     duration: ""
@@ -803,23 +803,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "703"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:24 GMT
+      - Tue, 20 Feb 2024 14:10:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf65c333-ef5f-4c29-b2f1-b3fb0e53577a
+      - 7e6504f9-8090-45b4-8470-de25cbd19fa7
     status: 200 OK
     code: 200
     duration: ""
@@ -836,23 +836,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVWlJiaitWeDBoMjdHV0plMFZnOVRGYy9WT3hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEkwCk1ESXlNREUwTURnME4xb1hEVE0wTURJeE56RTBNRGcwTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFvSzNKZnBTM21LTjYzZU9JRlJCNnN3WDRoeEx2a1djaDM1Y3RHbUJOVkdvakt2NEJtQjdwVVptdFJhMEYKRGRBMEZ5NmFUazBOS3ZObXh3L2Z2dnlxUjNOOHBTbWtzc0NFdE53d3NmZXJLR1l5S0Y4STRtb3lhKythQldPRApDbTNqcEhEcjVRUTBIbU9Lb2p4QlVBZG1MR3BGMnUxYmprMDBqNTV0TnJEQnk4eWRNRWlYUmhaVEtlcmVCcUpqCm54UEFFOTBmelR2Ukx0K0xuQ2RIakNuZnl0WUJkK3ZNSW52U0U0dmQ5Y1NFYWFRTDFoemFBVEFZTkdPMSt3RDUKV0xpdzJoTGh1QWJ1T1Y5YS9IdGVJQWVheTJLcnRtVWJsY1p5MjFOWEVxWnRMUmtKaFExVXVoWE9PU0t6cTdUTwpwRDRjUHg4VHQza2V2V0ptL3JKNysxK3Zud0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qUXVNb2NFTTU1K3lJY0VyQkFZQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpXSlh4ZmJTbGFXeTNEMGQKblU5VUlLTnR4RExFdmhqWnd3VlB6cnowNWZ0RXBXZUFwcUhrTVhsRTU3ZU85RmtzdUcwZFN2bnd6cDgzUmVQSQprSzBVVndtMUNxM0xCUGg2N2FmYWJoK1U1V3B6WWx5cUI2dmgzMll4SGFiRlRjeE1QSUZuQ1VpTGpKR2JSOEJpClNwRjVYaExHMndzSzVoRmIrTkVPd3NsSEprM2oxcStNV255REhra0g4VEJWYVJma2w4QlNRRnhLSjhSTUpFSUwKcnR5Ym5BVitLMUFaSjhQVUE3VUYrRkJNeGZhZzZ5WVBPYXR0N3FiZCtXdWhFb0Npa3hRSHZHRlViQnhLbXR5ZQpVNGUrbGpOS1RQbEM4N2VzWk9DcTRCYlk5NU5OODFvY3V2R216YlBCY1NFYjJDVS9HREprQVY3ZHVpM21nV052Cmc5RnhxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1240"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:24 GMT
+      - Tue, 20 Feb 2024 14:10:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9aa84655-47a9-4078-b992-2303ee1d9a20
+      - b83e9cb4-1d36-40d1-b76b-6effcc9af877
     status: 200 OK
     code: 200
     duration: ""
@@ -869,23 +869,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f5d5030c-716e-4800-b495-c39be3c06b66&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-20T14:07:43.689923Z","id":"a1f3843d-a3d1-4399-a128-a714772842d1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"f5d5030c-716e-4800-b495-c39be3c06b66","mac_address":"02:00:00:18:83:50","name":"test-rdb-endpoints","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:15.420365Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1731"
+      - "545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:25 GMT
+      - Tue, 20 Feb 2024 14:10:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 373d0a1e-c011-442c-a55d-66917337e369
+      - 86e42513-228c-47ee-b4ea-1633a321450d
     status: 200 OK
     code: 200
     duration: ""
@@ -902,23 +902,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "516"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:25 GMT
+      - Tue, 20 Feb 2024 14:10:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1385ace5-bcd6-43d3-9912-7237d8805f78
+      - 65dbf134-4cfe-4883-a533-f1adcaa42f82
     status: 200 OK
     code: 200
     duration: ""
@@ -935,23 +935,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "703"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:25 GMT
+      - Tue, 20 Feb 2024 14:10:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1c76667-2ca2-4929-8e79-478bc4f88a93
+      - df89e7c6-ddd9-42cf-ad0f-334f9c280309
     status: 200 OK
     code: 200
     duration: ""
@@ -968,23 +968,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVWlJiaitWeDBoMjdHV0plMFZnOVRGYy9WT3hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEkwCk1ESXlNREUwTURnME4xb1hEVE0wTURJeE56RTBNRGcwTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFvSzNKZnBTM21LTjYzZU9JRlJCNnN3WDRoeEx2a1djaDM1Y3RHbUJOVkdvakt2NEJtQjdwVVptdFJhMEYKRGRBMEZ5NmFUazBOS3ZObXh3L2Z2dnlxUjNOOHBTbWtzc0NFdE53d3NmZXJLR1l5S0Y4STRtb3lhKythQldPRApDbTNqcEhEcjVRUTBIbU9Lb2p4QlVBZG1MR3BGMnUxYmprMDBqNTV0TnJEQnk4eWRNRWlYUmhaVEtlcmVCcUpqCm54UEFFOTBmelR2Ukx0K0xuQ2RIakNuZnl0WUJkK3ZNSW52U0U0dmQ5Y1NFYWFRTDFoemFBVEFZTkdPMSt3RDUKV0xpdzJoTGh1QWJ1T1Y5YS9IdGVJQWVheTJLcnRtVWJsY1p5MjFOWEVxWnRMUmtKaFExVXVoWE9PU0t6cTdUTwpwRDRjUHg4VHQza2V2V0ptL3JKNysxK3Zud0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qUXVNb2NFTTU1K3lJY0VyQkFZQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpXSlh4ZmJTbGFXeTNEMGQKblU5VUlLTnR4RExFdmhqWnd3VlB6cnowNWZ0RXBXZUFwcUhrTVhsRTU3ZU85RmtzdUcwZFN2bnd6cDgzUmVQSQprSzBVVndtMUNxM0xCUGg2N2FmYWJoK1U1V3B6WWx5cUI2dmgzMll4SGFiRlRjeE1QSUZuQ1VpTGpKR2JSOEJpClNwRjVYaExHMndzSzVoRmIrTkVPd3NsSEprM2oxcStNV255REhra0g4VEJWYVJma2w4QlNRRnhLSjhSTUpFSUwKcnR5Ym5BVitLMUFaSjhQVUE3VUYrRkJNeGZhZzZ5WVBPYXR0N3FiZCtXdWhFb0Npa3hRSHZHRlViQnhLbXR5ZQpVNGUrbGpOS1RQbEM4N2VzWk9DcTRCYlk5NU5OODFvY3V2R216YlBCY1NFYjJDVS9HREprQVY3ZHVpM21nV052Cmc5RnhxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1240"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:25 GMT
+      - Tue, 20 Feb 2024 14:10:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a0c9dff-8dc2-4000-ac69-c118652ecd34
+      - 740a64fe-3b70-4859-ab20-96b3cb6888bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1001,23 +1001,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f5d5030c-716e-4800-b495-c39be3c06b66&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-20T14:07:43.689923Z","id":"a1f3843d-a3d1-4399-a128-a714772842d1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"f5d5030c-716e-4800-b495-c39be3c06b66","mac_address":"02:00:00:18:83:50","name":"test-rdb-endpoints","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:15.420365Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1731"
+      - "545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:25 GMT
+      - Tue, 20 Feb 2024 14:10:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1025,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30bed6f1-1f9e-4523-9988-8fe2aad15749
+      - 3372a3e9-46b5-4ea0-8b27-4003ed361937
     status: 200 OK
     code: 200
     duration: ""
@@ -1034,23 +1034,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "516"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:25 GMT
+      - Tue, 20 Feb 2024 14:10:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1058,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd4dcd86-8283-40ee-ab6b-da4100ccf794
+      - d69a5ef3-02e0-4d71-a134-63ab4650103d
     status: 200 OK
     code: 200
     duration: ""
@@ -1067,23 +1067,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1240"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:26 GMT
+      - Tue, 20 Feb 2024 14:10:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1091,40 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 412f6739-4162-459d-8988-1637cd2f4793
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1240"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:13:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f8b5b63c-20f5-4796-a5b2-4bbb5287904d
+      - 2fbcccd6-ee36-4ea2-89a2-b96012f793f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,23 +1102,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1240"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:26 GMT
+      - Tue, 20 Feb 2024 14:10:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1159,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 473638fb-45e6-4ab5-8626-0e8cb1e0f2a5
+      - f187cc95-e968-4f66-8b40-61d5a4b3e35c
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,23 +1135,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1240"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:26 GMT
+      - Tue, 20 Feb 2024 14:10:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1192,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f6eb063-c28a-4c2d-8b52-4fbbaf467f6a
+      - 50d0be46-5ccb-4c4b-a53e-0395434a5489
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,23 +1168,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1240"
+      - "1284"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:30 GMT
+      - Tue, 20 Feb 2024 14:10:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1225,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b835e50-d041-4cb5-b695-65bc894a3d05
+      - c943f2b0-86b4-49d3-9e37-424480363aaf
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,23 +1203,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/endpoints
     method: POST
   response:
     body: '{"id":"","name":null,"port":0}'
     headers:
       Content-Length:
-      - "30"
+      - "32"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:32 GMT
+      - Tue, 20 Feb 2024 14:10:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1260,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab6b32f0-3047-447d-86ff-7f2aab3fc9c0
+      - 21240ddd-5fa3-4fc3-8e9d-93b1edbab5bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,23 +1236,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":null,"endpoints":[{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":null,"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1247"
+      - "1291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:33 GMT
+      - Tue, 20 Feb 2024 14:10:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1293,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a12c581c-e913-4783-95ba-a9bc38563ea6
+      - 94837b3a-00c2-48be-9a2b-56fbdd4dc4de
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,23 +1269,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:03 GMT
+      - Tue, 20 Feb 2024 14:11:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1326,7 +1293,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff90b403-7eb4-4bdd-931a-05ec5cb32152
+      - f5fb4cd9-40d1-4993-a9f5-1ff404c1b3b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,23 +1302,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVWlJiaitWeDBoMjdHV0plMFZnOVRGYy9WT3hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEkwCk1ESXlNREUwTURnME4xb1hEVE0wTURJeE56RTBNRGcwTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFvSzNKZnBTM21LTjYzZU9JRlJCNnN3WDRoeEx2a1djaDM1Y3RHbUJOVkdvakt2NEJtQjdwVVptdFJhMEYKRGRBMEZ5NmFUazBOS3ZObXh3L2Z2dnlxUjNOOHBTbWtzc0NFdE53d3NmZXJLR1l5S0Y4STRtb3lhKythQldPRApDbTNqcEhEcjVRUTBIbU9Lb2p4QlVBZG1MR3BGMnUxYmprMDBqNTV0TnJEQnk4eWRNRWlYUmhaVEtlcmVCcUpqCm54UEFFOTBmelR2Ukx0K0xuQ2RIakNuZnl0WUJkK3ZNSW52U0U0dmQ5Y1NFYWFRTDFoemFBVEFZTkdPMSt3RDUKV0xpdzJoTGh1QWJ1T1Y5YS9IdGVJQWVheTJLcnRtVWJsY1p5MjFOWEVxWnRMUmtKaFExVXVoWE9PU0t6cTdUTwpwRDRjUHg4VHQza2V2V0ptL3JKNysxK3Zud0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qUXVNb2NFTTU1K3lJY0VyQkFZQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpXSlh4ZmJTbGFXeTNEMGQKblU5VUlLTnR4RExFdmhqWnd3VlB6cnowNWZ0RXBXZUFwcUhrTVhsRTU3ZU85RmtzdUcwZFN2bnd6cDgzUmVQSQprSzBVVndtMUNxM0xCUGg2N2FmYWJoK1U1V3B6WWx5cUI2dmgzMll4SGFiRlRjeE1QSUZuQ1VpTGpKR2JSOEJpClNwRjVYaExHMndzSzVoRmIrTkVPd3NsSEprM2oxcStNV255REhra0g4VEJWYVJma2w4QlNRRnhLSjhSTUpFSUwKcnR5Ym5BVitLMUFaSjhQVUE3VUYrRkJNeGZhZzZ5WVBPYXR0N3FiZCtXdWhFb0Npa3hRSHZHRlViQnhLbXR5ZQpVNGUrbGpOS1RQbEM4N2VzWk9DcTRCYlk5NU5OODFvY3V2R216YlBCY1NFYjJDVS9HREprQVY3ZHVpM21nV052Cmc5RnhxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1731"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:03 GMT
+      - Tue, 20 Feb 2024 14:11:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1359,7 +1326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d308e33f-95d1-4334-82c4-100ed8faef13
+      - 94d1239c-1a50-49da-97aa-754eb04839d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,23 +1335,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f5d5030c-716e-4800-b495-c39be3c06b66&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-20T14:07:43.689923Z","id":"a1f3843d-a3d1-4399-a128-a714772842d1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"f5d5030c-716e-4800-b495-c39be3c06b66","mac_address":"02:00:00:18:83:50","name":"test-rdb-endpoints","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:15.420365Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "516"
+      - "545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:03 GMT
+      - Tue, 20 Feb 2024 14:11:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1392,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e253845-183f-418b-b2e2-dd2285008e70
+      - 2516d601-f139-4a45-8fa0-b0deac2a017a
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,23 +1368,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:03 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1425,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5eecc60b-f399-4b4f-96e3-11b02a433a93
+      - 4132292c-163c-4c81-ad4a-97421449cf43
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,23 +1401,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:03 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1458,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e6f7a33-c89f-4b5e-8192-e3b5ec8ae4b7
+      - 9d9a6169-4a45-497a-bde4-81f5e75c3fce
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,23 +1434,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:03 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1491,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a67c81f2-9514-457c-b01f-6d080ea8d170
+      - 8e4fa045-fd62-4cde-86da-c4d4839a9805
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,23 +1467,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:04 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1524,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39e0cef1-4f30-421e-a290-e35876d65fe9
+      - c97c06e1-c14d-4117-907a-1cc32eb238c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1533,23 +1500,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVWlJiaitWeDBoMjdHV0plMFZnOVRGYy9WT3hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEkwCk1ESXlNREUwTURnME4xb1hEVE0wTURJeE56RTBNRGcwTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFvSzNKZnBTM21LTjYzZU9JRlJCNnN3WDRoeEx2a1djaDM1Y3RHbUJOVkdvakt2NEJtQjdwVVptdFJhMEYKRGRBMEZ5NmFUazBOS3ZObXh3L2Z2dnlxUjNOOHBTbWtzc0NFdE53d3NmZXJLR1l5S0Y4STRtb3lhKythQldPRApDbTNqcEhEcjVRUTBIbU9Lb2p4QlVBZG1MR3BGMnUxYmprMDBqNTV0TnJEQnk4eWRNRWlYUmhaVEtlcmVCcUpqCm54UEFFOTBmelR2Ukx0K0xuQ2RIakNuZnl0WUJkK3ZNSW52U0U0dmQ5Y1NFYWFRTDFoemFBVEFZTkdPMSt3RDUKV0xpdzJoTGh1QWJ1T1Y5YS9IdGVJQWVheTJLcnRtVWJsY1p5MjFOWEVxWnRMUmtKaFExVXVoWE9PU0t6cTdUTwpwRDRjUHg4VHQza2V2V0ptL3JKNysxK3Zud0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qUXVNb2NFTTU1K3lJY0VyQkFZQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpXSlh4ZmJTbGFXeTNEMGQKblU5VUlLTnR4RExFdmhqWnd3VlB6cnowNWZ0RXBXZUFwcUhrTVhsRTU3ZU85RmtzdUcwZFN2bnd6cDgzUmVQSQprSzBVVndtMUNxM0xCUGg2N2FmYWJoK1U1V3B6WWx5cUI2dmgzMll4SGFiRlRjeE1QSUZuQ1VpTGpKR2JSOEJpClNwRjVYaExHMndzSzVoRmIrTkVPd3NsSEprM2oxcStNV255REhra0g4VEJWYVJma2w4QlNRRnhLSjhSTUpFSUwKcnR5Ym5BVitLMUFaSjhQVUE3VUYrRkJNeGZhZzZ5WVBPYXR0N3FiZCtXdWhFb0Npa3hRSHZHRlViQnhLbXR5ZQpVNGUrbGpOS1RQbEM4N2VzWk9DcTRCYlk5NU5OODFvY3V2R216YlBCY1NFYjJDVS9HREprQVY3ZHVpM21nV052Cmc5RnhxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1731"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:04 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1557,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b13bed2-549a-4ede-97da-219e9a2e725b
+      - d4ffa83a-ca38-48ec-86fe-7869c2fb9da2
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,23 +1533,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f5d5030c-716e-4800-b495-c39be3c06b66&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-20T14:07:43.689923Z","id":"a1f3843d-a3d1-4399-a128-a714772842d1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"f5d5030c-716e-4800-b495-c39be3c06b66","mac_address":"02:00:00:18:83:50","name":"test-rdb-endpoints","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:15.420365Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "516"
+      - "545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:04 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1590,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f203573-46e4-491c-b35c-58234db8c0dc
+      - 17565b5d-3dfc-4e3a-946e-e1b73695e631
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,23 +1566,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "703"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:04 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1623,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad3936c9-5d20-4912-84c7-0f5076f2d236
+      - 960cc31e-4f16-41c9-b8fe-9045326fcd7e
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,23 +1599,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:04 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1656,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2f8ff26-c90d-4f3b-88b9-d0e7f2bdbb2b
+      - 45a43440-efc9-4dd7-82b3-cf92bdb9b670
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,23 +1632,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVWlJiaitWeDBoMjdHV0plMFZnOVRGYy9WT3hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEkwCk1ESXlNREUwTURnME4xb1hEVE0wTURJeE56RTBNRGcwTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFvSzNKZnBTM21LTjYzZU9JRlJCNnN3WDRoeEx2a1djaDM1Y3RHbUJOVkdvakt2NEJtQjdwVVptdFJhMEYKRGRBMEZ5NmFUazBOS3ZObXh3L2Z2dnlxUjNOOHBTbWtzc0NFdE53d3NmZXJLR1l5S0Y4STRtb3lhKythQldPRApDbTNqcEhEcjVRUTBIbU9Lb2p4QlVBZG1MR3BGMnUxYmprMDBqNTV0TnJEQnk4eWRNRWlYUmhaVEtlcmVCcUpqCm54UEFFOTBmelR2Ukx0K0xuQ2RIakNuZnl0WUJkK3ZNSW52U0U0dmQ5Y1NFYWFRTDFoemFBVEFZTkdPMSt3RDUKV0xpdzJoTGh1QWJ1T1Y5YS9IdGVJQWVheTJLcnRtVWJsY1p5MjFOWEVxWnRMUmtKaFExVXVoWE9PU0t6cTdUTwpwRDRjUHg4VHQza2V2V0ptL3JKNysxK3Zud0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qUXVNb2NFTTU1K3lJY0VyQkFZQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpXSlh4ZmJTbGFXeTNEMGQKblU5VUlLTnR4RExFdmhqWnd3VlB6cnowNWZ0RXBXZUFwcUhrTVhsRTU3ZU85RmtzdUcwZFN2bnd6cDgzUmVQSQprSzBVVndtMUNxM0xCUGg2N2FmYWJoK1U1V3B6WWx5cUI2dmgzMll4SGFiRlRjeE1QSUZuQ1VpTGpKR2JSOEJpClNwRjVYaExHMndzSzVoRmIrTkVPd3NsSEprM2oxcStNV255REhra0g4VEJWYVJma2w4QlNRRnhLSjhSTUpFSUwKcnR5Ym5BVitLMUFaSjhQVUE3VUYrRkJNeGZhZzZ5WVBPYXR0N3FiZCtXdWhFb0Npa3hRSHZHRlViQnhLbXR5ZQpVNGUrbGpOS1RQbEM4N2VzWk9DcTRCYlk5NU5OODFvY3V2R216YlBCY1NFYjJDVS9HREprQVY3ZHVpM21nV052Cmc5RnhxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1731"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:04 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1689,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 571198c1-2260-49dd-b291-4079901027fc
+      - a92afac8-ae1e-47e6-9442-b04ddb38e36c
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,23 +1665,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=f5d5030c-716e-4800-b495-c39be3c06b66&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.124.2/22","created_at":"2023-12-18T13:10:17.549784Z","id":"25e87fef-5f03-497f-b598-65be1e2ca3c4","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","mac_address":"02:00:00:15:AA:0D","name":"test-rdb-endpoints","type":"rdb_instance"},"source":{"subnet_id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:10:54.666693Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-20T14:07:43.689923Z","id":"a1f3843d-a3d1-4399-a128-a714772842d1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"f5d5030c-716e-4800-b495-c39be3c06b66","mac_address":"02:00:00:18:83:50","name":"test-rdb-endpoints","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:15.420365Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "516"
+      - "545"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:04 GMT
+      - Tue, 20 Feb 2024 14:11:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1722,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2e64ab7-3866-4b19-a670-c4743b6265ff
+      - 4bf5106b-b241-4b55-ab11-17364c4cd27e
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,23 +1698,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:05 GMT
+      - Tue, 20 Feb 2024 14:11:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1755,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1966cf31-2238-4ec4-b742-127faa698015
+      - b6d39b3d-b9c6-4c61-b9ee-20fac0f2a231
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,23 +1731,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:05 GMT
+      - Tue, 20 Feb 2024 14:11:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1788,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02576053-ebbe-42f9-a54f-c17f09ffacd9
+      - 88edd791-817b-484b-97c4-b531a0c012ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1799,23 +1766,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:05 GMT
+      - Tue, 20 Feb 2024 14:11:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1823,7 +1790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0942bd20-2fd8-42b6-92bc-faec50b73c38
+      - a3fa4712-b608-4f3c-b3d7-6773994cb7fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1832,23 +1799,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1457"
+      - "1512"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:05 GMT
+      - Tue, 20 Feb 2024 14:11:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1856,7 +1823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d89d1dd3-63b7-42f2-b130-290084b8694e
+      - b00b8272-bdb9-4d02-850e-caa0d2f755be
     status: 200 OK
     code: 200
     duration: ""
@@ -1865,9 +1832,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/dbd79c5f-682c-4cc5-9b3a-7bae6e683cde
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/8ce2edf9-7578-465c-80aa-cb96bd10d256
     method: DELETE
   response:
     body: ""
@@ -1877,9 +1844,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:06 GMT
+      - Tue, 20 Feb 2024 14:11:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1887,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3e3bf13-138c-417d-b35c-6ce95a2caa64
+      - d47063bd-9f3c-423c-b7d5-a798a6fd6ac4
     status: 204 No Content
     code: 204
     duration: ""
@@ -1896,23 +1863,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},{"id":"dbd79c5f-682c-4cc5-9b3a-7bae6e683cde","ip":"172.16.124.2","name":null,"port":5432,"private_network":{"private_network_id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","service_ip":"172.16.124.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"8ce2edf9-7578-465c-80aa-cb96bd10d256","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","service_ip":"172.16.24.2/22","zone":"fr-par-1"}},{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1463"
+      - "1518"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:06 GMT
+      - Tue, 20 Feb 2024 14:11:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1920,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0951546f-4ff7-4ec8-a71d-40c4cd78aabe
+      - d7aef85c-e788-4d26-99f9-a5a594ab4e66
     status: 200 OK
     code: 200
     duration: ""
@@ -1929,23 +1896,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1238"
+      - "1288"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:36 GMT
+      - Tue, 20 Feb 2024 14:11:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1953,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9383af9e-a60a-4d05-afb0-5f45fdcdd883
+      - 6ef27292-8b20-4be6-8e33-1d2b077ca3e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1962,23 +1929,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1238"
+      - "1288"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:36 GMT
+      - Tue, 20 Feb 2024 14:11:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1986,7 +1953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 570f7ad9-4da1-4e47-a3d6-04b9a0211ca3
+      - 3378e3e9-adcc-4115-932b-7ca555aee77c
     status: 200 OK
     code: 200
     duration: ""
@@ -1995,23 +1962,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVWlJiaitWeDBoMjdHV0plMFZnOVRGYy9WT3hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEkwCk1ESXlNREUwTURnME4xb1hEVE0wTURJeE56RTBNRGcwTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFvSzNKZnBTM21LTjYzZU9JRlJCNnN3WDRoeEx2a1djaDM1Y3RHbUJOVkdvakt2NEJtQjdwVVptdFJhMEYKRGRBMEZ5NmFUazBOS3ZObXh3L2Z2dnlxUjNOOHBTbWtzc0NFdE53d3NmZXJLR1l5S0Y4STRtb3lhKythQldPRApDbTNqcEhEcjVRUTBIbU9Lb2p4QlVBZG1MR3BGMnUxYmprMDBqNTV0TnJEQnk4eWRNRWlYUmhaVEtlcmVCcUpqCm54UEFFOTBmelR2Ukx0K0xuQ2RIakNuZnl0WUJkK3ZNSW52U0U0dmQ5Y1NFYWFRTDFoemFBVEFZTkdPMSt3RDUKV0xpdzJoTGh1QWJ1T1Y5YS9IdGVJQWVheTJLcnRtVWJsY1p5MjFOWEVxWnRMUmtKaFExVXVoWE9PU0t6cTdUTwpwRDRjUHg4VHQza2V2V0ptL3JKNysxK3Zud0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qUXVNb2NFTTU1K3lJY0VyQkFZQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpXSlh4ZmJTbGFXeTNEMGQKblU5VUlLTnR4RExFdmhqWnd3VlB6cnowNWZ0RXBXZUFwcUhrTVhsRTU3ZU85RmtzdUcwZFN2bnd6cDgzUmVQSQprSzBVVndtMUNxM0xCUGg2N2FmYWJoK1U1V3B6WWx5cUI2dmgzMll4SGFiRlRjeE1QSUZuQ1VpTGpKR2JSOEJpClNwRjVYaExHMndzSzVoRmIrTkVPd3NsSEprM2oxcStNV255REhra0g4VEJWYVJma2w4QlNRRnhLSjhSTUpFSUwKcnR5Ym5BVitLMUFaSjhQVUE3VUYrRkJNeGZhZzZ5WVBPYXR0N3FiZCtXdWhFb0Npa3hRSHZHRlViQnhLbXR5ZQpVNGUrbGpOS1RQbEM4N2VzWk9DcTRCYlk5NU5OODFvY3V2R216YlBCY1NFYjJDVS9HREprQVY3ZHVpM21nV052Cmc5RnhxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1731"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:36 GMT
+      - Tue, 20 Feb 2024 14:11:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2019,7 +1986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7157b578-c169-4030-b1d9-b32fefa6180b
+      - 2ec16c48-58e1-4fd4-848b-6dd634b86ad2
     status: 200 OK
     code: 200
     duration: ""
@@ -2028,23 +1995,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "26"
+      - "1288"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:37 GMT
+      - Tue, 20 Feb 2024 14:11:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2052,7 +2019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62c4129f-aa1a-4394-a8bc-dda240c4e513
+      - 1ab5cbae-0d5a-4ef8-9f37-3c7d0e365509
     status: 200 OK
     code: 200
     duration: ""
@@ -2061,23 +2028,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2024-02-20T14:07:40.963988Z","dhcp_enabled":true,"id":"dfbe6449-bc74-429c-9b7f-52257ab7e48d","name":"test-rdb-endpoints","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:40.963988Z","id":"5d9fb5ca-6cec-4958-9d8a-b2dd410e0670","subnet":"172.16.24.0/22","updated_at":"2024-02-20T14:07:40.963988Z"},{"created_at":"2024-02-20T14:07:40.963988Z","id":"8bdea823-3cfd-41b1-bcf9-eb1bf48ab800","subnet":"fd63:256c:45f7:fdf1::/64","updated_at":"2024-02-20T14:07:40.963988Z"}],"tags":[],"updated_at":"2024-02-20T14:07:40.963988Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1238"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:37 GMT
+      - Tue, 20 Feb 2024 14:11:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2085,7 +2052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69cefdac-3a34-43e0-b571-9de1099034a5
+      - 13c991c8-9e61-4a33-91af-03d06d113b5f
     status: 200 OK
     code: 200
     duration: ""
@@ -2094,23 +2061,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:10:15.574321Z","dhcp_enabled":true,"id":"f21ee77a-b1cf-4bc7-8df8-09daf0824272","name":"test-rdb-endpoints","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:10:15.574321Z","id":"fb7b6fcf-52e0-4d6f-bd6c-ca553e38155f","subnet":"172.16.124.0/22","updated_at":"2023-12-18T13:10:15.574321Z"},{"created_at":"2023-12-18T13:10:15.574321Z","id":"a5d27e66-d1c7-4ded-96b0-711453e14fec","subnet":"fd5f:519c:6d46:f731::/64","updated_at":"2023-12-18T13:10:15.574321Z"}],"tags":[],"updated_at":"2023-12-18T13:10:15.574321Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "703"
+      - "1288"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:37 GMT
+      - Tue, 20 Feb 2024 14:11:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2118,7 +2085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24c93b7a-2ce1-49bd-a4ae-0ace59047bdb
+      - 8e6962d0-9504-49da-a7b2-c9d9ea26871e
     status: 200 OK
     code: 200
     duration: ""
@@ -2127,23 +2094,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVWlJiaitWeDBoMjdHV0plMFZnOVRGYy9WT3hZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TkM0eU1CNFhEVEkwCk1ESXlNREUwTURnME4xb1hEVE0wTURJeE56RTBNRGcwTjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU5DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFvSzNKZnBTM21LTjYzZU9JRlJCNnN3WDRoeEx2a1djaDM1Y3RHbUJOVkdvakt2NEJtQjdwVVptdFJhMEYKRGRBMEZ5NmFUazBOS3ZObXh3L2Z2dnlxUjNOOHBTbWtzc0NFdE53d3NmZXJLR1l5S0Y4STRtb3lhKythQldPRApDbTNqcEhEcjVRUTBIbU9Lb2p4QlVBZG1MR3BGMnUxYmprMDBqNTV0TnJEQnk4eWRNRWlYUmhaVEtlcmVCcUpqCm54UEFFOTBmelR2Ukx0K0xuQ2RIakNuZnl0WUJkK3ZNSW52U0U0dmQ5Y1NFYWFRTDFoemFBVEFZTkdPMSt3RDUKV0xpdzJoTGh1QWJ1T1Y5YS9IdGVJQWVheTJLcnRtVWJsY1p5MjFOWEVxWnRMUmtKaFExVXVoWE9PU0t6cTdUTwpwRDRjUHg4VHQza2V2V0ptL3JKNysxK3Zud0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qUXVNb2NFTTU1K3lJY0VyQkFZQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUpXSlh4ZmJTbGFXeTNEMGQKblU5VUlLTnR4RExFdmhqWnd3VlB6cnowNWZ0RXBXZUFwcUhrTVhsRTU3ZU85RmtzdUcwZFN2bnd6cDgzUmVQSQprSzBVVndtMUNxM0xCUGg2N2FmYWJoK1U1V3B6WWx5cUI2dmgzMll4SGFiRlRjeE1QSUZuQ1VpTGpKR2JSOEJpClNwRjVYaExHMndzSzVoRmIrTkVPd3NsSEprM2oxcStNV255REhra0g4VEJWYVJma2w4QlNRRnhLSjhSTUpFSUwKcnR5Ym5BVitLMUFaSjhQVUE3VUYrRkJNeGZhZzZ5WVBPYXR0N3FiZCtXdWhFb0Npa3hRSHZHRlViQnhLbXR5ZQpVNGUrbGpOS1RQbEM4N2VzWk9DcTRCYlk5NU5OODFvY3V2R216YlBCY1NFYjJDVS9HREprQVY3ZHVpM21nV052Cmc5RnhxUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1238"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:37 GMT
+      - Tue, 20 Feb 2024 14:11:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2151,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c59a2d83-bd74-409a-8db3-f164b8e2f459
+      - b36e31b9-d313-4c41-ba03-362a73e14522
     status: 200 OK
     code: 200
     duration: ""
@@ -2160,23 +2127,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVVWhvakVVSVdISTJEZWZpWEtRQVpleVRLdFdjd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFM01pNHhOaTR4TWpRdU1qQWVGdzB5Ck16RXlNVGd4TXpFeE1qWmFGdzB6TXpFeU1UVXhNekV4TWpaYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hOekl1TVRZdU1USTBMakl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUNjYVZXb2tYWWU4ZzV4czVWbkpJME9HRUVNVTJLdUJwajVWd2N4bWlMeThCZTB1Vm9FZzZHc3VsSGUKcDBVZTVmNUZCQ2FRQXhBalQxc1hjR2lUV2VLcDlsbXFqekRkajdZRlVyOVlDQXdlUW5KQ2F1dSsrRkxuYjU0VwpkY3h5eGFZSkpBZnZWY3VycmRwZUFXSFZya2xtcEJ3WklyUElmVnAwNEFiOVE4QVVwL3F5Nm1aY3BYZ2ZGaUFFCldBN1hhekJOOUFHMFl6OTFualY5YWtmczZ0NFRvanVkUzQ1QjNQVDR4QVo2K2UvWXBiQmJpTk8xcWIrTnBCUWwKNjg5bU5HYTMrbWN2RFlYZVFaRGE3Mng2WUliNWZpeWhmNFdzZ01sd2hiWUJvNktiN0Q2NjVCTmZwYUxkZFBOYwpKb3AyUklIMkdMRzZJcHVOTmdISlh0anNrZktqQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTNNaTR4Ck5pNHhNalF1TW9jRU13K0M2b2NFckJCOEFqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFKUUxuZFJQZkFYaUIKTW43dUQ1RXBhWVhPcnMwRG9KVUh4L3pRM0tyWXR4L1kwQ3c3dGtyRnRkTTh5Zmt6a29weGJhZ1IwVUY4U3VWWgpHZWtsQkFqbW9hK1FVVkIwN2VmWFloYUdxRHhIcUthejRHU0pPMFRpODE3eXdPSmdNTHBFb3liMEh0dkpyei9VClMrbzFmL0h2cFNrMUp1dVdPMjJFalVhRmdRQnptQ1cvRFNiam1IVEtEbEhrcVU1YTk2a3lsYkpYU3dadTlxdmQKK1BzN1NGNHZ2MVJZQTY0R29qeEtiR0x4OEIxcHhvZ2h1c0tiTUMxWXYvVmdZRzdKb3hSamdPTjJvNHRjYUNIQwp6bzJuUjNLTDAwYUE5eWRIOHNCQjdwaHl2VGZURFNCcGpqSmttTFpMV2NneWw4akkrR2xId1dPMlNIQlI3blJzCnAzUmJxS2hXNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1731"
+      - "1288"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:37 GMT
+      - Tue, 20 Feb 2024 14:11:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2184,7 +2151,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbba8fef-b935-4127-af02-b55819ca8d4b
+      - b74f7a3c-a63c-4030-8a2b-201e73677d91
     status: 200 OK
     code: 200
     duration: ""
@@ -2193,89 +2160,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "26"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8d57173b-0d10-4cdb-9094-450e92ee2b0f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1238"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 125f5451-7b5c-40c1-acba-ec1f2334ea47
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1241"
+      - "1291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:38 GMT
+      - Tue, 20 Feb 2024 14:11:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2283,7 +2184,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50778161-b10f-4c20-adfd-3bb6b7409f88
+      - 00868e10-7ba9-45ae-ac19-241b92a55b60
     status: 200 OK
     code: 200
     duration: ""
@@ -2292,23 +2193,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:10:17.123764Z","endpoint":{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554},"endpoints":[{"id":"b1aecb79-3a49-44f8-9f10-d3a52837ea34","ip":"195.154.68.173","load_balancer":{},"name":null,"port":6554}],"engine":"PostgreSQL-15","id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:43.185561Z","endpoint":{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300},"endpoints":[{"id":"68fdcaf4-49a2-412e-b765-dd264055eb62","ip":"195.154.68.173","load_balancer":{},"name":null,"port":26300}],"engine":"PostgreSQL-15","id":"f5d5030c-716e-4800-b495-c39be3c06b66","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","test_endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1241"
+      - "1291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:38 GMT
+      - Tue, 20 Feb 2024 14:11:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2316,7 +2217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56926c43-7317-480e-84b2-0537d5b97b5c
+      - 712201f3-dd3f-45a8-8a7d-0ac5b0efce94
     status: 200 OK
     code: 200
     duration: ""
@@ -2325,9 +2226,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f21ee77a-b1cf-4bc7-8df8-09daf0824272
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/dfbe6449-bc74-429c-9b7f-52257ab7e48d
     method: DELETE
   response:
     body: ""
@@ -2337,9 +2238,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:38 GMT
+      - Tue, 20 Feb 2024 14:11:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2347,7 +2248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8cb473d-533a-4933-8e39-94837e47a276
+      - d86356b1-ee75-40fd-b41a-7063f27b7cb5
     status: 204 No Content
     code: 204
     duration: ""
@@ -2356,12 +2257,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"f5d5030c-716e-4800-b495-c39be3c06b66","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2370,9 +2271,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:09 GMT
+      - Tue, 20 Feb 2024 14:12:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2380,7 +2281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55f53ad9-c330-40f9-87ee-c5009be34fc4
+      - 2c7841c7-e8f8-46a4-885a-12b9c734af11
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2389,12 +2290,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/f5d5030c-716e-4800-b495-c39be3c06b66
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"9f6e5a34-73e3-4419-8bd1-7c3bff0ff40e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"f5d5030c-716e-4800-b495-c39be3c06b66","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2403,9 +2304,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:09 GMT
+      - Tue, 20 Feb 2024 14:12:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2413,7 +2314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f5f800c-682a-4f60-a0d8-0790ea6ea8da
+      - ea0d8291-c767-47db-9d5d-ef908dd5f2b9
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-dhcp.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,9 +318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:04 GMT
+      - Tue, 20 Feb 2024 14:07:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,34 +328,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de8a9f3a-ccd0-4670-a24c-2c7db9867bfa
+      - 9fc94656-81fe-48de-9d99-ff35e1a04c35
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24"}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.1.0/24"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:05 GMT
+      - Tue, 20 Feb 2024 14:07:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9c673cf-02a4-4d42-b654-cb486574308f
+      - 07f6644b-1155-4733-bad4-90fcb394a149
     status: 200 OK
     code: 200
     duration: ""
@@ -372,23 +372,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1beb022d-a42b-40cb-b2de-0ec91b4a21af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/e10548d4-05c7-42df-aa47-650dc299c8d4
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:05 GMT
+      - Tue, 20 Feb 2024 14:07:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -396,102 +396,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9e20217-b0d0-4210-9169-6bc94924cc20
+      - 6cc116f2-e7a0-4c5c-bebc-457f6738a682
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
+    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
-    method: POST
-  response:
-    body: '{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":null,"id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8c9310dd-4f23-4bfb-8165-5cdfbc3e9006
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/32db68aa-b0f4-4f91-98c3-1edff23c735f
-    method: GET
-  response:
-    body: '{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":null,"id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "356"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:12:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 404907bf-5f4e-40e1-98db-0d435607a0bb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"my_private_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"172.16.8.0/22","updated_at":"2023-12-18T13:12:05.727743Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:05.727743Z"}],"tags":[],"updated_at":"2023-12-18T13:12:05.727743Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:07:41.068833Z","dhcp_enabled":true,"id":"6037c87c-7429-4ebf-961c-c958ec6d445e","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:07:41.068833Z","id":"af6fa737-0f71-40bf-a646-a137fd5d5143","subnet":"172.16.4.0/22","updated_at":"2024-02-20T14:07:41.068833Z"},{"created_at":"2024-02-20T14:07:41.068833Z","id":"9b66499c-8e0e-4876-9165-43abe3da15c4","subnet":"fd68:d440:21c4:3a61::/64","updated_at":"2024-02-20T14:07:41.068833Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.068833Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:06 GMT
+      - Tue, 20 Feb 2024 14:07:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -499,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f81c4a6-839d-47d1-8d19-3550c5c8fc6b
+      - 4e1357d9-de10-4213-98dd-6de60425bc29
     status: 200 OK
     code: 200
     duration: ""
@@ -508,23 +440,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/6037c87c-7429-4ebf-961c-c958ec6d445e
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"172.16.8.0/22","updated_at":"2023-12-18T13:12:05.727743Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:05.727743Z"}],"tags":[],"updated_at":"2023-12-18T13:12:05.727743Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:07:41.068833Z","dhcp_enabled":true,"id":"6037c87c-7429-4ebf-961c-c958ec6d445e","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:07:41.068833Z","id":"af6fa737-0f71-40bf-a646-a137fd5d5143","subnet":"172.16.4.0/22","updated_at":"2024-02-20T14:07:41.068833Z"},{"created_at":"2024-02-20T14:07:41.068833Z","id":"9b66499c-8e0e-4876-9165-43abe3da15c4","subnet":"fd68:d440:21c4:3a61::/64","updated_at":"2024-02-20T14:07:41.068833Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.068833Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "701"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:06 GMT
+      - Tue, 20 Feb 2024 14:07:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -532,34 +464,102 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 626dd5a6-fe46-4230-abda-c6ce7a94f1eb
+      - 4baf2a3c-565e-4513-bdde-a924298401cf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
+    method: POST
+  response:
+    body: '{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":null,"id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "369"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:07:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 969c809e-b78b-47d3-8997-048209384770
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/06412087-2ca6-4067-ab25-8bb70e100385
+    method: GET
+  response:
+    body: '{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":null,"id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "369"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:07:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f46b92da-e9b6-4682-afc9-d71043793e48
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"06412087-2ca6-4067-ab25-8bb70e100385","enable_smtp":false,"enable_bastion":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:06.473486Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:41.999350Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:06 GMT
+      - Tue, 20 Feb 2024 14:07:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -567,7 +567,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d890f65e-2d0e-4a6b-b0c1-2501efe56576
+      - ca6a5e88-af3f-40f0-851f-c573440ea48c
     status: 200 OK
     code: 200
     duration: ""
@@ -576,23 +576,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:06.513848Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:42.067222Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "941"
+      - "1003"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:06 GMT
+      - Tue, 20 Feb 2024 14:07:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -600,34 +600,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f6c62e0-0e51-463e-bf74-a5490519f56f
+      - 02719ada-ce92-458a-89ea-dd152c6ee6de
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-private-network-dhcp","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-private-network-dhcp","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "998"
+      - "1034"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:07 GMT
+      - Tue, 20 Feb 2024 14:07:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -635,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d959d08-6d1e-42aa-8a65-4a0fbfa4ba40
+      - e4cc8b04-5473-4356-b2f0-16748a891a60
     status: 200 OK
     code: 200
     duration: ""
@@ -644,23 +644,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "998"
+      - "1034"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:07 GMT
+      - Tue, 20 Feb 2024 14:07:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -668,7 +668,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8500093-a68a-45d5-8e8e-27bd15e3de0b
+      - 1a5f2ba1-1f3e-486b-8e73-16401c717597
     status: 200 OK
     code: 200
     duration: ""
@@ -677,23 +677,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:07.117243Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:42.288312Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "1004"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:11 GMT
+      - Tue, 20 Feb 2024 14:07:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -701,7 +701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42ea3c99-11b8-4fc7-b95b-b4ef2b77cc32
+      - 8f134bbc-e0ed-49fb-8a9d-fd838a52e7d9
     status: 200 OK
     code: 200
     duration: ""
@@ -710,23 +710,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:07.117243Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:42.288312Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "1004"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:11 GMT
+      - Tue, 20 Feb 2024 14:07:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -734,7 +734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a28c3f2-7b6f-409d-afd3-1a0016c40bb6
+      - a72af9a9-5bc5-4dd9-8c85-3acf997b7e40
     status: 200 OK
     code: 200
     duration: ""
@@ -743,23 +743,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:07.117243Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:53.476247Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:11 GMT
+      - Tue, 20 Feb 2024 14:07:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -767,34 +767,100 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 351176e3-0beb-410f-a45d-84cbab8c8357
+      - fbdca2b1-4a58-46dd-9514-56553d054ec3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:53.476247Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1000"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:07:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1657f4cb-c69b-43a3-90ee-0a34f1439847
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:53.476247Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1000"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:07:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ad98c6a0-26f5-4c06-8c08-38269d74c009
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"e10548d4-05c7-42df-aa47-650dc299c8d4"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":null,"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"created","updated_at":"2023-12-18T13:12:12.805688Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":null,"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"created","updated_at":"2024-02-20T14:07:59.728441Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "953"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Tue, 20 Feb 2024 14:07:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -802,7 +868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 298da923-e02b-4a80-af04-5a84d84c12d4
+      - 3a4a7bad-7908-4c1f-9ffd-a328abf52a94
     status: 200 OK
     code: 200
     duration: ""
@@ -811,23 +877,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":null,"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"created","updated_at":"2023-12-18T13:12:12.805688Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:13.004873Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":null,"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"created","updated_at":"2024-02-20T14:07:59.728441Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:59.914126Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1894"
+      - "1986"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Tue, 20 Feb 2024 14:07:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -835,7 +901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29351e36-21b9-4472-893a-b27d98432fff
+      - 2671ade9-047c-40eb-961f-f50865cf20fa
     status: 200 OK
     code: 200
     duration: ""
@@ -844,23 +910,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":null,"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"created","updated_at":"2023-12-18T13:12:12.805688Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:13.004873Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":null,"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"created","updated_at":"2024-02-20T14:07:59.728441Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:59.914126Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1894"
+      - "1986"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:18 GMT
+      - Tue, 20 Feb 2024 14:08:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -868,7 +934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de8254d5-7b0f-415d-9ce4-a66935193525
+      - ebfaf3ae-a5b4-48d4-bd18-af8e1413035f
     status: 200 OK
     code: 200
     duration: ""
@@ -877,23 +943,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"configuring","updated_at":"2024-02-20T14:08:05.953354Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:07:59.914126Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "2005"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Tue, 20 Feb 2024 14:08:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -901,7 +967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ed62c34-930c-4d5b-aef4-cfe52cbaf937
+      - 490bf758-08b2-46ca-9cec-b0fad96f0f7e
     status: 200 OK
     code: 200
     duration: ""
@@ -910,23 +976,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "966"
+      - "1034"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Tue, 20 Feb 2024 14:08:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -934,7 +1000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87b363b3-e24b-411e-8dd5-3e70aa98accd
+      - f117fc88-adcf-4a62-80da-c479962f6b93
     status: 200 OK
     code: 200
     duration: ""
@@ -943,23 +1009,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Tue, 20 Feb 2024 14:08:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -967,7 +1033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbdb00a8-e607-4770-88e3-a3131e9151d7
+      - 22a1440e-bf64-4dd5-8da6-714564925130
     status: 200 OK
     code: 200
     duration: ""
@@ -976,23 +1042,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Tue, 20 Feb 2024 14:08:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1000,7 +1066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06a3b752-1835-43d6-95a6-f3d074492507
+      - 73ea2701-2a56-402f-849c-a140a3d84e7e
     status: 200 OK
     code: 200
     duration: ""
@@ -1009,23 +1075,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:23 GMT
+      - Tue, 20 Feb 2024 14:08:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1033,7 +1099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ee65e88-38b2-43da-94b9-596779211dee
+      - 11649ab0-8136-4aea-af96-0659d3eb32f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1042,23 +1108,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "998"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:37 GMT
+      - Tue, 20 Feb 2024 14:08:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1066,7 +1132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 624b3f4a-d3f9-484e-bcec-2fc8f12fdf3a
+      - d7fae462-9a89-421e-9177-e026b74eea37
     status: 200 OK
     code: 200
     duration: ""
@@ -1075,23 +1141,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "998"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:07 GMT
+      - Tue, 20 Feb 2024 14:08:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1099,7 +1165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af0d040d-ad47-485c-a27f-61a937dd9a21
+      - 58709967-d5a0-4fdf-aecd-752c3c48d393
     status: 200 OK
     code: 200
     duration: ""
@@ -1108,23 +1174,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "998"
+      - "1034"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:38 GMT
+      - Tue, 20 Feb 2024 14:08:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1132,7 +1198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d35740b-5679-43ba-a8f6-c7b9cfe2e56b
+      - 2eebbfeb-e3a9-4e1e-9d90-c91b2d1d7967
     status: 200 OK
     code: 200
     duration: ""
@@ -1141,23 +1207,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "998"
+      - "1034"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:08 GMT
+      - Tue, 20 Feb 2024 14:09:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1165,7 +1231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5de463ba-d88c-4678-a154-602574f8dff1
+      - 3dbe2a20-0b11-45a4-a57d-9d2afd41b2ec
     status: 200 OK
     code: 200
     duration: ""
@@ -1174,23 +1240,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "998"
+      - "1034"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:38 GMT
+      - Tue, 20 Feb 2024 14:09:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1198,7 +1264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab16f896-d42f-4be3-918f-df8dc0974fa3
+      - d9d1dfe2-b33a-4d88-b01d-2ffeb5ebd8c0
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,23 +1273,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:09 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1231,7 +1297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9d1347f-4f8d-4f94-b603-7d48df8abdcd
+      - 96c8abfa-209c-4f22-a8a8-d9a897656100
     status: 200 OK
     code: 200
     duration: ""
@@ -1240,23 +1306,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVWDBUMmR3VnRhczRaTXpVQyswdmNNc3g2d3Bvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qUXdNakl3TVRRd09ETTFXaGNOTXpRd01qRTNNVFF3T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtFUUF3bS9PTnRyV2pvSHE5R0hrRkJPbVRKYU1pNGNkQUxHQ3h4Y2F1VzJLbFFleko4ZmlMaTIKcFl1YzFlaGNqYm1pK3NRN3VXaVNadm1FZHBIb2ViQlNJTERIampsWkRWd1ZmVnpkQzFGbkIzR21VWVk1aXo5Kwpra1NMd2VtVVhjY3BHNXE2S1FvdU1qeWxuRXZ4ZkwrVC84UHlqK2txeU1xckwzVkc2bURJTFNhcTJDMUZOMC91CmFCMmJwekhmbzM5Ky9VYVFEQ0dtckhaaXgwU2VLeG02dENqWkhpVkViSjdQVkhtK3c2VTl0MGdLYng0U1JrSlEKYnR1bjBXcDkxOGZVQnl5aVMxa0RvZEpKYVdoZCtWdlFhT1lST2wrdGplZVdNVVluLzQ2ci9rNjhhTG1yYzFZUwpWcTJ2YUZRZU9lYVVYR0RmbzVDM1UyY2Y2cUp0aURFQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzk2ZTRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQTJTUXhkWEIKSWlING9JT0YyUC9ZN0c5T0puWEtqOGNvNldtR3RYdXJ0Y2k2RmhoRC96QVFtd0xMbzdlaDVJSGlQNWdUWXNRNQpUdzdodmxteFFqb3NOblBqdldEb0VWbE9WczFZUjdhTklWYXVYZWdDVWpXTlIxQVZIVnFYWmU5MCtUUWVFWjlhCkVaSmlDbmhKTEtYclNCSlZScDF2VnBhbU1LNjNERDZxMGN1Y21ubU04cFkvQ0VqMzBoZTdFTGxoZEs1emVMK3MKSWtTQmFudGM2WlJmTHNSM1docGtTeDVqVkJSWnZwanpRWDVJUEY3WWJ5WlVwVFV0cENnQXJDNU8xTFR2WnFpcApCOWZGY3I0R2hzZDAyZ01mTk9oZUxvd1F4aUo5L1NGMGZYaE5tMlBtbjR2N043aVRBSzNRWE1GcDlyK1dySGpWCk1aYlN1MTQ2TDdMb29RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1735"
+      - "1737"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:09 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1264,7 +1330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 041ee327-532c-4806-9ada-12fb36b477dd
+      - e7368b61-c2b7-462c-b7da-be58ccfa32bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1273,23 +1339,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=12377601-1a76-4443-a514-11f4d01902a4&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:09 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1297,7 +1363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bf2cd97-d3a2-4a82-9d95-3af714c99e49
+      - cb59d214-e1c4-4ab9-9173-0af42a4a0812
     status: 200 OK
     code: 200
     duration: ""
@@ -1306,23 +1372,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:09 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1330,7 +1396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30ab5eb7-24ac-4483-ac89-c44dd8843993
+      - 1ac6ddf2-9251-4876-94d7-1ffc86684a41
     status: 200 OK
     code: 200
     duration: ""
@@ -1339,23 +1405,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:09 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1363,34 +1429,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aae22e3-2909-4f67-a136-4cb21776d64b
+      - 33f78a84-77dd-46a9-b055-39f663207de6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: '{"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:10:13.570316Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"edeacaea-be90-4fba-864f-76b83af80ef3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:10:13.570316Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:09 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1398,7 +1464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcbf5bf6-cfd4-4c2f-aedf-fb4e04082b38
+      - 80189932-8cd9-4fa5-9b4f-a907de9b8951
     status: 200 OK
     code: 200
     duration: ""
@@ -1407,23 +1473,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1431,7 +1497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a877efd0-f1f5-4d3e-a3ab-b27a1ab46b74
+      - 5f63f73b-2897-4f19-a212-512245fd53ed
     status: 200 OK
     code: 200
     duration: ""
@@ -1440,23 +1506,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/edeacaea-be90-4fba-864f-76b83af80ef3
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:10:13.570316Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"edeacaea-be90-4fba-864f-76b83af80ef3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:10:13.570316Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1464,7 +1530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70eca5e9-9d0d-4c05-8629-f51ab4276436
+      - 67fa4190-88fa-4469-94dc-8b4047eae118
     status: 200 OK
     code: 200
     duration: ""
@@ -1473,23 +1539,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1497,7 +1563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f8de29d-4dad-4967-9e06-73b223004f9e
+      - 106d4c03-bd05-4cb8-ad96-98e8a9fe5de1
     status: 200 OK
     code: 200
     duration: ""
@@ -1506,23 +1572,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/32db68aa-b0f4-4f91-98c3-1edff23c735f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/e10548d4-05c7-42df-aa47-650dc299c8d4
     method: GET
   response:
-    body: '{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "390"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1530,7 +1596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3034d53-f1fe-42a4-aa77-ebc41aed0154
+      - 1dd0588c-d5fe-4e1c-86a3-d5f43e61ddc1
     status: 200 OK
     code: 200
     duration: ""
@@ -1539,23 +1605,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/06412087-2ca6-4067-ab25-8bb70e100385
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:12.252645Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:12.257657Z"}],"tags":[],"updated_at":"2023-12-18T13:12:19.395677Z","vpc_id":"2b3f79e3-074e-4215-8a45-5556223283a1"}'
+    body: '{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "702"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1563,7 +1629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2fba459-74ff-427b-b39c-40421860d440
+      - efdf3486-ac16-43b1-a8d2-c7ada1039d86
     status: 200 OK
     code: 200
     duration: ""
@@ -1572,23 +1638,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1beb022d-a42b-40cb-b2de-0ec91b4a21af
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/6037c87c-7429-4ebf-961c-c958ec6d445e
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:07:41.068833Z","dhcp_enabled":true,"id":"6037c87c-7429-4ebf-961c-c958ec6d445e","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:07:41.068833Z","id":"af6fa737-0f71-40bf-a646-a137fd5d5143","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:57.929066Z"},{"created_at":"2024-02-20T14:07:41.068833Z","id":"9b66499c-8e0e-4876-9165-43abe3da15c4","subnet":"fd68:d440:21c4:3a61::/64","updated_at":"2024-02-20T14:07:57.933987Z"}],"tags":[],"updated_at":"2024-02-20T14:08:06.496868Z","vpc_id":"76407d14-c7ca-43b8-bff5-ce31e312ef6d"}'
     headers:
       Content-Length:
-      - "568"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1596,7 +1662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79b328f2-5d1f-4977-85f6-cfbb9e040a95
+      - e69e850e-262e-4eb3-98fc-32c36b306f35
     status: 200 OK
     code: 200
     duration: ""
@@ -1605,23 +1671,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1629,7 +1695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0401b6f-9862-4cb3-ad8f-a3e69e5294eb
+      - 67d52951-cadb-4f76-8b3d-3a686dfd194b
     status: 200 OK
     code: 200
     duration: ""
@@ -1638,23 +1704,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1662,7 +1728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2636e6d1-817d-40e6-a6dd-a95c792ccd0d
+      - ca8f010e-82ea-46ef-abfb-6e4dc71a1860
     status: 200 OK
     code: 200
     duration: ""
@@ -1671,23 +1737,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1695,7 +1761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f1b0a94-7da1-4969-ab7f-c6d3ae542d75
+      - a9f9ccee-f496-4ac5-a383-12cfd97b059b
     status: 200 OK
     code: 200
     duration: ""
@@ -1704,23 +1770,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1728,7 +1794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0fa11c7-e4ff-44e5-9ec9-d0152c5fbaee
+      - 912a5dae-09c0-4851-84dd-0314383ae57a
     status: 200 OK
     code: 200
     duration: ""
@@ -1737,23 +1803,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4/certificate
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVWDBUMmR3VnRhczRaTXpVQyswdmNNc3g2d3Bvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qUXdNakl3TVRRd09ETTFXaGNOTXpRd01qRTNNVFF3T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtFUUF3bS9PTnRyV2pvSHE5R0hrRkJPbVRKYU1pNGNkQUxHQ3h4Y2F1VzJLbFFleko4ZmlMaTIKcFl1YzFlaGNqYm1pK3NRN3VXaVNadm1FZHBIb2ViQlNJTERIampsWkRWd1ZmVnpkQzFGbkIzR21VWVk1aXo5Kwpra1NMd2VtVVhjY3BHNXE2S1FvdU1qeWxuRXZ4ZkwrVC84UHlqK2txeU1xckwzVkc2bURJTFNhcTJDMUZOMC91CmFCMmJwekhmbzM5Ky9VYVFEQ0dtckhaaXgwU2VLeG02dENqWkhpVkViSjdQVkhtK3c2VTl0MGdLYng0U1JrSlEKYnR1bjBXcDkxOGZVQnl5aVMxa0RvZEpKYVdoZCtWdlFhT1lST2wrdGplZVdNVVluLzQ2ci9rNjhhTG1yYzFZUwpWcTJ2YUZRZU9lYVVYR0RmbzVDM1UyY2Y2cUp0aURFQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzk2ZTRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQTJTUXhkWEIKSWlING9JT0YyUC9ZN0c5T0puWEtqOGNvNldtR3RYdXJ0Y2k2RmhoRC96QVFtd0xMbzdlaDVJSGlQNWdUWXNRNQpUdzdodmxteFFqb3NOblBqdldEb0VWbE9WczFZUjdhTklWYXVYZWdDVWpXTlIxQVZIVnFYWmU5MCtUUWVFWjlhCkVaSmlDbmhKTEtYclNCSlZScDF2VnBhbU1LNjNERDZxMGN1Y21ubU04cFkvQ0VqMzBoZTdFTGxoZEs1emVMK3MKSWtTQmFudGM2WlJmTHNSM1docGtTeDVqVkJSWnZwanpRWDVJUEY3WWJ5WlVwVFV0cENnQXJDNU8xTFR2WnFpcApCOWZGY3I0R2hzZDAyZ01mTk9oZUxvd1F4aUo5L1NGMGZYaE5tMlBtbjR2N043aVRBSzNRWE1GcDlyK1dySGpWCk1aYlN1MTQ2TDdMb29RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "966"
+      - "1737"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1761,7 +1827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24c4f67a-f4d7-4df3-b3b0-7d9da55b116d
+      - d4872f92-e6e2-40fe-a5a4-f4995da39b5b
     status: 200 OK
     code: 200
     duration: ""
@@ -1770,23 +1836,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1735"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1794,7 +1860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f6a050b-3cd7-4416-8d43-cf16e692d641
+      - b87f186a-611a-49ed-b349-d68a98ad6e3f
     status: 200 OK
     code: 200
     duration: ""
@@ -1803,419 +1869,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "26"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4a79f18-2497-4533-b960-88f5e061f19b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1b1801ef-2fe9-4eae-8dfd-bec3693ca108
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/32db68aa-b0f4-4f91-98c3-1edff23c735f
-    method: GET
-  response:
-    body: '{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "390"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 66b48610-8307-4ca0-a602-7f271643d504
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1beb022d-a42b-40cb-b2de-0ec91b4a21af
-    method: GET
-  response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "568"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04b62612-9572-42f1-ae2e-758523a42443
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 73192001-01cf-4d4a-8dc5-1e3ace98ffc5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1903"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1406212e-dbdf-405c-bef2-0ee0f9b6441c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aa604e2b-739c-47a8-a947-ae8b9202169f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:12.252645Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:12.257657Z"}],"tags":[],"updated_at":"2023-12-18T13:12:19.395677Z","vpc_id":"2b3f79e3-074e-4215-8a45-5556223283a1"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a020705c-6f90-4c74-baa2-80a06d0b1fcf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1903"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a19a8c76-a2da-4693-b71f-fce33697ebfd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1255"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 27ce7733-c28f-4317-a5a5-0456d660cf87
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f15840e3-1135-4938-835b-36374fdc4a88
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1735"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 051950b0-33b2-4f99-a111-63c500ecddf4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=12377601-1a76-4443-a514-11f4d01902a4&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:11 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2223,7 +1893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 85687f42-d0a1-464a-955b-4a0afa9212c6
+      - 41979bc5-3df1-4c21-9e62-839d7b948d77
     status: 200 OK
     code: 200
     duration: ""
@@ -2232,23 +1902,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/edeacaea-be90-4fba-864f-76b83af80ef3
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:15:09.929544Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:15:09.929544Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:10:13.570316Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"edeacaea-be90-4fba-864f-76b83af80ef3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:10:13.570316Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2256,7 +1926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38baa75f-63d4-4fbf-97ec-5f6454473971
+      - 35846343-2690-4ff2-9022-caf0771201e6
     status: 200 OK
     code: 200
     duration: ""
@@ -2265,23 +1935,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/06412087-2ca6-4067-ab25-8bb70e100385
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2289,7 +1959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caf09f14-a6a9-4c13-ba82-eee25ecf2dbd
+      - ab203628-1bb7-493b-af7c-b6590ed94ff5
     status: 200 OK
     code: 200
     duration: ""
@@ -2298,9 +1968,405 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/8d4d2fd1-55e0-479b-ad96-7f6b5045b7ca
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/e10548d4-05c7-42df-aa47-650dc299c8d4
+    method: GET
+  response:
+    body: '{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "586"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 79dfffe9-4aa8-486e-a280-30de22c5f3e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/edeacaea-be90-4fba-864f-76b83af80ef3
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:10:13.570316Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"edeacaea-be90-4fba-864f-76b83af80ef3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:10:13.570316Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "291"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 044c9860-d3f0-4c35-97eb-0844954fff70
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/6037c87c-7429-4ebf-961c-c958ec6d445e
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:07:41.068833Z","dhcp_enabled":true,"id":"6037c87c-7429-4ebf-961c-c958ec6d445e","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:07:41.068833Z","id":"af6fa737-0f71-40bf-a646-a137fd5d5143","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:57.929066Z"},{"created_at":"2024-02-20T14:07:41.068833Z","id":"9b66499c-8e0e-4876-9165-43abe3da15c4","subnet":"fd68:d440:21c4:3a61::/64","updated_at":"2024-02-20T14:07:57.933987Z"}],"tags":[],"updated_at":"2024-02-20T14:08:06.496868Z","vpc_id":"76407d14-c7ca-43b8-bff5-ce31e312ef6d"}'
+    headers:
+      Content-Length:
+      - "719"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5a012557-d7a9-42c4-82fb-a4250b199698
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 41c08afd-ce8f-4bda-845f-dea765518b14
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2026e144-c291-4324-86b7-f39a580dd9e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2568d4f0-aa69-4c8f-9101-2c8b6ed306e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1302"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e7a53f00-a671-47df-939f-fc4f438944d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 31e98e36-4d1f-478c-8895-79cbc6ab6898
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVWDBUMmR3VnRhczRaTXpVQyswdmNNc3g2d3Bvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qUXdNakl3TVRRd09ETTFXaGNOTXpRd01qRTNNVFF3T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtFUUF3bS9PTnRyV2pvSHE5R0hrRkJPbVRKYU1pNGNkQUxHQ3h4Y2F1VzJLbFFleko4ZmlMaTIKcFl1YzFlaGNqYm1pK3NRN3VXaVNadm1FZHBIb2ViQlNJTERIampsWkRWd1ZmVnpkQzFGbkIzR21VWVk1aXo5Kwpra1NMd2VtVVhjY3BHNXE2S1FvdU1qeWxuRXZ4ZkwrVC84UHlqK2txeU1xckwzVkc2bURJTFNhcTJDMUZOMC91CmFCMmJwekhmbzM5Ky9VYVFEQ0dtckhaaXgwU2VLeG02dENqWkhpVkViSjdQVkhtK3c2VTl0MGdLYng0U1JrSlEKYnR1bjBXcDkxOGZVQnl5aVMxa0RvZEpKYVdoZCtWdlFhT1lST2wrdGplZVdNVVluLzQ2ci9rNjhhTG1yYzFZUwpWcTJ2YUZRZU9lYVVYR0RmbzVDM1UyY2Y2cUp0aURFQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzk2ZTRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQTJTUXhkWEIKSWlING9JT0YyUC9ZN0c5T0puWEtqOGNvNldtR3RYdXJ0Y2k2RmhoRC96QVFtd0xMbzdlaDVJSGlQNWdUWXNRNQpUdzdodmxteFFqb3NOblBqdldEb0VWbE9WczFZUjdhTklWYXVYZWdDVWpXTlIxQVZIVnFYWmU5MCtUUWVFWjlhCkVaSmlDbmhKTEtYclNCSlZScDF2VnBhbU1LNjNERDZxMGN1Y21ubU04cFkvQ0VqMzBoZTdFTGxoZEs1emVMK3MKSWtTQmFudGM2WlJmTHNSM1docGtTeDVqVkJSWnZwanpRWDVJUEY3WWJ5WlVwVFV0cENnQXJDNU8xTFR2WnFpcApCOWZGY3I0R2hzZDAyZ01mTk9oZUxvd1F4aUo5L1NGMGZYaE5tMlBtbjR2N043aVRBSzNRWE1GcDlyK1dySGpWCk1aYlN1MTQ2TDdMb29RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1737"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d13c4c06-b6ad-439b-b3e7-90ea2023e126
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=12377601-1a76-4443-a514-11f4d01902a4&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d32990f4-74ca-469e-b856-e1b26be3a001
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/edeacaea-be90-4fba-864f-76b83af80ef3
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:10:13.570316Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"edeacaea-be90-4fba-864f-76b83af80ef3","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:10:13.570316Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "291"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f88354a-a171-4e73-974a-757fb2a61bf1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:10:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f667f6ff-7a4d-4139-aaa9-ac105030cd0e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/edeacaea-be90-4fba-864f-76b83af80ef3
     method: DELETE
   response:
     body: ""
@@ -2310,9 +2376,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2320,7 +2386,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09fcfbbd-b083-4883-bb6a-4f27d12ce6d5
+      - 549ad86a-6fc9-470f-9ce1-60b774ca91bf
     status: 204 No Content
     code: 204
     duration: ""
@@ -2329,23 +2395,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2353,7 +2419,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd0c7c8f-4445-43f6-b2fe-432e4bd892c9
+      - 70d52617-829c-4706-8a88-611d831d3f87
     status: 200 OK
     code: 200
     duration: ""
@@ -2362,23 +2428,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"ready","updated_at":"2023-12-18T13:12:22.105365Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"ready","updated_at":"2024-02-20T14:08:11.438069Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2386,7 +2452,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c00de2b-d7b7-4016-a333-99fb59364235
+      - 15f96c89-d1c5-49f8-bbb6-1ec21ad4ffcb
     status: 200 OK
     code: 200
     duration: ""
@@ -2395,23 +2461,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2419,7 +2485,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - face7c32-9bf2-47b0-819b-6d35ee323564
+      - 9ce67210-87fc-4863-86f9-bffccffbbcd6
     status: 200 OK
     code: 200
     duration: ""
@@ -2428,9 +2494,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2440,9 +2506,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2450,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a04d8b20-6a60-49cf-8d8b-45f352e451d1
+      - f68b0324-3f1c-4938-83b6-d83032378dcb
     status: 204 No Content
     code: 204
     duration: ""
@@ -2459,23 +2525,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"address":null,"created_at":"2024-02-20T14:07:59.728441Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:07:41.067665Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"e10548d4-05c7-42df-aa47-650dc299c8d4","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:41.067665Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","ipam_config":null,"mac_address":"02:00:00:13:6C:18","private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","status":"detaching","updated_at":"2024-02-20T14:10:15.790926Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1255"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2483,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15287076-cb91-442d-a7dc-0604222c6239
+      - 146ec02f-cfd9-4864-ba83-09f8d5ebb4d5
     status: 200 OK
     code: 200
     duration: ""
@@ -2492,23 +2558,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:12:12.805688Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:12:05.741180Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:05.741180Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","ipam_config":null,"mac_address":"02:00:00:12:3D:33","private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","status":"detaching","updated_at":"2023-12-18T13:15:12.400032Z","zone":"nl-ams-1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "970"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2516,7 +2582,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c988f879-bcae-4ea2-b5ec-91e1cfa4e38e
+      - 1f0d9ec5-2a9d-441d-971b-eadb9bb54d47
     status: 200 OK
     code: 200
     duration: ""
@@ -2527,23 +2593,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2551,7 +2617,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8350000c-8d01-4a0c-9687-f226deb308c7
+      - aa4540c0-3b30-4092-b838-35a1d61f2651
     status: 200 OK
     code: 200
     duration: ""
@@ -2560,23 +2626,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:12 GMT
+      - Tue, 20 Feb 2024 14:10:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2584,7 +2650,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c178cb89-18d3-4742-868f-1231d36be7dd
+      - f47c0df4-6b3a-4b17-8019-32aade12ca00
     status: 200 OK
     code: 200
     duration: ""
@@ -2593,9 +2659,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/aaf7c7fb-ccba-4682-969c-d3f8eb837b37
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/56a4329d-65c5-4394-9ce6-4dee48ba5802
     method: DELETE
   response:
     body: ""
@@ -2605,9 +2671,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:13 GMT
+      - Tue, 20 Feb 2024 14:10:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2615,7 +2681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1f72f1e-b348-4094-92c2-de9a837703e9
+      - d0d03289-4fb2-4348-ae09-023345b6311f
     status: 204 No Content
     code: 204
     duration: ""
@@ -2624,23 +2690,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[{"id":"aaf7c7fb-ccba-4682-969c-d3f8eb837b37","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"595e8430-6684-4031-be58-1b4291dd1ca6","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[{"id":"56a4329d-65c5-4394-9ce6-4dee48ba5802","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"6037c87c-7429-4ebf-961c-c958ec6d445e","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1308"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:13 GMT
+      - Tue, 20 Feb 2024 14:10:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2648,7 +2714,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a73c392b-f432-45d7-82f0-64cc31437c19
+      - fe5dfda2-9593-4832-9c0b-c60f1ac94894
     status: 200 OK
     code: 200
     duration: ""
@@ -2657,12 +2723,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/9a0ddcdf-3d0b-4407-97cf-fb811f84aba8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5ea72c2d-c852-4627-8d21-0cd8ed6ceefb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"9a0ddcdf-3d0b-4407-97cf-fb811f84aba8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"5ea72c2d-c852-4627-8d21-0cd8ed6ceefb","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2671,9 +2737,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:17 GMT
+      - Tue, 20 Feb 2024 14:10:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2681,7 +2747,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75833449-2d43-4117-b4f0-c556c3e2aee7
+      - c8410f80-8037-4e3c-a6a5-48ce0b237926
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2690,23 +2756,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "937"
+      - "999"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:17 GMT
+      - Tue, 20 Feb 2024 14:10:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2714,7 +2780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb4da720-bfb7-4fbc-958a-cd09cc4d2c87
+      - f26aa554-bebf-4d55-a6c3-c80a337da8d2
     status: 200 OK
     code: 200
     duration: ""
@@ -2723,12 +2789,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/1beb022d-a42b-40cb-b2de-0ec91b4a21af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/e10548d4-05c7-42df-aa47-650dc299c8d4
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1beb022d-a42b-40cb-b2de-0ec91b4a21af","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"e10548d4-05c7-42df-aa47-650dc299c8d4","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2737,9 +2803,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:17 GMT
+      - Tue, 20 Feb 2024 14:10:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2747,7 +2813,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f33bc006-d7fc-4193-bcda-f7075acb969b
+      - 3edc8f3a-a749-4316-b889-4c089301bacb
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2756,23 +2822,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:12:06.473486Z","gateway_networks":[],"id":"3b4b19a9-3332-4525-ad0e-379b3309390a","ip":{"address":"51.15.111.89","created_at":"2023-12-18T13:12:06.175839Z","gateway_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","id":"32db68aa-b0f4-4f91-98c3-1edff23c735f","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"89-111-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:12:06.175839Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:12:22.201274Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:07:41.999350Z","gateway_networks":[],"id":"adbbad55-385c-4faa-95e1-6584282fe71c","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:07:41.795353Z","gateway_id":"adbbad55-385c-4faa-95e1-6584282fe71c","id":"06412087-2ca6-4067-ab25-8bb70e100385","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:07:41.795353Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:08:11.645985Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "937"
+      - "999"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:17 GMT
+      - Tue, 20 Feb 2024 14:10:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2780,7 +2846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c71e152-b322-4108-97ef-98aefe8ac027
+      - 1503b348-6b0c-4592-b44c-9af00a3efd9c
     status: 200 OK
     code: 200
     duration: ""
@@ -2789,9 +2855,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -2801,9 +2867,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:17 GMT
+      - Tue, 20 Feb 2024 14:10:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2811,7 +2877,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d03ee3b5-eaf5-4a04-9780-504ac2600a2d
+      - 7d44aba3-5bcc-4347-aaa8-c538b8646b56
     status: 204 No Content
     code: 204
     duration: ""
@@ -2820,12 +2886,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/3b4b19a9-3332-4525-ad0e-379b3309390a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/adbbad55-385c-4faa-95e1-6584282fe71c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"3b4b19a9-3332-4525-ad0e-379b3309390a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"adbbad55-385c-4faa-95e1-6584282fe71c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -2834,9 +2900,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:17 GMT
+      - Tue, 20 Feb 2024 14:10:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2844,7 +2910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8329d67-730c-4d56-bc31-321c9ff254ca
+      - 823de94b-ac4b-4aef-9502-9c383f00ee21
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2853,9 +2919,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/32db68aa-b0f4-4f91-98c3-1edff23c735f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/06412087-2ca6-4067-ab25-8bb70e100385
     method: DELETE
   response:
     body: ""
@@ -2865,9 +2931,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:18 GMT
+      - Tue, 20 Feb 2024 14:10:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2875,7 +2941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9715e94-94b8-41ba-b8c1-4142c1f794d5
+      - 4285469e-b62b-4b02-a780-20f152e94cc0
     status: 204 No Content
     code: 204
     duration: ""
@@ -2884,23 +2950,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1035"
+      - "1076"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:44 GMT
+      - Tue, 20 Feb 2024 14:10:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2908,7 +2974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf7cd3d3-4e6c-4c5b-987c-50e7c7f43b48
+      - fe8bc64f-bd4a-4946-815e-377682004b24
     status: 200 OK
     code: 200
     duration: ""
@@ -2917,23 +2983,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1035"
+      - "1076"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:44 GMT
+      - Tue, 20 Feb 2024 14:10:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2941,7 +3007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39d288cc-75c9-418e-972b-2e599c25e326
+      - bc2bb83d-093a-437c-9d7e-f7217225ca02
     status: 200 OK
     code: 200
     duration: ""
@@ -2950,23 +3016,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVWDBUMmR3VnRhczRaTXpVQyswdmNNc3g2d3Bvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qUXdNakl3TVRRd09ETTFXaGNOTXpRd01qRTNNVFF3T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtFUUF3bS9PTnRyV2pvSHE5R0hrRkJPbVRKYU1pNGNkQUxHQ3h4Y2F1VzJLbFFleko4ZmlMaTIKcFl1YzFlaGNqYm1pK3NRN3VXaVNadm1FZHBIb2ViQlNJTERIampsWkRWd1ZmVnpkQzFGbkIzR21VWVk1aXo5Kwpra1NMd2VtVVhjY3BHNXE2S1FvdU1qeWxuRXZ4ZkwrVC84UHlqK2txeU1xckwzVkc2bURJTFNhcTJDMUZOMC91CmFCMmJwekhmbzM5Ky9VYVFEQ0dtckhaaXgwU2VLeG02dENqWkhpVkViSjdQVkhtK3c2VTl0MGdLYng0U1JrSlEKYnR1bjBXcDkxOGZVQnl5aVMxa0RvZEpKYVdoZCtWdlFhT1lST2wrdGplZVdNVVluLzQ2ci9rNjhhTG1yYzFZUwpWcTJ2YUZRZU9lYVVYR0RmbzVDM1UyY2Y2cUp0aURFQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzk2ZTRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQTJTUXhkWEIKSWlING9JT0YyUC9ZN0c5T0puWEtqOGNvNldtR3RYdXJ0Y2k2RmhoRC96QVFtd0xMbzdlaDVJSGlQNWdUWXNRNQpUdzdodmxteFFqb3NOblBqdldEb0VWbE9WczFZUjdhTklWYXVYZWdDVWpXTlIxQVZIVnFYWmU5MCtUUWVFWjlhCkVaSmlDbmhKTEtYclNCSlZScDF2VnBhbU1LNjNERDZxMGN1Y21ubU04cFkvQ0VqMzBoZTdFTGxoZEs1emVMK3MKSWtTQmFudGM2WlJmTHNSM1docGtTeDVqVkJSWnZwanpRWDVJUEY3WWJ5WlVwVFV0cENnQXJDNU8xTFR2WnFpcApCOWZGY3I0R2hzZDAyZ01mTk9oZUxvd1F4aUo5L1NGMGZYaE5tMlBtbjR2N043aVRBSzNRWE1GcDlyK1dySGpWCk1aYlN1MTQ2TDdMb29RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1735"
+      - "1737"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:44 GMT
+      - Tue, 20 Feb 2024 14:10:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2974,7 +3040,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 114aee9c-e5a9-4ace-9ccc-05943fdb8420
+      - ca72e7ea-bab4-4e52-b8e7-cb29c3593871
     status: 200 OK
     code: 200
     duration: ""
@@ -2983,23 +3049,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/6037c87c-7429-4ebf-961c-c958ec6d445e
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"created_at":"2024-02-20T14:07:41.068833Z","dhcp_enabled":true,"id":"6037c87c-7429-4ebf-961c-c958ec6d445e","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:07:41.068833Z","id":"af6fa737-0f71-40bf-a646-a137fd5d5143","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:07:57.929066Z"},{"created_at":"2024-02-20T14:07:41.068833Z","id":"9b66499c-8e0e-4876-9165-43abe3da15c4","subnet":"fd68:d440:21c4:3a61::/64","updated_at":"2024-02-20T14:07:57.933987Z"}],"tags":[],"updated_at":"2024-02-20T14:10:15.860102Z","vpc_id":"76407d14-c7ca-43b8-bff5-ce31e312ef6d"}'
     headers:
       Content-Length:
-      - "26"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:44 GMT
+      - Tue, 20 Feb 2024 14:10:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3007,7 +3073,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 651266bd-236c-4d35-abf4-02fd15f1bc6d
+      - 1a80da2b-7677-4a6b-bb6e-bdcaf5a6d644
     status: 200 OK
     code: 200
     duration: ""
@@ -3016,23 +3082,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:12:05.727743Z","dhcp_enabled":true,"id":"595e8430-6684-4031-be58-1b4291dd1ca6","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:12:05.727743Z","id":"d19789b8-fe9a-418c-8001-9af15e819caa","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:12:12.252645Z"},{"created_at":"2023-12-18T13:12:05.727743Z","id":"48650cb4-9a0a-4760-be54-0c2f3869af30","subnet":"fd5c:d510:d730:3751::/64","updated_at":"2023-12-18T13:12:12.257657Z"}],"tags":[],"updated_at":"2023-12-18T13:15:12.580185Z","vpc_id":"2b3f79e3-074e-4215-8a45-5556223283a1"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "702"
+      - "1076"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:44 GMT
+      - Tue, 20 Feb 2024 14:10:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3040,7 +3106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c913761-51cd-4c0a-976a-e101b496138f
+      - 55e9ec13-ab2c-442d-bdac-20dab87ade39
     status: 200 OK
     code: 200
     duration: ""
@@ -3049,23 +3115,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVWDBUMmR3VnRhczRaTXpVQyswdmNNc3g2d3Bvd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qUXdNakl3TVRRd09ETTFXaGNOTXpRd01qRTNNVFF3T0RNMVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUtFUUF3bS9PTnRyV2pvSHE5R0hrRkJPbVRKYU1pNGNkQUxHQ3h4Y2F1VzJLbFFleko4ZmlMaTIKcFl1YzFlaGNqYm1pK3NRN3VXaVNadm1FZHBIb2ViQlNJTERIampsWkRWd1ZmVnpkQzFGbkIzR21VWVk1aXo5Kwpra1NMd2VtVVhjY3BHNXE2S1FvdU1qeWxuRXZ4ZkwrVC84UHlqK2txeU1xckwzVkc2bURJTFNhcTJDMUZOMC91CmFCMmJwekhmbzM5Ky9VYVFEQ0dtckhaaXgwU2VLeG02dENqWkhpVkViSjdQVkhtK3c2VTl0MGdLYng0U1JrSlEKYnR1bjBXcDkxOGZVQnl5aVMxa0RvZEpKYVdoZCtWdlFhT1lST2wrdGplZVdNVVluLzQ2ci9rNjhhTG1yYzFZUwpWcTJ2YUZRZU9lYVVYR0RmbzVDM1UyY2Y2cUp0aURFQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzk2ZTRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQTJTUXhkWEIKSWlING9JT0YyUC9ZN0c5T0puWEtqOGNvNldtR3RYdXJ0Y2k2RmhoRC96QVFtd0xMbzdlaDVJSGlQNWdUWXNRNQpUdzdodmxteFFqb3NOblBqdldEb0VWbE9WczFZUjdhTklWYXVYZWdDVWpXTlIxQVZIVnFYWmU5MCtUUWVFWjlhCkVaSmlDbmhKTEtYclNCSlZScDF2VnBhbU1LNjNERDZxMGN1Y21ubU04cFkvQ0VqMzBoZTdFTGxoZEs1emVMK3MKSWtTQmFudGM2WlJmTHNSM1docGtTeDVqVkJSWnZwanpRWDVJUEY3WWJ5WlVwVFV0cENnQXJDNU8xTFR2WnFpcApCOWZGY3I0R2hzZDAyZ01mTk9oZUxvd1F4aUo5L1NGMGZYaE5tMlBtbjR2N043aVRBSzNRWE1GcDlyK1dySGpWCk1aYlN1MTQ2TDdMb29RPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1035"
+      - "1737"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:44 GMT
+      - Tue, 20 Feb 2024 14:10:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3073,7 +3139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52655dba-4e3c-45bc-98d2-8f633fbf721d
+      - 352372ff-f176-4f48-8b24-b38acf543ced
     status: 200 OK
     code: 200
     duration: ""
@@ -3082,23 +3148,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURaakNDQWs2Z0F3SUJBZ0lVYWFCWU1GVjNaVjNtQnRzVTJldWRqN0wySW9Rd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRFNU1pNHhOamd1TVM0eU5UUXdIaGNOCk1qTXhNakU0TVRNeE16RXdXaGNOTXpNeE1qRTFNVE14TXpFd1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05NVGt5TGpFMk9DNHhMakkxTkRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU0zdEN3cFp5Tk04MnpXa1B0TCtPM0RkUW4xSzZVckZUMFRWWGdtcHVFMFdmdHlHWWZtL3h4Rk8KVmhQTGRseW1WVzkxbmM0MVpOQjNrYWdWNTA2dVIwVXRVNEcrdGJzR1hDMzRueVNKenJUcDNTV21FdFllcFc1bgpYZWpKUG04UEJhajBnUTk1RGNCZWhXajNuR080Y1hlRkdjVlFvQUVpdFA2QTVMeXZ6SHgvdUdMZlh0bTQ2bGVUCmRiNEVEVkNCdlVJeVdiYmpYdFJjcW5FQmQyQXd1SXFiY2ZKU2ZkNlRZYy9xL1B3anVoSTlHTThDSWl0b1VmL3MKcjNWelo5ekU3cFJhUlBiMWhoK2hrb29jeklOU3dPSjZ0OUIzSGhrdkxyY3VjdlhMeStOVmVmc1lkbUU1aDRDZAo4Ri9kS2ppeUFodEM1MGtLZHhvMHFGT2tRMGpmVlQwQ0F3RUFBYU1vTUNZd0pBWURWUjBSQkIwd0c0SU5NVGt5CkxqRTJPQzR4TGpJMU5JY0VNdzllZzRjRXdLZ0IvakFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBeFdsb3JaZGYKbTVNY004RDc0bkZlQmcvaUFwRHNXLzhHeWFQbkI3dk94MUdseHdvVzR5VlliYS9IZExheW4vNHlVUmpDRWFERwpTNmdOUENBZllHVXh5SkM1OFV3UG9oZUdrN0RHM3c0anAwdzY5aThFNjk1YmUwcldOZVoxYnRodzNuSSt1QVVtCnZxRmJVTytQQUk1MWVOL1FuNmpMenNzMWx2VXRpejlPYnNUWVlTQUo0WGQ5WHRLcjhxTWQrNXNkdTl3Z3ErZkEKV2tWRFBvZGUyQVUrRTlpeTMwZ1N3TW5TTTlRUDVRL042VWxGMGplSmRZLzZQUlBydys1M09KSnlmMnlubjRRagpsZHNQUVRVS1BBaWdaNk5zZXNuOHNCQzY3N0Y5OWZ5VnNHTExZMlljRXhIUHZPTVhZbUQvNUhHc2x5cStkYjJpCmZZNHZYYTdRNUtYUWJnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1735"
+      - "1076"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:45 GMT
+      - Tue, 20 Feb 2024 14:10:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3106,7 +3172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3e81fd9-7b6d-46db-8328-2db6ec8da79a
+      - a2f70450-7b09-474f-b5e9-aaf3524c8c24
     status: 200 OK
     code: 200
     duration: ""
@@ -3115,23 +3181,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=50542597-2b06-4638-b994-75a604f5f044&resource_type=rdb_instance
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
+    method: DELETE
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "26"
+      - "1079"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:45 GMT
+      - Tue, 20 Feb 2024 14:10:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3139,7 +3205,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d31093f-0a18-4e3c-8ad4-586b829dafc6
+      - d925adff-baab-42eb-9e50-9949f9fe4f5c
     status: 200 OK
     code: 200
     duration: ""
@@ -3148,23 +3214,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:41.922854Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12377601-1a76-4443-a514-11f4d01902a4","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1035"
+      - "1079"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:45 GMT
+      - Tue, 20 Feb 2024 14:10:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3172,7 +3238,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaa3ce22-6b2f-483f-baaa-ed0d5c6f30db
+      - dd7d834f-5882-45d0-a9f4-f8dad5d36a59
     status: 200 OK
     code: 200
     duration: ""
@@ -3181,9 +3247,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/595e8430-6684-4031-be58-1b4291dd1ca6
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/6037c87c-7429-4ebf-961c-c958ec6d445e
     method: DELETE
   response:
     body: ""
@@ -3193,9 +3259,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:45 GMT
+      - Tue, 20 Feb 2024 14:10:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3203,7 +3269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4f33efb-828e-441f-8f03-1eb56cd1d1af
+      - 3e39ed43-6cf2-43a3-8123-b73fd6fc451c
     status: 204 No Content
     code: 204
     duration: ""
@@ -3212,78 +3278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1038"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 92c50d36-03f4-49d4-bdd1-512a8efeb324
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:12:06.764136Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"50542597-2b06-4638-b994-75a604f5f044","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-dhcp","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1038"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:45 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3c915dcb-3bce-49dd-a974-2f522113c884
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"50542597-2b06-4638-b994-75a604f5f044","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"12377601-1a76-4443-a514-11f4d01902a4","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3292,9 +3292,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:16 GMT
+      - Tue, 20 Feb 2024 14:11:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3302,7 +3302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 625a781f-8b82-4559-a8c4-b0a769ff7a37
+      - aeae52fc-6e4e-4286-a56b-6cc29896848a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3311,12 +3311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/50542597-2b06-4638-b994-75a604f5f044
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/12377601-1a76-4443-a514-11f4d01902a4
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"50542597-2b06-4638-b994-75a604f5f044","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"12377601-1a76-4443-a514-11f4d01902a4","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3325,9 +3325,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:16 GMT
+      - Tue, 20 Feb 2024 14:11:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3335,7 +3335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d7ac595-379d-4714-9107-6a0f1a10fb11
+      - 5d19b71a-405d-4902-a09c-b00a4bf4ddbb
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network-update.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network-update.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,9 +318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:04 GMT
+      - Tue, 20 Feb 2024 14:07:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,34 +328,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2e1ffa5-d966-4b3d-9520-f89fab5af7e6
+      - 5f5f78cb-0804-4204-9a6d-f691b49cc3c9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my_private_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "702"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:11 GMT
+      - Tue, 20 Feb 2024 14:07:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a7779d6-b052-4d3b-8052-ecc2715ad7c9
+      - 1a9af159-4130-491b-8d87-a1de4f18c54a
     status: 200 OK
     code: 200
     duration: ""
@@ -372,23 +372,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "702"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:11 GMT
+      - Tue, 20 Feb 2024 14:07:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -396,34 +396,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c99097d6-741b-4587-a706-5e1cd7901748
+      - 79927240-9d62-4066-a9e2-10ee41172528
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-private-network-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","ipam_config":{}}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-private-network-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","ipam_config":{}}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "996"
+      - "1032"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:12 GMT
+      - Tue, 20 Feb 2024 14:07:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -431,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a52baf06-6952-42c4-a3ba-74b8ecfab673
+      - c4458738-10a7-4e46-8dcd-54721f471bfe
     status: 200 OK
     code: 200
     duration: ""
@@ -440,23 +440,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "996"
+      - "1032"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:12 GMT
+      - Tue, 20 Feb 2024 14:07:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -464,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58244741-5c7f-432b-bd66-d50e056de424
+      - c08cc7c6-e0b1-4889-9d58-1ad85c6ba256
     status: 200 OK
     code: 200
     duration: ""
@@ -473,23 +473,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "996"
+      - "1032"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:43 GMT
+      - Tue, 20 Feb 2024 14:08:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 472b0afd-0f72-4e86-8206-7be5193b9aa2
+      - fa129a78-6d6b-43e5-b878-8e80c436f37d
     status: 200 OK
     code: 200
     duration: ""
@@ -506,23 +506,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "996"
+      - "1032"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:13 GMT
+      - Tue, 20 Feb 2024 14:08:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f47098d-b6c1-400b-b427-207fa399efa2
+      - 3dbf998b-7c7e-4fdf-8bb4-2f9cf1f26c4c
     status: 200 OK
     code: 200
     duration: ""
@@ -539,23 +539,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "996"
+      - "1032"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:43 GMT
+      - Tue, 20 Feb 2024 14:09:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 655e1617-7cd7-4895-a639-44a364c4ded8
+      - c9f20bcc-4ed1-45ba-a798-534b180b4892
     status: 200 OK
     code: 200
     duration: ""
@@ -572,23 +572,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "996"
+      - "1032"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:13 GMT
+      - Tue, 20 Feb 2024 14:09:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a65dcb2-a664-4a6d-8da9-80b82c14eba1
+      - 7055dc09-bd09-46d8-87cb-406aa1c1233a
     status: 200 OK
     code: 200
     duration: ""
@@ -605,23 +605,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "996"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:43 GMT
+      - Tue, 20 Feb 2024 14:10:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 746a42af-878a-4598-ac49-85fb7f595af7
+      - 4bb49524-303c-44a0-8ded-436f66179ffd
     status: 200 OK
     code: 200
     duration: ""
@@ -638,23 +638,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1253"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:14 GMT
+      - Tue, 20 Feb 2024 14:10:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc5ede8f-48c9-424a-b55f-93fa9f0c78c3
+      - ff68d426-3ad7-4b97-b919-fb50b111273f
     status: 200 OK
     code: 200
     duration: ""
@@ -671,23 +671,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-20T14:07:46.581682Z","id":"5d550a40-161a-4872-b1f9-b8e4f794bab2","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1dc01ac1-b827-4611-b081-943c96419b72","mac_address":"02:00:00:18:83:4F","name":"test-rdb-private-network-update","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e31cb470-b52b-434a-ad24-629772c44b38"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:14.095723Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1723"
+      - "558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:14 GMT
+      - Tue, 20 Feb 2024 14:10:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2caa5dc4-2af5-4a8f-ad45-93c984acd14a
+      - 0643c274-7608-4850-98a0-24cfc8e9c51d
     status: 200 OK
     code: 200
     duration: ""
@@ -704,23 +704,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.32.2/22","created_at":"2023-12-18T13:11:12.333430Z","id":"07b72054-9c99-4864-ad2c-34d33190028d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:10","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:11:55.863244Z","zone":null}],"total_count":1}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "528"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:14 GMT
+      - Tue, 20 Feb 2024 14:10:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be098fc0-e2c1-4750-b4f9-33a84a59993a
+      - a7765612-ebf7-472e-a791-ada50708f7ed
     status: 200 OK
     code: 200
     duration: ""
@@ -737,23 +737,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "702"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:14 GMT
+      - Tue, 20 Feb 2024 14:10:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58906fe0-55da-42b9-90fc-ee31683ad66f
+      - 7f741e5c-bc72-4ac0-a629-6799799f301a
     status: 200 OK
     code: 200
     duration: ""
@@ -770,23 +770,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1253"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:15 GMT
+      - Tue, 20 Feb 2024 14:10:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a90837a7-654c-47dd-94b8-f9208e8b8b8c
+      - 50f9fd13-0239-4e94-bad8-c88e88842c11
     status: 200 OK
     code: 200
     duration: ""
@@ -803,23 +803,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "702"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:15 GMT
+      - Tue, 20 Feb 2024 14:10:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61fed899-8ce9-4dc7-9c01-83fded566cd6
+      - 2be4f005-82f0-4407-bc95-3c46272d4135
     status: 200 OK
     code: 200
     duration: ""
@@ -836,23 +836,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1253"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:15 GMT
+      - Tue, 20 Feb 2024 14:10:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6079955b-e121-44e3-9811-e316f9db2cd1
+      - 170ea317-dafd-458c-81ce-945e0f001061
     status: 200 OK
     code: 200
     duration: ""
@@ -869,23 +869,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-20T14:07:46.581682Z","id":"5d550a40-161a-4872-b1f9-b8e4f794bab2","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1dc01ac1-b827-4611-b081-943c96419b72","mac_address":"02:00:00:18:83:4F","name":"test-rdb-private-network-update","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e31cb470-b52b-434a-ad24-629772c44b38"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:14.095723Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1723"
+      - "558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:15 GMT
+      - Tue, 20 Feb 2024 14:10:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0c38146-6012-4fd6-99f8-c4d02103a916
+      - a075b52b-38f3-46e1-b664-9932fd1631c4
     status: 200 OK
     code: 200
     duration: ""
@@ -902,23 +902,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.32.2/22","created_at":"2023-12-18T13:11:12.333430Z","id":"07b72054-9c99-4864-ad2c-34d33190028d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:10","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:11:55.863244Z","zone":null}],"total_count":1}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "528"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:15 GMT
+      - Tue, 20 Feb 2024 14:10:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b8a64ab-dc31-4149-8285-9f750dbbbb43
+      - c5d72197-ee89-4be7-8755-77f4d5e15c5b
     status: 200 OK
     code: 200
     duration: ""
@@ -935,23 +935,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "702"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:15 GMT
+      - Tue, 20 Feb 2024 14:10:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de34ca50-56a8-4fdd-8e10-c400c06cb303
+      - 4e8ec804-b197-46c9-9142-762edbd1e5d4
     status: 200 OK
     code: 200
     duration: ""
@@ -968,23 +968,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1253"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:15 GMT
+      - Tue, 20 Feb 2024 14:10:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90c65e46-c83b-4294-80a0-4df0a40379d6
+      - 143136d9-e360-40ed-99ef-93d9abece500
     status: 200 OK
     code: 200
     duration: ""
@@ -1001,23 +1001,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-20T14:07:46.581682Z","id":"5d550a40-161a-4872-b1f9-b8e4f794bab2","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1dc01ac1-b827-4611-b081-943c96419b72","mac_address":"02:00:00:18:83:4F","name":"test-rdb-private-network-update","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e31cb470-b52b-434a-ad24-629772c44b38"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:08:14.095723Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1723"
+      - "558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:16 GMT
+      - Tue, 20 Feb 2024 14:10:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1025,67 +1025,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c124070-51ea-419a-8e28-608bd5a0cf2d
+      - 81439a4c-173f-4182-a3e1-e050f307676e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[{"address":"172.16.32.2/22","created_at":"2023-12-18T13:11:12.333430Z","id":"07b72054-9c99-4864-ad2c-34d33190028d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:10","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:11:55.863244Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "528"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 61f9249c-fc3e-44e6-acbf-e1710be92ac4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"my_second_private_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"my_second_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:17 GMT
+      - Tue, 20 Feb 2024 14:10:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1093,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 020cd957-340e-4908-a251-820a393b136d
+      - afc081cf-8434-4f06-b80b-56c20c328fd4
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,23 +1069,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:17 GMT
+      - Tue, 20 Feb 2024 14:10:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1126,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee0425fa-350e-46db-a12c-124d634d7712
+      - fe2e6845-be9c-445c-b06a-9239af38d933
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,23 +1102,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1253"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:17 GMT
+      - Tue, 20 Feb 2024 14:10:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1159,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ccf20c0-8da1-4655-a52c-7c2686587f71
+      - 1d782209-4aa7-4122-a2a1-8e155fbb28fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,23 +1135,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1253"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:17 GMT
+      - Tue, 20 Feb 2024 14:10:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1192,834 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35800d3a-45a0-4d69-9f06-7626efa98c9d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: PATCH
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1253"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0ed6ef6e-d3ae-48bf-b02d-9e9a8e1f58cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1253"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dfbf0a83-cec4-4f49-99ba-82fdc26bcde5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/da8c6a95-e2f9-497d-9fff-7c94237a17ae
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 16e24149-184c-4be3-9a03-9f9ccddd91e2
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"da8c6a95-e2f9-497d-9fff-7c94237a17ae","ip":"172.16.32.2","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1259"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 91890826-fcb8-4fff-b240-4bcb99124c1d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1037"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4053286c-c779-4f2a-844c-30f8a89a75bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","ipam_config":{}}}}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/endpoints
-    method: POST
-  response:
-    body: '{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "218"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eefd8bd8-f006-4011-a919-9d3c4e42b412
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1262"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:14:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42ad1971-a4bc-48ad-be48-647bb1282dad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1255"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 66a57e09-e77c-4863-bf1f-f80b4a77da9d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1723"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 887086da-dba7-4fb9-b96e-0a8c44146851
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[{"address":"172.16.112.2/22","created_at":"2023-12-18T13:14:54.913878Z","id":"ba564d68-537c-4a92-a4a0-1b0503c6acfa","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:19","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"38e04ba4-c22c-46fe-8425-af85dcf01b16"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:14:56.649295Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "529"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fdd34dac-9663-4c70-a316-f3786e6036b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c3f18d46-859e-47ba-9d12-d85bdb306a20
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "710"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e3ddf278-95b0-409f-9886-9eda9e97e33d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1255"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71dd2243-8f55-4ec1-aaf2-66864b588c8f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c6bfdc5-192d-4982-aac6-acf5d525021d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "710"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2712e33a-1f6b-4821-902e-67f82b9c0c43
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1255"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6ff389bd-81bd-4918-a0e4-e57c79a03e5d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1723"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 771733c1-afde-4da0-b315-74fd75140222
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[{"address":"172.16.112.2/22","created_at":"2023-12-18T13:14:54.913878Z","id":"ba564d68-537c-4a92-a4a0-1b0503c6acfa","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:19","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"38e04ba4-c22c-46fe-8425-af85dcf01b16"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:14:56.649295Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "529"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3db4211e-8feb-441e-befb-2f623391bbd9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "710"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 98f5a948-bf98-42dc-b20e-7e8fd2a8c401
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2071d42-f8ed-4972-b809-df51b5fc0f30
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1255"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 77550f4e-4a37-4746-b61a-81aae95a64a0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1723"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3e3b64ef-dcd3-4ef8-b6c6-bdc4694d5b46
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[{"address":"172.16.112.2/22","created_at":"2023-12-18T13:14:54.913878Z","id":"ba564d68-537c-4a92-a4a0-1b0503c6acfa","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","mac_address":"02:00:00:15:AA:19","name":"test-rdb-private-network-update","type":"rdb_instance"},"source":{"subnet_id":"38e04ba4-c22c-46fe-8425-af85dcf01b16"},"tags":["managed","scwdbaas"],"updated_at":"2023-12-18T13:14:56.649295Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "529"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 42f8ef28-e1e8-44e6-b05d-db5fdbb92e6d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1255"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:33 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 22c546a9-8d48-444a-beed-d9f57fa7d433
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1255"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:15:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 82785c9b-e65b-4104-90d8-2e3d78b3b80f
+      - ebc721b7-6462-487e-8baa-48f8765859e3
     status: 200 OK
     code: 200
     duration: ""
@@ -2030,23 +1170,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:34 GMT
+      - Tue, 20 Feb 2024 14:10:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2054,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96d4a744-0710-4721-9514-4a73eba4fe9c
+      - e3b0d04e-aecc-4151-87d9-592cddc17a27
     status: 200 OK
     code: 200
     duration: ""
@@ -2063,23 +1203,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:34 GMT
+      - Tue, 20 Feb 2024 14:10:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2087,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb997d82-589a-4603-b0b3-aa8e83561c3e
+      - 312ef271-47ec-4ef9-8a53-4bae2d870cee
     status: 200 OK
     code: 200
     duration: ""
@@ -2096,9 +1236,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/8450a676-f697-48d5-bbd3-bd30560a9d02
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/5878d492-1e8c-4c51-a502-2c141bab93e5
     method: DELETE
   response:
     body: ""
@@ -2108,9 +1248,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:34 GMT
+      - Tue, 20 Feb 2024 14:10:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2118,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3499a08-8c60-41b1-b7ea-0db85b2174a7
+      - 9a273952-af18-400f-8cf0-9cc917b3c93b
     status: 204 No Content
     code: 204
     duration: ""
@@ -2127,23 +1267,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"8450a676-f697-48d5-bbd3-bd30560a9d02","ip":"172.16.112.2","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"5878d492-1e8c-4c51-a502-2c141bab93e5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1306"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:35 GMT
+      - Tue, 20 Feb 2024 14:10:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2151,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d9187c9-5fc8-4016-8911-1d67d6a2c202
+      - 4a33e15c-4a25-433f-9958-678833779887
     status: 200 OK
     code: 200
     duration: ""
@@ -2160,23 +1300,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1037"
+      - "1078"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:05 GMT
+      - Tue, 20 Feb 2024 14:11:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2184,34 +1324,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5a9fde4-0b54-45b2-aa67-4f69b41de62c
+      - b0b0b547-7c78-46f5-96fe-a94883b76b9a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","ipam_config":{}}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/endpoints
     method: POST
   response:
-    body: '{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}'
+    body: '{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "218"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:05 GMT
+      - Tue, 20 Feb 2024 14:11:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2219,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4495009a-57bc-4e41-bddc-9e407c1f8e7c
+      - 7116012c-b9d6-4e49-a756-0485a2ba421e
     status: 200 OK
     code: 200
     duration: ""
@@ -2228,23 +1368,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1262"
+      - "1307"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:06 GMT
+      - Tue, 20 Feb 2024 14:11:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2252,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 849da146-7252-405a-a6de-939a17d3aaea
+      - 1bbab53d-05d8-4566-af97-6402fda1a459
     status: 200 OK
     code: 200
     duration: ""
@@ -2261,23 +1401,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:36 GMT
+      - Tue, 20 Feb 2024 14:11:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2285,7 +1425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31e72a40-df9a-4a53-864a-16c1ee78cbc9
+      - 8a92d68c-06f5-4380-823d-93f1b7117f4d
     status: 200 OK
     code: 200
     duration: ""
@@ -2294,23 +1434,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1723"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:36 GMT
+      - Tue, 20 Feb 2024 14:11:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2318,7 +1458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb05fe4b-4bfa-4441-9d3c-d94e027ef8ff
+      - 0c33f182-a1a2-46be-81ea-ae8d0b30e861
     status: 200 OK
     code: 200
     duration: ""
@@ -2327,23 +1467,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2024-02-20T14:11:09.196117Z","id":"6a763bdc-dd4f-450b-bdb0-a717094c98c4","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1dc01ac1-b827-4611-b081-943c96419b72","mac_address":"02:00:00:18:83:5A","name":"test-rdb-private-network-update","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:11:10.166173Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "26"
+      - "558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:36 GMT
+      - Tue, 20 Feb 2024 14:11:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2351,7 +1491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82b284ef-e47f-4792-bd47-084bcaab14d0
+      - c26fa80e-4f18-4ebd-85b1-a0a3012c3a49
     status: 200 OK
     code: 200
     duration: ""
@@ -2360,23 +1500,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:36 GMT
+      - Tue, 20 Feb 2024 14:11:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2384,7 +1524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed104feb-b8bf-4380-a8ef-cb55752613dd
+      - 8503a32a-23ce-4690-b234-fa7c67a1b107
     status: 200 OK
     code: 200
     duration: ""
@@ -2393,23 +1533,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1255"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:36 GMT
+      - Tue, 20 Feb 2024 14:11:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2417,7 +1557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8d27be4-00fe-459d-afa9-eb2938026fd2
+      - 5b249c81-4caa-40f7-a44b-c5c3a8f36ae5
     status: 200 OK
     code: 200
     duration: ""
@@ -2426,23 +1566,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "710"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2450,7 +1590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69599299-e326-4565-9dfe-f1fa0f0b8966
+      - 0c57439a-1635-4e77-a667-5e636b3ca449
     status: 200 OK
     code: 200
     duration: ""
@@ -2459,23 +1599,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "702"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2483,7 +1623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec3ad2df-a08e-4fed-a7e0-b664ca404c1b
+      - 5d69a3c0-dcaa-4bef-a977-8dbe3173ab5b
     status: 200 OK
     code: 200
     duration: ""
@@ -2492,23 +1632,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1255"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2516,7 +1656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d4b1852-d8e9-4a73-9f53-6486175c056f
+      - 39758ee4-ebbb-4671-9b7c-4fdf1ed53618
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,23 +1665,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1723"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2549,7 +1689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d60b7f3-f0b3-43f2-9f89-add997ff51b2
+      - 3906b3a5-2c47-44cb-aa46-1bd31eef2e0c
     status: 200 OK
     code: 200
     duration: ""
@@ -2558,23 +1698,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "26"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2582,7 +1722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ecfc3d3-1c5f-43c9-aca5-83f211768933
+      - 74a043a8-d50a-4aec-842d-d84cc28d1e24
     status: 200 OK
     code: 200
     duration: ""
@@ -2591,23 +1731,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2024-02-20T14:11:09.196117Z","id":"6a763bdc-dd4f-450b-bdb0-a717094c98c4","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1dc01ac1-b827-4611-b081-943c96419b72","mac_address":"02:00:00:18:83:5A","name":"test-rdb-private-network-update","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:11:10.166173Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "710"
+      - "558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2615,7 +1755,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f97d60d7-e9f4-4bf2-9b3e-6268983d4340
+      - 81ce648b-9fbf-4037-91c0-04fb9f14a6ef
     status: 200 OK
     code: 200
     duration: ""
@@ -2624,23 +1764,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "702"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2648,7 +1788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6334e7c3-d10e-46dc-8dcc-65e08dfa4e19
+      - 86ea4b7c-9fb7-4a0f-82d1-0064a2dd3d0c
     status: 200 OK
     code: 200
     duration: ""
@@ -2657,23 +1797,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1255"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2681,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56a1a3a7-207f-4f07-8e06-10f2edb8a741
+      - c160d99a-c59b-4225-ba3e-8163ddee3ba8
     status: 200 OK
     code: 200
     duration: ""
@@ -2690,23 +1830,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1723"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:37 GMT
+      - Tue, 20 Feb 2024 14:11:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2714,7 +1854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c8ec92d-526a-47a7-90eb-0503b9aac26f
+      - 7bc653e3-8e68-448c-9613-0cbaa105d2a6
     status: 200 OK
     code: 200
     duration: ""
@@ -2723,23 +1863,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "26"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:38 GMT
+      - Tue, 20 Feb 2024 14:11:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2747,7 +1887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4e91be4-0a58-4e85-a0b1-d42df5f53a5b
+      - 6552195a-5063-4bfa-9312-48c4fd30226b
     status: 200 OK
     code: 200
     duration: ""
@@ -2756,23 +1896,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2024-02-20T14:11:09.196117Z","id":"6a763bdc-dd4f-450b-bdb0-a717094c98c4","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1dc01ac1-b827-4611-b081-943c96419b72","mac_address":"02:00:00:18:83:5A","name":"test-rdb-private-network-update","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:11:10.166173Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "1255"
+      - "558"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:38 GMT
+      - Tue, 20 Feb 2024 14:11:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2780,7 +1920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5ac15fe-7eee-4a72-a96f-64b27581370a
+      - 6a9c82fe-35c8-40ea-a3b9-3bee045b8ee6
     status: 200 OK
     code: 200
     duration: ""
@@ -2789,23 +1929,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:38 GMT
+      - Tue, 20 Feb 2024 14:11:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2813,7 +1953,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d137430-b7ce-463b-aa78-0c5fa7dd431b
+      - 0d91da2f-180f-4f61-9911-132e33e961af
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:11:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1df2ed1d-d043-49ca-bb69-faebd2b59132
     status: 200 OK
     code: 200
     duration: ""
@@ -2824,23 +1997,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:38 GMT
+      - Tue, 20 Feb 2024 14:11:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2848,7 +2021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81456f5f-9f37-4af8-b931-f4de28b17924
+      - 3ff1df20-9366-4a80-aa75-aff75ae110e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2857,23 +2030,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1255"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:39 GMT
+      - Tue, 20 Feb 2024 14:11:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2881,7 +2054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a1808bc-7047-443b-b884-a8c8c15791ae
+      - 3dc5fe99-4366-4eb2-894b-19d972945773
     status: 200 OK
     code: 200
     duration: ""
@@ -2890,9 +2063,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/a294d2ef-8d5f-4c58-975a-87889661c0fd
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/47e378dc-9c10-4cba-b503-cc5ecbff9854
     method: DELETE
   response:
     body: ""
@@ -2902,9 +2075,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:39 GMT
+      - Tue, 20 Feb 2024 14:11:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2912,7 +2085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8407917a-c9b2-4c88-8df8-0e4b524127a9
+      - 37952228-3e1b-4b4b-9675-394f33697941
     status: 204 No Content
     code: 204
     duration: ""
@@ -2921,23 +2094,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"a294d2ef-8d5f-4c58-975a-87889661c0fd","ip":"172.16.112.4","name":null,"port":5432,"private_network":{"private_network_id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","service_ip":"172.16.112.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"47e378dc-9c10-4cba-b503-cc5ecbff9854","ip":"172.16.40.2","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1261"
+      - "1306"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:39 GMT
+      - Tue, 20 Feb 2024 14:11:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2945,7 +2118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a30ebf3a-b693-4738-a3eb-fae2f173e3f1
+      - ec80f20a-bf1d-45d7-9e5f-fa040992312e
     status: 200 OK
     code: 200
     duration: ""
@@ -2954,23 +2127,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1037"
+      - "1078"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:09 GMT
+      - Tue, 20 Feb 2024 14:12:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2978,34 +2151,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8713533d-7f4a-478a-a3fa-ab31c270ca84
+      - a35b6526-1d60-4c4e-adda-4ff868852d0e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22"}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/endpoints
     method: POST
   response:
-    body: '{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}'
+    body: '{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "216"
+      - "222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:10 GMT
+      - Tue, 20 Feb 2024 14:12:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3013,7 +2186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d7072a2-26fc-42d7-a30f-1b9c00bdf691
+      - 30259482-11bb-4ef5-b5e6-8fe91ad83ba0
     status: 200 OK
     code: 200
     duration: ""
@@ -3022,23 +2195,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1260"
+      - "1307"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:10 GMT
+      - Tue, 20 Feb 2024 14:12:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3046,7 +2219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f978e83a-f04b-4d0e-8f0e-7ceba59f5a9b
+      - 37a93644-b707-40dc-9370-0808516ee5c0
     status: 200 OK
     code: 200
     duration: ""
@@ -3055,23 +2228,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1253"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:40 GMT
+      - Tue, 20 Feb 2024 14:12:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3079,7 +2252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c61a678-e6b4-4a58-9759-78d7c5f4245d
+      - e3e6fecb-9bab-4f38-971b-4f850a84ee64
     status: 200 OK
     code: 200
     duration: ""
@@ -3088,23 +2261,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1723"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:40 GMT
+      - Tue, 20 Feb 2024 14:12:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3112,7 +2285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a357501-d717-4eaf-a123-5415c0537d17
+      - d1e74e23-68a7-4d0d-831a-5282479b5d0b
     status: 200 OK
     code: 200
     duration: ""
@@ -3121,287 +2294,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "26"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5150e999-d434-41b8-ae27-b9052bbe5923
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1d96fe73-91ae-43b9-ad7b-cd2836355bd0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "710"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c068e03e-bb5f-48ca-8a0a-f8b2408c519c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1253"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd8b41e5-a982-4fd8-be69-012f16a0afb6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "710"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 909f3c0e-359f-450a-b911-828f5407210e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 53882cbe-4f22-4765-9f02-69089b7d7428
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1253"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd3c6ee7-885d-4dc4-9585-3e3853bd28c4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1723"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fc8d469d-a469-4322-82f3-e6bfbd9469f2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:42 GMT
+      - Tue, 20 Feb 2024 14:12:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3409,7 +2318,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e28e8993-af4d-4386-8243-20a598f0a79d
+      - 2c6d1ffa-3c43-427b-b32e-eb4a7b75cc86
     status: 200 OK
     code: 200
     duration: ""
@@ -3418,23 +2327,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:14:16.359874Z","dhcp_enabled":true,"id":"e6ef5ef7-0851-4498-a08f-88a7795b9e7e","name":"my_second_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:14:16.359874Z","id":"38e04ba4-c22c-46fe-8425-af85dcf01b16","subnet":"172.16.112.0/22","updated_at":"2023-12-18T13:14:16.359874Z"},{"created_at":"2023-12-18T13:14:16.359874Z","id":"46203135-de94-4c4e-b85f-51e9b3a23447","subnet":"fd5f:519c:6d46:b3f1::/64","updated_at":"2023-12-18T13:14:16.359874Z"}],"tags":[],"updated_at":"2023-12-18T13:14:16.359874Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "710"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:42 GMT
+      - Tue, 20 Feb 2024 14:12:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3442,7 +2351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b9685d4-f070-4302-8f41-43521ccf752f
+      - bcffc051-51ed-4d00-9d38-c88b4a0ebd98
     status: 200 OK
     code: 200
     duration: ""
@@ -3451,23 +2360,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "702"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:42 GMT
+      - Tue, 20 Feb 2024 14:12:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3475,7 +2384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8011c83-8b09-4e17-99d6-ae2dd17ca52d
+      - a9b76f24-6537-49ec-9634-b42b8c2456eb
     status: 200 OK
     code: 200
     duration: ""
@@ -3484,23 +2393,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1253"
+      - "726"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:42 GMT
+      - Tue, 20 Feb 2024 14:12:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3508,7 +2417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5f6ea65-26bf-417c-8faa-23e34154b1ad
+      - e1a137ec-223a-4ab2-b9d2-4877278ff69a
     status: 200 OK
     code: 200
     duration: ""
@@ -3517,23 +2426,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1723"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:42 GMT
+      - Tue, 20 Feb 2024 14:12:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3541,7 +2450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0913f225-1724-4a67-915e-35c347d97bcf
+      - 074e1039-9ae0-40f4-b347-22c9f1821428
     status: 200 OK
     code: 200
     duration: ""
@@ -3550,23 +2459,89 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4a39b7d-d030-4aff-97fd-d7934de24f27
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - be97ca4f-8ad3-4e33-9cdb-6ff0a5cc05c1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:42 GMT
+      - Tue, 20 Feb 2024 14:12:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3574,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0fe0bb5-7edc-4a60-9c86-e4ce983ae6c4
+      - e135d9e2-924b-4980-b09a-44792ea1e41e
     status: 200 OK
     code: 200
     duration: ""
@@ -3583,9 +2558,308 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e6ef5ef7-0851-4498-a08f-88a7795b9e7e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "726"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8070c8cd-4898-4e35-8427-8050e1dff87e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ddd739c-ab52-4c3e-8f9b-f046405a9fac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df99794e-5518-40e9-a816-74c9b5c026a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4d7e58ae-c7fe-4bdf-b5f8-b747e9292845
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b661f101-9c8e-4823-9a77-0edfdc9a4c7b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df35f309-f905-4fa7-9b80-27d309a7a02d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7fac97e5-51e2-4a1e-9ea2-f7e47d35a711
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: PATCH
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6a442979-a226-4f7e-b663-96af67c68d1e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:12:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3b80723e-c0ad-48fb-a320-35fef801648c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/86374001-38df-43b0-ad23-44fa5521aa5e
     method: DELETE
   response:
     body: ""
@@ -3595,9 +2869,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:43 GMT
+      - Tue, 20 Feb 2024 14:12:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3605,7 +2879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a869ca5-4495-46b2-9c43-2568469e2adc
+      - 9a4224fa-720a-43ff-8dc2-e6555d9ac167
     status: 204 No Content
     code: 204
     duration: ""
@@ -3614,23 +2888,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"86374001-38df-43b0-ad23-44fa5521aa5e","ip":"172.16.40.4","name":null,"port":5432,"private_network":{"private_network_id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","service_ip":"172.16.40.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "702"
+      - "1306"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:43 GMT
+      - Tue, 20 Feb 2024 14:12:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3638,7 +2912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e36ee24-c534-4fc0-b479-995ba04a4ffd
+      - 79d253f3-19de-4887-b007-98f086ae305c
     status: 200 OK
     code: 200
     duration: ""
@@ -3647,23 +2921,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1253"
+      - "1078"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:44 GMT
+      - Tue, 20 Feb 2024 14:13:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3671,7 +2945,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 266e16e1-1556-4ee7-a6e1-abeacf2bc0e2
+      - 31fdcc50-cff3-4d17-983d-0c47a37605a0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22"}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/endpoints
+    method: POST
+  response:
+    body: '{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "222"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:23 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35b97a3a-680b-430b-aba6-2a6aa82a6bc6
     status: 200 OK
     code: 200
     duration: ""
@@ -3680,23 +2989,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:11:10.877701Z","dhcp_enabled":true,"id":"b1140239-acf5-4862-b7df-3e03e16fa170","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-18T13:11:10.877701Z","id":"46d2ff0d-8ab5-4290-a59e-020165e3c4e3","subnet":"172.16.32.0/22","updated_at":"2023-12-18T13:11:10.877701Z"},{"created_at":"2023-12-18T13:11:10.877701Z","id":"623968ee-0917-428d-8487-bc9216549ea6","subnet":"fd5f:519c:6d46:1553::/64","updated_at":"2023-12-18T13:11:10.877701Z"}],"tags":[],"updated_at":"2023-12-18T13:11:10.877701Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "702"
+      - "1307"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:44 GMT
+      - Tue, 20 Feb 2024 14:13:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3704,7 +3013,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caf1cccd-3fe9-49b6-b9ab-ee7a87689060
+      - 001a3e59-756d-425d-917c-2518af072bac
     status: 200 OK
     code: 200
     duration: ""
@@ -3713,23 +3022,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1253"
+      - "1300"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:44 GMT
+      - Tue, 20 Feb 2024 14:13:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3737,7 +3046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77727631-5d78-48af-8683-e5fef018be83
+      - 6e8aa2eb-2fad-48ca-a4ee-9bb781db019e
     status: 200 OK
     code: 200
     duration: ""
@@ -3746,23 +3055,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVZmUyaXprWTJQUGVrUm0vSm9SYjBlQnkwckJZd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR6TWk0eU1CNFhEVEl6Ck1USXhPREV6TVRJeU4xb1hEVE16TVRJeE5URXpNVEl5TjFvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0ek1pNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF0Yms0WHJmcVoxRTlobUlSUnR6L0JMSzNRWDhSbDhmbUxDUGJvZnlDblBYbkhrcWVEZ1hVUUlYYTlZM3IKOThRNWYzQWNEaDNRSWJxSDNOdnFLQTBHOHcxSEkzdVFEK2RkUnpFNlJJQjhBV2I0aDBmV3ZqNjgwTmdBK1V0agowVWI4NEVVT2pvVkVzSkFndTRxbFZ5cmtmREh1eEpuYitlYXRlTXdGMXd6c0NENnpnczV3Nmd4Y3NUOTJrc3ZTClZwTzJXc3llcndtUm5MNFY2RXU4R3gxcEpsdlN1SDRERVM0aXRtZFVUUER3YjRSaC9XRFh2T3FJRm9JdVNrWWIKVU5YcENGd3pqNFJtQ1BNamdQV3Z5S3FrWFFFdXpZWXlUSFl3T0NTQzI5MWFzWldKZzdYU1djaWM2ZHd5V1JxQwpMOTR6Vlg4ZUhWMG5pd1RETFlGTGhSNmNMUUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck16SXVNb2NFTXcvN2I0Y0VyQkFnQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWp4TXRtcDhtbXlyUXRjZUkKNStlcVVSUUZEY1ZBVkQ0MGtlUHZxQUdmY0ZFanBQZ1JjMk95ZjZUT0JtMXpWMW9hbFJmSnVUUldjT25hMlRoTApoNEFxRmV3Z0l1WEVsVit3OFd4ekJFa1V3N1lDK0hiT0pUS2gxVCtKOU5nZWtERHJJUnpvQno3a0c4emJWQXBJCnNDdGowQ2Jwd2VZM0pSRVQvaDZma1BmT0txQWNJRlRCYXFaalNGdGZsREdxMmY4eXBGNWJ0UXc2NjJrV0k5cWIKZ0R3WnVHV050VmMzbk1wYXNvaUJQQzMxMXU5TXdpWWw0L3daZitpS1Qya1g4VjJ0eGZTS0hLWHM2Z2pDRUN4Qwo0T1MxTWZrclN6azNYd0dsK3kxL3VvV0ViL3dGRmVneE9HbmRhb0QyUUFDYWIrcGUreEw4cm1nM1ZaNzZyRU5rCkdVcm9xZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1723"
+      - "1725"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:44 GMT
+      - Tue, 20 Feb 2024 14:13:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3770,7 +3079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63f2ed2d-0be1-4400-8811-8a7b67af6349
+      - 5415ca8f-dfcf-4e39-9c1a-1ce53e121999
     status: 200 OK
     code: 200
     duration: ""
@@ -3779,23 +3088,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=aab3574a-aa1a-42bc-a445-a3396cb432b1&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:44 GMT
+      - Tue, 20 Feb 2024 14:13:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3803,7 +3112,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ee8d7d0-9550-44cb-a76c-31069b2733a2
+      - de967c33-7bb9-40fa-b760-b1c06f273643
     status: 200 OK
     code: 200
     duration: ""
@@ -3812,23 +3121,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "1253"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:44 GMT
+      - Tue, 20 Feb 2024 14:13:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3836,7 +3145,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 342df190-62eb-4040-a990-4746fc64acd9
+      - 9800b78c-edee-45c3-bb2f-598c56e3cdd5
     status: 200 OK
     code: 200
     duration: ""
@@ -3845,23 +3154,551 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "726"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62f26804-7863-49eb-bb51-bd9dc5f6c242
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4d6cf3eb-2fde-46e1-a258-0b3a8e7e5222
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "726"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52f4add1-a1fa-4c62-b9b8-398edf3e87d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 109a1a3f-51a3-4e83-af3a-8f600b06a51c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ccb98801-7241-4902-9ac7-a9c218d12122
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e358516-1fea-4b8c-a4c4-5db6239b54e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7cf59b26-8e46-48fd-9a16-8dbadd5ca9a9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:10:37.070556Z","dhcp_enabled":true,"id":"e9d7a8c1-42e6-497d-8547-285e77c27b46","name":"my_second_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:10:37.070556Z","id":"866e4bb8-ebc9-4bd1-a8b6-d8fd1c387b85","subnet":"172.16.40.0/22","updated_at":"2024-02-20T14:10:37.070556Z"},{"created_at":"2024-02-20T14:10:37.070556Z","id":"bdd3da51-22c4-4b47-848f-750b1a0e3d82","subnet":"fd63:256c:45f7:ffbe::/64","updated_at":"2024-02-20T14:10:37.070556Z"}],"tags":[],"updated_at":"2024-02-20T14:10:37.070556Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "726"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 871df6ca-8cdd-4b48-a5d1-7a4d85bd5024
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 076fa7e6-b17e-4c83-97e9-17f9518788a6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 939dd33a-600b-4506-a3d4-8f39da3728d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73ec7737-5b1a-4ee4-9b18-7a968ed168b1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed47050b-b5e2-4747-acf6-b5d93379f3f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3030312a-19bd-40ec-8d59-7f9ec8f386f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ffd88613-ce7d-44fe-ad29-a20e0ccd3a03
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: PATCH
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 262232d8-e53a-4b18-aee7-c02aee61c350
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 28d31ead-803b-47c9-8a2a-ee5dd9989337
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/863ccdf8-e25f-4c13-bee0-6890dba79cd4
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: ""
     headers:
-      Content-Length:
-      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:45 GMT
+      - Tue, 20 Feb 2024 14:13:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3869,7 +3706,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52107bc9-3efe-44df-84d5-092b8b0826f5
+      - bf0bf9db-a7f2-4b76-82d3-d988706efda6
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"863ccdf8-e25f-4c13-bee0-6890dba79cd4","ip":"172.16.28.4","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1306"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5ec22a8d-82b7-46da-b29b-a9900e50c132
     status: 200 OK
     code: 200
     duration: ""
@@ -3878,23 +3748,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
-    method: GET
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e9d7a8c1-42e6-497d-8547-285e77c27b46
+    method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:11:11.963651Z","endpoint":null,"endpoints":[{"id":"88df8fba-0cb9-484f-ac63-5b5723d1a972","ip":"172.16.32.4","name":null,"port":5432,"private_network":{"private_network_id":"b1140239-acf5-4862-b7df-3e03e16fa170","service_ip":"172.16.32.4/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: ""
     headers:
-      Content-Length:
-      - "1256"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:45 GMT
+      - Tue, 20 Feb 2024 14:14:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3902,7 +3770,75 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fb0ddc5-860e-44e0-9758-4d4345eebee1
+      - 2b5a1983-1f16-4e87-b4d4-cf3a50766f19
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1078"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f54d787e-d5dd-45fb-ac20-d606b7ef8049
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","ipam_config":{}}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/endpoints
+    method: POST
+  response:
+    body: '{"id":"62a8d6ed-6a04-440a-906c-26e44bebd0a5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "222"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4217336d-1b58-4d94-acdf-070278fab45f
     status: 200 OK
     code: 200
     duration: ""
@@ -3911,12 +3847,441 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","type":"not_found"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"62a8d6ed-6a04-440a-906c-26e44bebd0a5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1307"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c9fbfb2-f8ea-495f-9300-95892e08fec4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"62a8d6ed-6a04-440a-906c-26e44bebd0a5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6d5bfd11-0f4c-425c-9fae-68fee2e75f0d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 392e9f8b-a3a7-4ff5-82a0-e9305b783a2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-20T14:14:30.728077Z","id":"9efb059d-7518-4c0e-8245-9f39d8296f09","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1dc01ac1-b827-4611-b081-943c96419b72","mac_address":"02:00:00:18:83:68","name":"test-rdb-private-network-update","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e31cb470-b52b-434a-ad24-629772c44b38"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:14:32.202674Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "558"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fbc08acf-c12e-4f09-bab5-f225c306c908
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 76a5cc6c-5b72-4591-9ea9-40dfd975148b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"62a8d6ed-6a04-440a-906c-26e44bebd0a5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1bb731fb-66d9-4b7f-8f68-d79f4838d2fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:07:41.037709Z","dhcp_enabled":true,"id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-20T14:07:41.037709Z","id":"e31cb470-b52b-434a-ad24-629772c44b38","subnet":"172.16.28.0/22","updated_at":"2024-02-20T14:07:41.037709Z"},{"created_at":"2024-02-20T14:07:41.037709Z","id":"1f6169ed-78a0-45e5-9502-6e61d6ea66b5","subnet":"fd63:256c:45f7:269::/64","updated_at":"2024-02-20T14:07:41.037709Z"}],"tags":[],"updated_at":"2024-02-20T14:07:41.037709Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b3c42283-164f-4f0a-9175-2b2d9464399d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"62a8d6ed-6a04-440a-906c-26e44bebd0a5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1f962a6c-4f85-4f58-ba73-730272263872
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVTElUMGhLclpaRWdvNUJDUERwUjM2RHdjNnJ3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5T0M0eU1CNFhEVEkwCk1ESXlNREUwTURnME5sb1hEVE0wTURJeE56RTBNRGcwTmxvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU9DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUF5djUwdXB4by9pbGo0U0pYVTE0cE41YTc4NXhWbWx0TGg3TWdNK0cxYjdtMmxGN1M2TDhSN0FGL2FINmUKMnBLRjRsN2ZqeXZYUllyTGlEZHpYV2tyUTJzbHZjV3pnYTM2S2ZWVnNNOGc2TXZ2eE1tcHByTElKZk83LzIwdwo2eGR3b0g3eSs3RjFGNHlkUkcxaGlTczRRcGVaZ3RXZjdaTFljaDJpemR2YlBFOHdGL1N2Z01NK0JQS1hMV0VwCmkrZER5aWoveHFQV3JoczVQb3VRcnI3NmRrcURsNU9IckNlbW44MjM2cERnV3ByYlJGVGNDOWtvdFpZcGROUGcKOG9jdFVaellWRWwzVmt4SGZFM3NwMTg0ODRmRWVOd2VzZ0JmV3ZiS0d2LzRJbGpRWlhjNEFGSkc2UnNYVnMxbgpvS3FvZTFGT2xUbFUwQytSKzlHUG9FQis4UUlEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qZ3VNb2NFTTU1aVlZY0VyQkFjQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVorZTVwY3Y4U25rU3NHaysKa29hYkdRS3FvVHkyTHdHQS9OMk84VEpOWFp6dUVsT3VGUUN4VCtzdVFVQkNvT2d2RllrQSsySzVYNWxQTU5mNgpkcU51V2ZBYWovVEhTMGlxSExhclJYQkJPOGJMWk5sUmR3eFRlWWZwbTYyZ3d6UzBDSGFOelZzWFdtcmpOc3RRClJ4MTFOYkhrTEFqeno1T1M0WkJSQndMbFBKa3ZqanVTNzh2bWRJZ1JrRFVCT0h4SkdiekIzU1VLNGlTdHJuTkoKMVlWMzI2ZFFJTXUzbVVpVGV3VFBBWDExM0kzbWZJVGRFeU1YZ2MxdjZFd2gyTGpmdnNxa3dSWFZkaXQ2VWxwaAp0U0Q4Tm94UEhUWkhHVVpMN21LK3A1L1pBRGRtVkQ5b1czdHh0YzVXdUNZRHNEakw2TWtsMDlMMVBNb0ZZQ2JFCm1RWEpTZz09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8792394f-40ca-4691-9759-b73ea14addcb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=1dc01ac1-b827-4611-b081-943c96419b72&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-20T14:14:30.728077Z","id":"9efb059d-7518-4c0e-8245-9f39d8296f09","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"1dc01ac1-b827-4611-b081-943c96419b72","mac_address":"02:00:00:18:83:68","name":"test-rdb-private-network-update","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e31cb470-b52b-434a-ad24-629772c44b38"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-20T14:14:32.202674Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "558"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - afaff1fc-ac22-4236-8d2d-b6a34006b0c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"62a8d6ed-6a04-440a-906c-26e44bebd0a5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1300"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b37481a8-13ba-498b-8609-bb775ec6ea65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"62a8d6ed-6a04-440a-906c-26e44bebd0a5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1303"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e33d80b3-5fca-4a05-8f01-662154d1623f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:07:46.133904Z","endpoint":null,"endpoints":[{"id":"62a8d6ed-6a04-440a-906c-26e44bebd0a5","ip":"172.16.28.2","name":null,"port":5432,"private_network":{"private_network_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","service_ip":"172.16.28.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"1dc01ac1-b827-4611-b081-943c96419b72","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1303"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35e8c652-746a-4214-bced-d6c1335abdaf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1dc01ac1-b827-4611-b081-943c96419b72","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3925,9 +4290,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:15 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3935,7 +4300,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8366b4b-3e82-446a-bd4c-c5f56cb0c461
+      - ed759ade-cb9a-487a-a3ea-5abee87328ac
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3944,9 +4309,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: DELETE
   response:
     body: ""
@@ -3956,9 +4321,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:16 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3966,7 +4331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 415e2898-38ea-4e75-a0e4-f7613713856e
+      - 2f68e72d-dd2b-4c3a-9689-6493cfd0847b
     status: 204 No Content
     code: 204
     duration: ""
@@ -3975,12 +4340,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/aab3574a-aa1a-42bc-a445-a3396cb432b1
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/1dc01ac1-b827-4611-b081-943c96419b72
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"aab3574a-aa1a-42bc-a445-a3396cb432b1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"1dc01ac1-b827-4611-b081-943c96419b72","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -3989,9 +4354,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:17 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3999,7 +4364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66502db6-f6ef-43f6-8d47-fe7f3b5eac59
+      - d43fafd3-31c5-491b-87b6-92a6268edaac
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4008,12 +4373,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b1140239-acf5-4862-b7df-3e03e16fa170
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/69738871-3c1f-4141-8e4b-ad5d1a46060d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"b1140239-acf5-4862-b7df-3e03e16fa170","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"69738871-3c1f-4141-8e4b-ad5d1a46060d","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4022,9 +4387,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:17 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4032,7 +4397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6196475-62ea-4046-94a2-a8c6db08152d
+      - dc19e212-4b55-441e-98bc-6fbbb9fcc337
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-instance-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-private-network.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -318,9 +318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:04 GMT
+      - Tue, 20 Feb 2024 14:07:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,34 +328,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16b03ad0-8b51-4aa7-93f5-319edb7928b0
+      - c08ea661-dfc1-4122-867b-40029ace2953
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my_private_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:11:19.028977Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:11 GMT
+      - Tue, 20 Feb 2024 14:11:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd68e186-cebf-4b36-8c0d-1cac3b879133
+      - 6042d560-a0fd-4470-9f9d-8cfddd4a9653
     status: 200 OK
     code: 200
     duration: ""
@@ -372,23 +372,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:11:19.028977Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:11 GMT
+      - Tue, 20 Feb 2024 14:11:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c42bca20-e911-4b87-ad59-a8b532ce07f4
+      - 41b2effd-e856-471c-b01d-0558e08e96ba
     status: 200 OK
     code: 200
     duration: ""
@@ -405,23 +405,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:11:19.028977Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:12 GMT
+      - Tue, 20 Feb 2024 14:11:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6f05a8f-56b7-4c83-9b1e-d5822109197b
+      - b88548fc-61ca-476e-8a1e-60468a727eb3
     status: 200 OK
     code: 200
     duration: ""
@@ -438,23 +438,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:11:19.028977Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:12 GMT
+      - Tue, 20 Feb 2024 14:11:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -462,34 +462,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b7a7f54-bb55-4610-86b3-5daed663154e
+      - ada09dd0-4215-466d-90c9-42efc62cc84a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-private-network","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-private-network","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"init_settings":null,"volume_type":"bssd","volume_size":10000000000,"init_endpoints":[{"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24"}}],"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "991"
+      - "1027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:13 GMT
+      - Tue, 20 Feb 2024 14:11:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90fb5ff9-5424-4b15-8efb-9acc5e7afd5b
+      - 8c9977d9-5f70-44f5-b3b1-af11a8516fb7
     status: 200 OK
     code: 200
     duration: ""
@@ -506,23 +506,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "991"
+      - "1027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:13 GMT
+      - Tue, 20 Feb 2024 14:11:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eccd528f-6a79-4d97-bced-4b042bed7c9f
+      - bf43a12d-9f6b-4aeb-9e2e-aa25ce0635fc
     status: 200 OK
     code: 200
     duration: ""
@@ -539,23 +539,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "991"
+      - "1027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:43 GMT
+      - Tue, 20 Feb 2024 14:11:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4c3bdb7-06e8-4e9f-bd0b-05339f49fa58
+      - 7f2d203d-0325-4b29-8c72-eff39b005026
     status: 200 OK
     code: 200
     duration: ""
@@ -572,23 +572,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "991"
+      - "1027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:13 GMT
+      - Tue, 20 Feb 2024 14:12:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5d7ce88-3045-4065-b482-09e33937c99b
+      - 7bf4993b-538f-41bf-aa53-5f86a4ee6d97
     status: 200 OK
     code: 200
     duration: ""
@@ -605,23 +605,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "991"
+      - "1027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:44 GMT
+      - Tue, 20 Feb 2024 14:12:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4f39c7c-ee75-4ae3-a5e2-2cffba1ccd5c
+      - f02fdaff-da6a-4a1c-bf69-f1c8b1111009
     status: 200 OK
     code: 200
     duration: ""
@@ -638,23 +638,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "991"
+      - "1027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:14 GMT
+      - Tue, 20 Feb 2024 14:13:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a66beff8-d4da-4ff3-9b03-18d616a3f8c1
+      - 85b638da-9e70-4071-8871-8a36a117badf
     status: 200 OK
     code: 200
     duration: ""
@@ -671,23 +671,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "991"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:44 GMT
+      - Tue, 20 Feb 2024 14:13:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 531f3dec-19b6-4d5b-a7a2-8983156b949a
+      - 83c71e1d-5ffa-483b-824d-8eb8233cf062
     status: 200 OK
     code: 200
     duration: ""
@@ -704,23 +704,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "991"
+      - "1733"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:14 GMT
+      - Tue, 20 Feb 2024 14:13:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95008587-6d65-40e9-924a-f2740123a514
+      - e3be43d8-9fa4-41ae-8881-9625f92f4490
     status: 200 OK
     code: 200
     duration: ""
@@ -737,122 +737,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "991"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:16:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1b361f7e-bd30-4063-85ac-0a59040d0b38
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1248"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c9b6f7b1-592d-445d-9fb5-12b52edc1515
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1731"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c2df51fa-3091-494d-a94a-a4ad74d1b5f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb25bfb2-524f-472b-9a7d-c16b83b256de&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:15 GMT
+      - Tue, 20 Feb 2024 14:13:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -860,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67f58f3c-9a10-4973-80c6-5f24c6e78f6f
+      - 3427d728-4857-4d3c-8e23-698af7109fce
     status: 200 OK
     code: 200
     duration: ""
@@ -869,23 +770,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:15 GMT
+      - Tue, 20 Feb 2024 14:13:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -893,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b688df7-7e33-4420-b02d-837f503fc0a0
+      - 212fb7ae-6dd4-403b-a83d-0f534fb5fe7f
     status: 200 OK
     code: 200
     duration: ""
@@ -902,23 +803,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:11:19.028977Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "702"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:15 GMT
+      - Tue, 20 Feb 2024 14:13:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -926,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce01f9a1-9ccb-46cd-8e0c-3b4f7f69650c
+      - f5561dae-9ba8-4c22-8bba-c18827704d3c
     status: 200 OK
     code: 200
     duration: ""
@@ -935,23 +836,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:16 GMT
+      - Tue, 20 Feb 2024 14:13:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -959,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7902cacf-4690-42d6-88d5-65af28e30076
+      - 5e17c2c1-de71-4eea-aad5-64293ad41820
     status: 200 OK
     code: 200
     duration: ""
@@ -968,23 +869,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1731"
+      - "1733"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:16 GMT
+      - Tue, 20 Feb 2024 14:13:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -992,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0de6a2e3-e5e2-4f50-9ee5-87c48e0541c0
+      - 969b47ec-b9a9-4117-bfe4-75ba49f47c9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1001,155 +902,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "26"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2522ee1f-2af4-470a-86e3-eb78ef26e509
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:13:11.094528Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
-    headers:
-      Content-Length:
-      - "702"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 404482cc-4361-470e-8044-666b2f5f97f0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1248"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 08bc54ca-867c-4412-8942-4f0c7b8bc7e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1731"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:17:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17d05300-5233-4e8c-b32f-b94ad4db8a6a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb25bfb2-524f-472b-9a7d-c16b83b256de&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:17 GMT
+      - Tue, 20 Feb 2024 14:13:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1157,7 +926,139 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3db4a93-dbcd-4585-91bb-58a05d1ede69
+      - 700ba6d4-2701-45ef-ad69-1f78aec1b2a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:11:19.028977Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    headers:
+      Content-Length:
+      - "719"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3385d09d-3681-43ba-a614-ca32221bc23c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1295"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5810a3d-8583-43c3-a8d9-ac6b34aa5082
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1733"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - be8f0281-331b-4fbf-b5f0-8f10c7d8fd6f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb25bfb2-524f-472b-9a7d-c16b83b256de&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:13:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0ec54716-1bff-45d2-9e99-eccb757b2941
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,23 +1069,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
     method: PATCH
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.655984Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "717"
+      - "734"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:17 GMT
+      - Tue, 20 Feb 2024 14:13:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1192,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 189a1eb0-5ef9-473f-8d3e-d752dc61a560
+      - 1e1d04bb-2e83-42d9-93c6-e74bf97b79e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,23 +1102,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.655984Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "717"
+      - "734"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:17 GMT
+      - Tue, 20 Feb 2024 14:13:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1225,34 +1126,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60a7b276-ff5e-41ff-a486-86b20d6b913b
+      - ef227e2c-d949-4d04-97e8-ad1a3ad5c1c9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"my_private_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"my_private_network","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"172.16.0.0/22","updated_at":"2023-12-18T13:17:17.306857Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:17:17.306857Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.306857Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:13:53.648351Z","dhcp_enabled":true,"id":"e409e337-e21b-408c-826c-bfe506d5a3e7","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:13:53.648351Z","id":"96a3abc1-4ee4-40e0-ab29-5e32b3946fee","subnet":"172.16.4.0/22","updated_at":"2024-02-20T14:13:53.648351Z"},{"created_at":"2024-02-20T14:13:53.648351Z","id":"b574e40b-78ba-47da-9164-2bbfa4baf318","subnet":"fd68:d440:21c4:5b08::/64","updated_at":"2024-02-20T14:13:53.648351Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.648351Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "700"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:17 GMT
+      - Tue, 20 Feb 2024 14:13:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1260,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23dc37e7-fd63-4626-8689-e7a2fac52bbc
+      - 4178ffdd-1487-42a4-91d1-a8afe677470c
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,23 +1170,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e409e337-e21b-408c-826c-bfe506d5a3e7
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"172.16.0.0/22","updated_at":"2023-12-18T13:17:17.306857Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:17:17.306857Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.306857Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:13:53.648351Z","dhcp_enabled":true,"id":"e409e337-e21b-408c-826c-bfe506d5a3e7","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:13:53.648351Z","id":"96a3abc1-4ee4-40e0-ab29-5e32b3946fee","subnet":"172.16.4.0/22","updated_at":"2024-02-20T14:13:53.648351Z"},{"created_at":"2024-02-20T14:13:53.648351Z","id":"b574e40b-78ba-47da-9164-2bbfa4baf318","subnet":"fd68:d440:21c4:5b08::/64","updated_at":"2024-02-20T14:13:53.648351Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.648351Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "700"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:18 GMT
+      - Tue, 20 Feb 2024 14:13:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1293,7 +1194,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e2d04b3-0f8c-48cc-bb9e-7d15e469eade
+      - c057b932-96cc-430e-9b99-1e643ff2a840
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,23 +1203,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:18 GMT
+      - Tue, 20 Feb 2024 14:13:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1326,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb300174-3a37-44a2-ab2b-89290fbdac8d
+      - 2af100f6-537a-4123-9625-94c3481ababf
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,23 +1236,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:18 GMT
+      - Tue, 20 Feb 2024 14:13:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1359,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebe48391-cd20-4702-b380-6cf409c41006
+      - 32fdbbfe-45c4-4251-bd5c-a8bd52ce1782
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,23 +1271,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:19 GMT
+      - Tue, 20 Feb 2024 14:13:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1394,7 +1295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1955eda-a28e-413c-a4d6-8478d5177611
+      - 8280b239-d775-4ded-9ea1-cd8df9be5bb0
     status: 200 OK
     code: 200
     duration: ""
@@ -1403,23 +1304,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1248"
+      - "1295"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:19 GMT
+      - Tue, 20 Feb 2024 14:13:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1427,7 +1328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf99c275-457a-4e30-a5ca-033d6060d3a5
+      - cb0a9604-28d4-4afd-a8a5-4a882cd9ec1a
     status: 200 OK
     code: 200
     duration: ""
@@ -1436,9 +1337,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/4442db4c-3b00-44d5-bac8-1194041c9695
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/ed45a1e0-d38e-4e70-932b-9df7fd6bec61
     method: DELETE
   response:
     body: ""
@@ -1448,9 +1349,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:19 GMT
+      - Tue, 20 Feb 2024 14:13:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1458,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aac5299-a8db-4aa0-9f77-7afced955086
+      - 79ef8dd2-a314-4dc8-80bb-289fa74862a8
     status: 204 No Content
     code: 204
     duration: ""
@@ -1467,23 +1368,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"4442db4c-3b00-44d5-bac8-1194041c9695","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ed45a1e0-d38e-4e70-932b-9df7fd6bec61","ip":"192.168.1.42","name":null,"port":5432,"private_network":{"private_network_id":"f13abdfa-0b61-42c7-af07-5519e374ad99","service_ip":"192.168.1.42/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1254"
+      - "1301"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:19 GMT
+      - Tue, 20 Feb 2024 14:13:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1491,7 +1392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - daa2b7be-44d3-4b8f-b6eb-a068b3f61694
+      - 46373928-dc80-4eba-a43e-db80b749d199
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,23 +1401,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1030"
+      - "1071"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:50 GMT
+      - Tue, 20 Feb 2024 14:14:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1524,34 +1425,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f3692ed-125b-417e-b956-214e91df5b39
+      - d667fce4-5ddf-47a2-9504-778081b9cfdc
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":{"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24"}}}'
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24"}}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/endpoints
     method: POST
   response:
-    body: '{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
+    body: '{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}'
     headers:
       Content-Length:
-      - "220"
+      - "226"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:50 GMT
+      - Tue, 20 Feb 2024 14:14:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1559,7 +1460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0d7395b-c4a9-45ba-95e2-6857aefbc36f
+      - 02d4197b-e211-4d1e-80e6-57ca1f0b7169
     status: 200 OK
     code: 200
     duration: ""
@@ -1568,23 +1469,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1257"
+      - "1304"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:51 GMT
+      - Tue, 20 Feb 2024 14:14:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1592,7 +1493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f572417-41f0-4a29-b68e-d44539b2e54e
+      - 530fc43b-282e-423e-8b09-df5af0922d52
     status: 200 OK
     code: 200
     duration: ""
@@ -1601,23 +1502,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:21 GMT
+      - Tue, 20 Feb 2024 14:14:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1625,7 +1526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4f18bfc-2631-49bb-bca1-6240ce40a91e
+      - bacb216d-aeae-416c-a55c-f31f82190a2b
     status: 200 OK
     code: 200
     duration: ""
@@ -1634,23 +1535,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1731"
+      - "1733"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:21 GMT
+      - Tue, 20 Feb 2024 14:14:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1658,7 +1559,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80c38ee0-f7a4-42c0-821a-194fb6e2d054
+      - a2fbabc0-e3e3-409b-af08-425149cf9347
     status: 200 OK
     code: 200
     duration: ""
@@ -1667,221 +1568,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "26"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64e4c761-f388-45e9-a484-53b050432f9f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1250"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ecc58a35-4f2a-48bf-a071-9af344415964
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
-    headers:
-      Content-Length:
-      - "717"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a3d44594-3946-4ccc-84fd-db0f712d62ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"172.16.0.0/22","updated_at":"2023-12-18T13:17:17.306857Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:17:17.306857Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.306857Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
-    headers:
-      Content-Length:
-      - "700"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c85dec9c-712c-4ef0-8881-8c9d51689bcb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1250"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1175d206-3583-46b0-b715-ed5763175ed3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1731"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 87338d27-9793-4741-83de-56974ad17c33
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb25bfb2-524f-472b-9a7d-c16b83b256de&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
+      - Tue, 20 Feb 2024 14:14:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1889,7 +1592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52caa35a-3e88-4fa9-8321-3896abcf29bc
+      - 5835b5c9-875c-4dab-b643-39434878283b
     status: 200 OK
     code: 200
     duration: ""
@@ -1898,23 +1601,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "717"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
+      - Tue, 20 Feb 2024 14:14:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1922,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afb0aee8-77b7-4191-aaf6-85d25a4e13d0
+      - 6fac794d-a1ea-4a4b-9e70-bc311cc8ac58
     status: 200 OK
     code: 200
     duration: ""
@@ -1931,23 +1634,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"172.16.0.0/22","updated_at":"2023-12-18T13:17:17.306857Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:17:17.306857Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.306857Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.655984Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "700"
+      - "734"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
+      - Tue, 20 Feb 2024 14:14:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1955,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e88bf229-15e8-4b2e-ae8d-966cf647765d
+      - e37b2728-e4c0-4c10-86d9-2dff76a2ad52
     status: 200 OK
     code: 200
     duration: ""
@@ -1964,23 +1667,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e409e337-e21b-408c-826c-bfe506d5a3e7
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"created_at":"2024-02-20T14:13:53.648351Z","dhcp_enabled":true,"id":"e409e337-e21b-408c-826c-bfe506d5a3e7","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:13:53.648351Z","id":"96a3abc1-4ee4-40e0-ab29-5e32b3946fee","subnet":"172.16.4.0/22","updated_at":"2024-02-20T14:13:53.648351Z"},{"created_at":"2024-02-20T14:13:53.648351Z","id":"b574e40b-78ba-47da-9164-2bbfa4baf318","subnet":"fd68:d440:21c4:5b08::/64","updated_at":"2024-02-20T14:13:53.648351Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.648351Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "1250"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:23 GMT
+      - Tue, 20 Feb 2024 14:14:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1988,7 +1691,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd0840b2-ce51-403f-bf13-22a5af988946
+      - 24a041e2-428f-4923-b0ca-ebf09cb0f467
     status: 200 OK
     code: 200
     duration: ""
@@ -1997,23 +1700,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1731"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:23 GMT
+      - Tue, 20 Feb 2024 14:14:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2021,7 +1724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c3766e4-906f-4569-9783-cd47163270dd
+      - ee129bcf-0007-41d7-8c98-fed33854f517
     status: 200 OK
     code: 200
     duration: ""
@@ -2030,23 +1733,56 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1733"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a185db8-4a75-4b96-aea3-4ffb5ff4256d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb25bfb2-524f-472b-9a7d-c16b83b256de&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:23 GMT
+      - Tue, 20 Feb 2024 14:14:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2054,34 +1790,199 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a678160-181e-45ea-9156-e44aa84f3a16
+      - 51f3f816-2ea0-40c6-a3c1-5865750da402
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.655984Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    headers:
+      Content-Length:
+      - "734"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2c9490a8-417d-41c2-a87b-a3b19963d509
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e409e337-e21b-408c-826c-bfe506d5a3e7
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:13:53.648351Z","dhcp_enabled":true,"id":"e409e337-e21b-408c-826c-bfe506d5a3e7","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:13:53.648351Z","id":"96a3abc1-4ee4-40e0-ab29-5e32b3946fee","subnet":"172.16.4.0/22","updated_at":"2024-02-20T14:13:53.648351Z"},{"created_at":"2024-02-20T14:13:53.648351Z","id":"b574e40b-78ba-47da-9164-2bbfa4baf318","subnet":"fd68:d440:21c4:5b08::/64","updated_at":"2024-02-20T14:13:53.648351Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.648351Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d82513b-a8b5-4422-9004-a25b945fea21
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1297"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 80050f84-8327-4f1c-bc97-3dff7110c2b3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1733"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b16893b0-27cb-4c18-9e30-9b6b0106dda9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb25bfb2-524f-472b-9a7d-c16b83b256de&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:14:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3be4b4d1-7826-411f-881f-0ff516490756
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","subnet":"192.168.1.0/24"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:24 GMT
+      - Tue, 20 Feb 2024 14:14:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2089,7 +1990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27dc12d0-8b43-4dfc-b1a5-6b377a343e25
+      - e418f13f-6c47-4c14-847c-f814814cf122
     status: 200 OK
     code: 200
     duration: ""
@@ -2098,23 +1999,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/588e6ee2-c516-4f79-99a2-9bd52977f31e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/ddb00377-ce23-4946-b851-071a15fc7a86
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:24 GMT
+      - Tue, 20 Feb 2024 14:14:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2122,34 +2023,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8f520dc-e078-4d73-8171-0a05d5376d3a
+      - feebb646-afb8-45d6-aed3-5c0b10462d3f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips
     method: POST
   response:
-    body: '{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":null,"id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":null,"id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "356"
+      - "369"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:24 GMT
+      - Tue, 20 Feb 2024 14:14:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2157,7 +2058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69b1263a-3eee-488b-846b-4d23277187e3
+      - cc72390d-70b5-443e-987c-5b0723acf02c
     status: 200 OK
     code: 200
     duration: ""
@@ -2166,23 +2067,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/929d4c74-2aff-47ea-a2f1-0b1c54824de4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/b2d9693d-dc54-4678-a47a-38c6db90c353
     method: GET
   response:
-    body: '{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":null,"id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"}'
+    body: '{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":null,"id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "356"
+      - "369"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:24 GMT
+      - Tue, 20 Feb 2024 14:14:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2190,34 +2091,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e798d2f1-a0e0-4058-8e86-1e22e02dfe1c
+      - e3c46069-2246-4da0-a9a7-e12df2b4effa
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"b2d9693d-dc54-4678-a47a-38c6db90c353","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:24.696189Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:14:59.391358Z","upstream_dns_servers":[],"version":null,"zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:24 GMT
+      - Tue, 20 Feb 2024 14:14:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2225,7 +2126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63553eeb-6da9-4664-8498-e4129bf51c4a
+      - 524da135-3b6b-48a2-a745-1efdd5e3fc38
     status: 200 OK
     code: 200
     duration: ""
@@ -2234,23 +2135,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:24.747545Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:14:59.461444Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "941"
+      - "1003"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:24 GMT
+      - Tue, 20 Feb 2024 14:14:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2258,7 +2159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f7a17fd-360b-4617-b3cf-8db87a336993
+      - 1a63c869-56a2-4180-98b0-0f75ff8abf1a
     status: 200 OK
     code: 200
     duration: ""
@@ -2267,23 +2168,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:25.512265Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:14:59.630377Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "1004"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:29 GMT
+      - Tue, 20 Feb 2024 14:15:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2291,7 +2192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48fecd13-618b-488b-9306-4115a9429c66
+      - 350f0c05-a831-4627-b194-6c8fe3d0cd5f
     status: 200 OK
     code: 200
     duration: ""
@@ -2300,23 +2201,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:25.512265Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:14:59.630377Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "1004"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:29 GMT
+      - Tue, 20 Feb 2024 14:15:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2324,7 +2225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38941cc9-32e2-4ce5-bf5e-983a03ace0b0
+      - 587c6c56-ff07-4575-a115-7c584dbe93e4
     status: 200 OK
     code: 200
     duration: ""
@@ -2333,23 +2234,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:25.512265Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:11.217437Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "938"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:29 GMT
+      - Tue, 20 Feb 2024 14:15:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2357,34 +2258,100 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01d32f25-cb52-4291-b6c9-1d442fdeb253
+      - 0708892f-7f40-4d2c-9fab-3738c83b0a90
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"588e6ee2-c516-4f79-99a2-9bd52977f31e"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:11.217437Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1000"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f5bf7249-5ac0-4caa-9dca-14e8b19e099e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:11.217437Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1000"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 82ce0c30-a2ff-47fd-8d51-3268027f26ad
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"ddb00377-ce23-4946-b851-071a15fc7a86"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":null,"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"created","updated_at":"2023-12-18T13:18:30.956720Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":null,"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"created","updated_at":"2024-02-20T14:15:17.020190Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "953"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:31 GMT
+      - Tue, 20 Feb 2024 14:15:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2392,7 +2359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5c5134e-0c75-4284-b6d9-7736f1a1a360
+      - 406c52d5-ad59-4317-b3be-43640d3c4a76
     status: 200 OK
     code: 200
     duration: ""
@@ -2401,23 +2368,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":null,"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"created","updated_at":"2023-12-18T13:18:30.956720Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:31.135726Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":null,"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"created","updated_at":"2024-02-20T14:15:17.020190Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:17.211626Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1894"
+      - "1986"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:31 GMT
+      - Tue, 20 Feb 2024 14:15:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2425,7 +2392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c350f9e7-c5f3-409d-adde-39d58644c229
+      - 08f4d81c-625d-459d-9539-ad0ca4c32827
     status: 200 OK
     code: 200
     duration: ""
@@ -2434,23 +2401,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":null,"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"created","updated_at":"2023-12-18T13:18:30.956720Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:31.135726Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":null,"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"created","updated_at":"2024-02-20T14:15:17.020190Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:17.211626Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1894"
+      - "1986"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:36 GMT
+      - Tue, 20 Feb 2024 14:15:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2458,7 +2425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2dde3750-e010-4d24-86b7-cca851d4d564
+      - ec4f5cad-ee60-4154-921c-a912d9b470fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2467,23 +2434,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"configuring","updated_at":"2024-02-20T14:15:23.176016Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:17.211626Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "2005"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:41 GMT
+      - Tue, 20 Feb 2024 14:15:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2491,7 +2458,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5d625b4-82b8-4591-85af-b2e607580596
+      - 14f43077-9787-4475-b7fc-88360e181c32
     status: 200 OK
     code: 200
     duration: ""
@@ -2500,23 +2467,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:41 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2524,7 +2491,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2744a29c-c3e2-4e7c-9c78-54d13f8c4e95
+      - 46d09490-e2cc-4a95-aaf1-77668e81b372
     status: 200 OK
     code: 200
     duration: ""
@@ -2533,23 +2500,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:41 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2557,7 +2524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b26ec2ba-b66a-4937-875e-716cd717b388
+      - e8b6bffe-f793-4234-86a7-8f90aeb4e93d
     status: 200 OK
     code: 200
     duration: ""
@@ -2566,23 +2533,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:41 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2590,7 +2557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36cbebcf-43d6-4bc4-afe5-e67d2fbe5004
+      - 9dae6ea8-e49b-4eb0-9b02-bf61fd8f7067
     status: 200 OK
     code: 200
     duration: ""
@@ -2599,23 +2566,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:41 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2623,7 +2590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7a33f52-e463-4f39-a8ec-8cc166ac0b08
+      - c0a11b21-7426-47b6-a8d9-0532eae2cb12
     status: 200 OK
     code: 200
     duration: ""
@@ -2632,23 +2599,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:41 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2656,7 +2623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9ddbad8-4760-4f85-8898-af4f5c454f74
+      - 9ba67035-66e3-4a2f-8d8d-97b3d2701a66
     status: 200 OK
     code: 200
     duration: ""
@@ -2665,23 +2632,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:41 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2689,34 +2656,67 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4254fcb6-a84a-4173-a699-c9979127e963
+      - 65694633-dd2d-4cc1-9e6e-6b2ad08e8fc8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f258025b-0513-4432-b42c-47f585d12884
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","public_port":42,"private_ip":"192.168.1.1","private_port":5432,"protocol":"both"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:15:32.805934Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:15:32.805934Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:41 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2724,7 +2724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00f8dbac-320c-4797-9fd3-b1f08f5a72a8
+      - 4c395fab-56bb-4e06-b9bf-275b6e98317d
     status: 200 OK
     code: 200
     duration: ""
@@ -2733,23 +2733,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2757,7 +2757,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec7eb7de-6901-492a-9eb1-4c2cb862dcfe
+      - 6144ce9a-5768-4a68-9193-e92804e237fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2766,23 +2766,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:15:32.805934Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:15:32.805934Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2790,7 +2790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f3b03f1-6ffc-4de9-996d-ca22adc554ce
+      - 03c0d165-252f-4549-8eb8-8f9c8a149483
     status: 200 OK
     code: 200
     duration: ""
@@ -2799,23 +2799,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2823,7 +2823,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e890655-11b7-4a50-9808-7b412b7adbba
+      - b231f1e7-bfa5-483c-8275-6004cee1cf04
     status: 200 OK
     code: 200
     duration: ""
@@ -2832,23 +2832,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/588e6ee2-c516-4f79-99a2-9bd52977f31e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/ddb00377-ce23-4946-b851-071a15fc7a86
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2856,7 +2856,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a42569a-0b27-4779-bea8-263540ac8cb9
+      - 36304827-c74b-4937-a307-2428a1f5862a
     status: 200 OK
     code: 200
     duration: ""
@@ -2865,23 +2865,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/929d4c74-2aff-47ea-a2f1-0b1c54824de4
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
     method: GET
   response:
-    body: '{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.655984Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
     headers:
       Content-Length:
-      - "390"
+      - "734"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2889,7 +2889,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 944776d2-bd4a-45c4-93cd-bff5cf90446b
+      - a62107ff-7ab8-4474-9ece-02bcfe0a3604
     status: 200 OK
     code: 200
     duration: ""
@@ -2898,23 +2898,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e409e337-e21b-408c-826c-bfe506d5a3e7
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:30.405111Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:18:30.410109Z"}],"tags":[],"updated_at":"2023-12-18T13:18:37.444983Z","vpc_id":"4a115924-8c5e-49f8-8294-c0c9297ea9b9"}'
+    body: '{"created_at":"2024-02-20T14:13:53.648351Z","dhcp_enabled":true,"id":"e409e337-e21b-408c-826c-bfe506d5a3e7","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:13:53.648351Z","id":"96a3abc1-4ee4-40e0-ab29-5e32b3946fee","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:15:15.200584Z"},{"created_at":"2024-02-20T14:13:53.648351Z","id":"b574e40b-78ba-47da-9164-2bbfa4baf318","subnet":"fd68:d440:21c4:5b08::/64","updated_at":"2024-02-20T14:15:15.204007Z"}],"tags":[],"updated_at":"2024-02-20T14:15:23.766052Z","vpc_id":"b3d404a0-ad75-40e3-9ebf-954d628bf2d6"}'
     headers:
       Content-Length:
-      - "701"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2922,7 +2922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27c48c36-8614-4158-a9e4-73bf9568d835
+      - 5509c1b8-9041-4447-9088-db86525fd0d8
     status: 200 OK
     code: 200
     duration: ""
@@ -2931,23 +2931,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/b2d9693d-dc54-4678-a47a-38c6db90c353
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
+    body: '{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "717"
+      - "403"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2955,7 +2955,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ac49f51-44fe-4738-b7db-06d77f479cc0
+      - 9de4c9cd-9edc-4bc8-8548-31ff58eaa7e1
     status: 200 OK
     code: 200
     duration: ""
@@ -2964,23 +2964,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2988,7 +2988,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fda9c4c7-6a93-4e9a-ba15-d677a3d513cb
+      - 3bfe47ce-8726-4cb8-bc40-bf446bff206d
     status: 200 OK
     code: 200
     duration: ""
@@ -2997,23 +2997,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3021,7 +3021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 843c71e1-108a-4d97-89b6-fd996f94deb8
+      - 801c8a24-11f3-4de1-ae8e-efa6ff5b081b
     status: 200 OK
     code: 200
     duration: ""
@@ -3030,23 +3030,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3054,7 +3054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbf4daa7-edae-40cd-8291-bf49e009c792
+      - c6c24df3-d444-4755-8e6a-485b21f7c027
     status: 200 OK
     code: 200
     duration: ""
@@ -3063,23 +3063,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3087,7 +3087,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c50ef2c7-3ecb-4b25-a508-b8cd26857d86
+      - ce5c9569-a15b-4604-9d4d-b113204a5646
     status: 200 OK
     code: 200
     duration: ""
@@ -3096,23 +3096,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3120,7 +3120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24982b87-4543-49ae-ace6-c6bd10522696
+      - e9756edc-402d-4ee9-a790-0c61f9dde88d
     status: 200 OK
     code: 200
     duration: ""
@@ -3129,23 +3129,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1731"
+      - "1733"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3153,7 +3153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6879acb-d04b-4afe-b11b-938f1cf9917e
+      - b4599b53-2ca1-4a26-96ab-6a81316f7a23
     status: 200 OK
     code: 200
     duration: ""
@@ -3162,452 +3162,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "26"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4fa1d270-7018-46d2-bd7e-fa3f65b7d938
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ca17ca07-ddc8-4e05-8d1b-6ad99575d588
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/588e6ee2-c516-4f79-99a2-9bd52977f31e
-    method: GET
-  response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "568"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b55ed2b5-1f9f-4712-a575-ce16f348b6b3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1903"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 311ca298-03f3-40a5-ab7e-fc98bd2732a5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "283"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2101c7a-5555-41c7-b5e8-becf15705e6d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:13:11.094528Z","dhcp_enabled":true,"id":"d21626f3-323a-4395-86b3-02a67bfd4e6a","name":"my_private_network_to_be_replaced","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:13:11.094528Z","id":"72fb0972-9d18-424c-bf6b-b73b2246b503","subnet":"172.16.12.0/22","updated_at":"2023-12-18T13:13:11.094528Z"},{"created_at":"2023-12-18T13:13:11.094528Z","id":"f1d4c92c-cbde-4fbd-83f5-cfbb946dde7a","subnet":"fd5c:d510:d730:d874::/64","updated_at":"2023-12-18T13:13:11.094528Z"}],"tags":[],"updated_at":"2023-12-18T13:17:17.314511Z","vpc_id":"5976fd03-14dd-4892-a481-034469de59c6"}'
-    headers:
-      Content-Length:
-      - "717"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 83d82f52-3356-47d5-bab7-fadcc2188bee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/929d4c74-2aff-47ea-a2f1-0b1c54824de4
-    method: GET
-  response:
-    body: '{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "390"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5dbd1a78-2d47-4269-b636-9a85c1ee06af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
-    method: GET
-  response:
-    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:30.405111Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:18:30.410109Z"}],"tags":[],"updated_at":"2023-12-18T13:18:37.444983Z","vpc_id":"4a115924-8c5e-49f8-8294-c0c9297ea9b9"}'
-    headers:
-      Content-Length:
-      - "701"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 258a2816-a990-4071-a31e-d0734270b340
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3f138593-4cd5-4acc-871c-076fe114d928
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "1903"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 13b1e544-c3c7-405f-8f01-d1cb75633d43
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1250"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e89aa675-af11-4fbb-9354-02c7e21d1480
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 86116eeb-c9d7-4ce3-8f81-7b9b2206fdd8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1731"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c91568ae-73a2-4545-9e96-e5ef272e360c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb25bfb2-524f-472b-9a7d-c16b83b256de&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
     headers:
       Content-Length:
-      - "26"
+      - "27"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3615,7 +3186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3d27c84-5e5d-4d34-8f05-663dbcfb33e3
+      - 89f3ad49-2792-4735-a943-ecb22d9c226d
     status: 200 OK
     code: 200
     duration: ""
@@ -3624,23 +3195,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:18:41.870801Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"87599c5d-1441-474c-a4b9-af5a75bdf349","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2023-12-18T13:18:41.870801Z","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:15:32.805934Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:15:32.805934Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "283"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3648,7 +3219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 817db8b6-a1d9-48c1-89b7-eae4c0ff3a83
+      - d8839a59-8ae1-4a8d-a0cc-e5110d2d9543
     status: 200 OK
     code: 200
     duration: ""
@@ -3657,23 +3228,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"created_at":"2024-02-20T14:15:32.805934Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:15:32.805934Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
+      - Tue, 20 Feb 2024 14:15:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3681,7 +3252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 095d9155-a2b0-4ab7-9686-74fbfaf2b402
+      - afe2f864-e6e0-45da-961d-767409a48c07
     status: 200 OK
     code: 200
     duration: ""
@@ -3690,9 +3261,438 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/87599c5d-1441-474c-a4b9-af5a75bdf349
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:11:19.028977Z","dhcp_enabled":true,"id":"f13abdfa-0b61-42c7-af07-5519e374ad99","name":"my_private_network_to_be_replaced","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:11:19.028977Z","id":"31c37dc5-b601-466b-94d0-8b32b521d11d","subnet":"172.16.16.0/22","updated_at":"2024-02-20T14:11:19.028977Z"},{"created_at":"2024-02-20T14:11:19.028977Z","id":"c91bd171-956f-47f2-b8c2-5587a72fe6e7","subnet":"fd68:d440:21c4:1596::/64","updated_at":"2024-02-20T14:11:19.028977Z"}],"tags":[],"updated_at":"2024-02-20T14:13:53.655984Z","vpc_id":"4309b839-ccd3-4b18-ab44-8d79ebcde6a1"}'
+    headers:
+      Content-Length:
+      - "734"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a82c02b9-a147-4f8a-a0bb-4d524ccfa229
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/ddb00377-ce23-4946-b851-071a15fc7a86
+    method: GET
+  response:
+    body: '{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "586"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 636f7927-4218-4048-808f-8323b5683dd8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e409e337-e21b-408c-826c-bfe506d5a3e7
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:13:53.648351Z","dhcp_enabled":true,"id":"e409e337-e21b-408c-826c-bfe506d5a3e7","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:13:53.648351Z","id":"96a3abc1-4ee4-40e0-ab29-5e32b3946fee","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:15:15.200584Z"},{"created_at":"2024-02-20T14:13:53.648351Z","id":"b574e40b-78ba-47da-9164-2bbfa4baf318","subnet":"fd68:d440:21c4:5b08::/64","updated_at":"2024-02-20T14:15:15.204007Z"}],"tags":[],"updated_at":"2024-02-20T14:15:23.766052Z","vpc_id":"b3d404a0-ad75-40e3-9ebf-954d628bf2d6"}'
+    headers:
+      Content-Length:
+      - "719"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9779bbb4-e731-4b5f-a579-87176a5832cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/b2d9693d-dc54-4678-a47a-38c6db90c353
+    method: GET
+  response:
+    body: '{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "403"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f43a9d98-165c-4d41-8baf-519a61687ed3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e63c8343-f2e4-475e-9ba4-aa2cd93ff5c6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:33 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85bf6c08-b44f-4468-9eb0-b7d37bdd3695
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 10eb93c6-ed34-4839-9610-cdf8bae67862
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1297"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a506375d-ed18-40ba-904c-1ba482da62ea
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a6efd84b-f001-417e-8589-eebfde47c0b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1733"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85026da1-71af-417f-bd58-6f8937b45594
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=eb25bfb2-524f-472b-9a7d-c16b83b256de&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[],"total_count":0}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08858c08-dd96-4a81-95a0-65b603de522d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-20T14:15:32.805934Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db","private_ip":"192.168.1.1","private_port":5432,"protocol":"both","public_port":42,"updated_at":"2024-02-20T14:15:32.805934Z","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "291"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dbffe30c-0178-4815-bad7-8a829017b71d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f4177bc4-043c-48f1-bc28-eb0732f1f1bc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/pat-rules/2a12bcbe-ba59-4137-b8e7-d2d6fa9cc4db
     method: DELETE
   response:
     body: ""
@@ -3702,9 +3702,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3712,7 +3712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da539ece-5124-4fc3-a564-f652c298b8d3
+      - c58fd4bf-fbb6-4639-a05b-3a2b49bd38de
     status: 204 No Content
     code: 204
     duration: ""
@@ -3721,23 +3721,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "1903"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3745,7 +3745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66f3dfdc-ec76-4df3-9c3e-40314d100a7d
+      - 8bbabc7f-14a0-4ce2-bdb3-1f93d36720c5
     status: 200 OK
     code: 200
     duration: ""
@@ -3754,23 +3754,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"ready","updated_at":"2023-12-18T13:18:40.497823Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"ready","updated_at":"2024-02-20T14:15:31.366539Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3778,7 +3778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f95c08c1-0775-464a-bca7-bdd2d0376da4
+      - a5db9c8f-ec9c-4edf-8c4f-95b8a39970d0
     status: 200 OK
     code: 200
     duration: ""
@@ -3787,23 +3787,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:43 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3811,7 +3811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 616d1fe5-5be1-4156-8b43-6de13d51e78e
+      - a92a2f4c-713e-4608-8fa8-dcd361bfc773
     status: 200 OK
     code: 200
     duration: ""
@@ -3820,9 +3820,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3832,9 +3832,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:44 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3842,7 +3842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a492a60-d0b9-4c97-bfe2-38726f9a07c1
+      - fd1483e3-b61f-49cd-9f98-4d96eb15d2d1
     status: 204 No Content
     code: 204
     duration: ""
@@ -3851,23 +3851,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-18T13:18:30.956720Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-18T13:18:24.054596Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:24.054596Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","ipam_config":null,"mac_address":"02:00:00:12:3D:3C","private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","status":"detaching","updated_at":"2023-12-18T13:18:43.989027Z","zone":"nl-ams-1"}'
+    body: '{"address":null,"created_at":"2024-02-20T14:15:17.020190Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-20T14:14:58.479473Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ddb00377-ce23-4946-b851-071a15fc7a86","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:14:58.479473Z","valid_lifetime":"3600s","zone":"nl-ams-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"a1404034-d83b-43d7-8f78-d5177315d395","ipam_config":null,"mac_address":"02:00:00:13:6C:1E","private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","status":"detaching","updated_at":"2024-02-20T14:15:34.721275Z","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "970"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:44 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3875,7 +3875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e6c4083-cc05-4e08-9843-503c058933a2
+      - d2fb6c39-8f9a-43f8-a2f2-84480be4bcfb
     status: 200 OK
     code: 200
     duration: ""
@@ -3884,23 +3884,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:44 GMT
+      - Tue, 20 Feb 2024 14:15:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3908,40 +3908,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6bc09efa-e727-4765-872a-21d48c819a6a
+      - 007bb6bf-3102-4672-9920-a248a47c46ef
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/d21626f3-323a-4395-86b3-02a67bfd4e6a
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:18:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ed431ca4-28c7-486d-9ee5-f13033a2d996
-    status: 204 No Content
-    code: 204
     duration: ""
 - request:
     body: '{}'
@@ -3950,23 +3919,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:44 GMT
+      - Tue, 20 Feb 2024 14:15:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3974,7 +3943,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae8e7c41-e63f-4eb8-851b-cf46c0082fdb
+      - 3914a9db-0f72-4085-ad0e-e57e24355a42
     status: 200 OK
     code: 200
     duration: ""
@@ -3983,23 +3952,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1250"
+      - "1297"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:44 GMT
+      - Tue, 20 Feb 2024 14:15:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4007,7 +3976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf4a7af4-2c12-47bd-b9c9-69b91bb4941e
+      - 61e3a384-a4ce-4586-92c4-8fd9568094a3
     status: 200 OK
     code: 200
     duration: ""
@@ -4016,9 +3985,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/c0f08595-6f0e-47cd-bd51-f73dee67723d
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/endpoints/ab93b64b-f216-49c1-8636-0d6962b654a5
     method: DELETE
   response:
     body: ""
@@ -4028,9 +3997,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:44 GMT
+      - Tue, 20 Feb 2024 14:15:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4038,7 +4007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82e6e861-c4f6-4f9f-90b3-aedccc36d9a9
+      - 214bcf14-844f-4fdc-a98a-77e5545f0429
     status: 204 No Content
     code: 204
     duration: ""
@@ -4047,23 +4016,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[{"id":"c0f08595-6f0e-47cd-bd51-f73dee67723d","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"ed86be17-32e1-4c40-af44-0f7ab98de215","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[{"id":"ab93b64b-f216-49c1-8636-0d6962b654a5","ip":"192.168.1.254","name":null,"port":5432,"private_network":{"private_network_id":"e409e337-e21b-408c-826c-bfe506d5a3e7","service_ip":"192.168.1.254/24","zone":"nl-ams-1"}}],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1256"
+      - "1303"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:44 GMT
+      - Tue, 20 Feb 2024 14:15:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4071,7 +4040,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cafb4360-5f56-4436-9f06-bd0dde24b6e5
+      - c99fd784-9a23-4762-bf53-7c7d2f23aafb
     status: 200 OK
     code: 200
     duration: ""
@@ -4080,12 +4049,43 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/5734714e-489b-4c2f-b0bc-0efc12f852b0
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/f13abdfa-0b61-42c7-af07-5519e374ad99
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 20 Feb 2024 14:15:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0c2d6d4d-fb44-4331-8ee9-124b821ca581
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateway-networks/a1404034-d83b-43d7-8f78-d5177315d395
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"5734714e-489b-4c2f-b0bc-0efc12f852b0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"a1404034-d83b-43d7-8f78-d5177315d395","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -4094,9 +4094,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:49 GMT
+      - Tue, 20 Feb 2024 14:15:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4104,7 +4104,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07b77482-68a6-4348-bc59-a61aed49e1bd
+      - 58bd8125-160b-4762-a8ba-bbe52a3ab860
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4113,23 +4113,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "937"
+      - "999"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:49 GMT
+      - Tue, 20 Feb 2024 14:15:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4137,7 +4137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4f506af-0f11-4c05-9263-7a174bbec31c
+      - 639d54c1-1fa6-49d7-87fe-9c4b51054bd5
     status: 200 OK
     code: 200
     duration: ""
@@ -4146,12 +4146,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/588e6ee2-c516-4f79-99a2-9bd52977f31e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/dhcps/ddb00377-ce23-4946-b851-071a15fc7a86
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"588e6ee2-c516-4f79-99a2-9bd52977f31e","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"ddb00377-ce23-4946-b851-071a15fc7a86","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4160,9 +4160,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:49 GMT
+      - Tue, 20 Feb 2024 14:15:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4170,7 +4170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d6c37eb-c4d7-4bdb-8927-a0fe2f98d9a2
+      - a885b6e0-6bd1-4107-b9dd-cad4d8b617a8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4179,23 +4179,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-18T13:18:24.696189Z","gateway_networks":[],"id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","ip":{"address":"51.15.37.109","created_at":"2023-12-18T13:18:24.464586Z","gateway_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","id":"929d4c74-2aff-47ea-a2f1-0b1c54824de4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"109-37-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-18T13:18:24.464586Z","zone":"nl-ams-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2023-12-18T13:18:40.634655Z","upstream_dns_servers":[],"version":"0.6.1","zone":"nl-ams-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-20T14:14:59.391358Z","gateway_networks":[],"id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","ip":{"address":"51.158.168.204","created_at":"2024-02-20T14:14:59.150306Z","gateway_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","id":"b2d9693d-dc54-4678-a47a-38c6db90c353","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","reverse":"204-168-158-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-20T14:14:59.150306Z","zone":"nl-ams-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"nl-ams-1"},"updated_at":"2024-02-20T14:15:31.512704Z","upstream_dns_servers":[],"version":"0.6.3","zone":"nl-ams-1"}'
     headers:
       Content-Length:
-      - "937"
+      - "999"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:49 GMT
+      - Tue, 20 Feb 2024 14:15:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4203,7 +4203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cadf2b4-d494-475c-9fad-b520b708b763
+      - 23f184a5-8e8f-4ae9-b706-b2d07c84fcd8
     status: 200 OK
     code: 200
     duration: ""
@@ -4212,9 +4212,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -4224,9 +4224,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:49 GMT
+      - Tue, 20 Feb 2024 14:15:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4234,7 +4234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93d5ffae-99a8-4025-b59e-cfa6e7b9828b
+      - 9e5ca3ec-61f5-4b65-8a23-1d56e5c28536
     status: 204 No Content
     code: 204
     duration: ""
@@ -4243,12 +4243,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/62fc2ce4-83c8-443b-acdd-6737bd588d30
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/gateways/7164b36f-d02b-4a03-b273-ce7d377d88a7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"62fc2ce4-83c8-443b-acdd-6737bd588d30","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"7164b36f-d02b-4a03-b273-ce7d377d88a7","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -4257,9 +4257,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:49 GMT
+      - Tue, 20 Feb 2024 14:15:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4267,7 +4267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ed21c75-b03d-4f39-9aac-5f6c2d1de668
+      - 75b74e8f-abbe-421a-88e0-69094cc1fd02
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4276,9 +4276,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/929d4c74-2aff-47ea-a2f1-0b1c54824de4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/nl-ams-1/ips/b2d9693d-dc54-4678-a47a-38c6db90c353
     method: DELETE
   response:
     body: ""
@@ -4288,9 +4288,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:49 GMT
+      - Tue, 20 Feb 2024 14:15:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4298,7 +4298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e725890c-900a-48b1-87c9-435b3bfa3bee
+      - 2b1690eb-4dec-44d1-bfae-fa8d3c0e4afc
     status: 204 No Content
     code: 204
     duration: ""
@@ -4307,23 +4307,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1030"
+      - "1071"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:15 GMT
+      - Tue, 20 Feb 2024 14:16:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4331,7 +4331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b387d82f-164b-40e9-8ed8-f4b4d008506a
+      - 22de7429-e529-4f3b-b44f-504802472d54
     status: 200 OK
     code: 200
     duration: ""
@@ -4340,23 +4340,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1030"
+      - "1071"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:15 GMT
+      - Tue, 20 Feb 2024 14:16:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4364,7 +4364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8897400a-2291-42d8-b735-ef805d286b3b
+      - 33505291-ebd7-4122-b41e-0b3372a8a515
     status: 200 OK
     code: 200
     duration: ""
@@ -4373,23 +4373,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1731"
+      - "1733"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:15 GMT
+      - Tue, 20 Feb 2024 14:16:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4397,7 +4397,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07a52055-d0c3-44fb-bd75-26db5a0f2616
+      - 8d6af663-b19d-4e98-aa0f-7e21290da7d1
     status: 200 OK
     code: 200
     duration: ""
@@ -4406,23 +4406,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e409e337-e21b-408c-826c-bfe506d5a3e7
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"created_at":"2024-02-20T14:13:53.648351Z","dhcp_enabled":true,"id":"e409e337-e21b-408c-826c-bfe506d5a3e7","name":"my_private_network","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"nl-ams","subnets":[{"created_at":"2024-02-20T14:13:53.648351Z","id":"96a3abc1-4ee4-40e0-ab29-5e32b3946fee","subnet":"192.168.1.0/24","updated_at":"2024-02-20T14:15:15.200584Z"},{"created_at":"2024-02-20T14:13:53.648351Z","id":"b574e40b-78ba-47da-9164-2bbfa4baf318","subnet":"fd68:d440:21c4:5b08::/64","updated_at":"2024-02-20T14:15:15.204007Z"}],"tags":[],"updated_at":"2024-02-20T14:15:34.792378Z","vpc_id":"b3d404a0-ad75-40e3-9ebf-954d628bf2d6"}'
     headers:
       Content-Length:
-      - "26"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:16 GMT
+      - Tue, 20 Feb 2024 14:16:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4430,7 +4430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30b14e16-ea77-4fdf-b639-431cc2dcdede
+      - dd5b8ff5-d25c-49d1-b4d9-ad1fe99cb03b
     status: 200 OK
     code: 200
     duration: ""
@@ -4439,23 +4439,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"created_at":"2023-12-18T13:17:17.306857Z","dhcp_enabled":true,"id":"ed86be17-32e1-4c40-af44-0f7ab98de215","name":"my_private_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"nl-ams","subnets":[{"created_at":"2023-12-18T13:17:17.306857Z","id":"b2b6c7ba-0069-4cb2-abbe-1b53cdbc4c46","subnet":"192.168.1.0/24","updated_at":"2023-12-18T13:18:30.405111Z"},{"created_at":"2023-12-18T13:17:17.306857Z","id":"05f55433-8af9-4897-8a89-9cb5ad4ae21f","subnet":"fd5c:d510:d730:4be::/64","updated_at":"2023-12-18T13:18:30.410109Z"}],"tags":[],"updated_at":"2023-12-18T13:18:44.146014Z","vpc_id":"4a115924-8c5e-49f8-8294-c0c9297ea9b9"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "701"
+      - "1071"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:16 GMT
+      - Tue, 20 Feb 2024 14:16:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4463,7 +4463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26fcb7f2-5301-4f1e-a797-89274e7f392a
+      - 9c704262-4ca4-4e46-b045-5e51daa1b823
     status: 200 OK
     code: 200
     duration: ""
@@ -4472,23 +4472,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVS2Y0S3lQMmJDTFVPKzhlQXdjMDFkbHF1Ui9Jd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck5EQXlNakF4TkRFeU1UTmFGdzB6TkRBeU1UY3hOREV5TVROYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURkeGpyWGhtc0h2MGQxRzBWNkRUNXU5Yi9zTVF3Vk55WkF4bnRxUXVzZERsUEt5RHh5R1R1QXRHN20KYk1MU01VNzhZa0lDQlRzdlZYT1BLWHU5UEJNaVBOMGZSek92WG4xRjkxNTNyVTJyOENwZWxxaUN4QjVnT3YvdwpmQU9yMk5oWGpyS0JoM0hucTBydU5qT3RmMXlOaFo5YnBLMGdDa1JXVzhxY1ZqZU1rbHJXY0dmRHJLdCtaUlFVClNGUk95eTNBNk1ZaUVya2dBVnExbkx2Y3RUSUpJU2lrKzd1Q1lRSEJBbHN1Wm5sOHpvVExPLzVZOEIrRlorVUIKTnoyRlU4OGgwR3c4WVdjM3R3eDdzek1lL0poSENVdFhIVTBrbTV2UEZQSTdOelYyMVFNRkZ2WTA0U29vMFp6VQp1NTVPRkEvUDhGWmUzWU53RTdUalJPenM4WmxsQWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OXdOb2NFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFpRnRjRDNGUVJQUEQKenJ6TE1jaFFiTzJTcHZrL1hCV3JBWDA3aFpnazFsVkswTUlwTWp0L0l2aEJFZ1c5UTVCa2xwRVlhajk5K2pRNApvWWtjOTlxbHI1dTVXbk5MOFZVVzNVenM4L3hGVGdiVXM1QkRrUHpXZDczQWdMWkVvbDZFNjRPc1ptdS9QMnpqCnBDRzRNSFFyODFxL3RSVXJMRVNxaE9uU21VUW1rYXQzODR4c0JjLzBGTHp0OTNWUkRRbkphV2VDNXFBMzBjVmUKaXBRMXVMU1JKc05KRUpsV1BKaWt2aHpDdkNnbHM0TVZkeGJ3cnM0N2JoNHk1OXBPcmd0aSt1TVIxTCtZYUl6Nwo4bEh3ZlpRT04zV3lYc0xMaUEwOHNjdWtRRTdkTy9ITHpzV05kWEpCWEdldWpKVXhxV2h5ekJzQWlCUTZHeU1MCjdDOXN4aTFabnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1030"
+      - "1733"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:16 GMT
+      - Tue, 20 Feb 2024 14:16:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4496,7 +4496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0ed04e6-81f6-40a2-b54c-f0b015fd9941
+      - 3dfcd584-db23-40fb-8653-d047d516527a
     status: 200 OK
     code: 200
     duration: ""
@@ -4505,23 +4505,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZekNDQWt1Z0F3SUJBZ0lVZEVGWWpMcDFMYVdKVUt2amtSUzlwaFU0c3Z3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1Z6RUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RlRBVEJnTlZCQU1NRERFNU1pNHhOamd1TVM0ME1qQWVGdzB5Ck16RXlNVGd4TXpFME1UZGFGdzB6TXpFeU1UVXhNekUwTVRkYU1GY3hDekFKQmdOVkJBWVRBa1pTTVE0d0RBWUQKVlFRSURBVlFZWEpwY3pFT01Bd0dBMVVFQnd3RlVHRnlhWE14RVRBUEJnTlZCQW9NQ0ZOallXeGxkMkY1TVJVdwpFd1lEVlFRRERBd3hPVEl1TVRZNExqRXVOREl3Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUUMwY1NoZUNPOW5zYU0ydjhNelRkaTNXNFljUFhkQW9xRjdXVUhqZXlpblk4ZkYvbGZnZ2lYZEFCc1oKWjlIeWNaNHE5TkVpNkZueWM4MzFEaFJORU9XQ3RLSDU5T0Jia2l0MEpMeVROYTd5RTNNZ1hySDhTcE1EOUdUVQpldGNhd2h2MUNjcVFvaVEvb1NjU0VMVFdnQXFiUzFMcmtuT25aT1F0RlArb2p3MDBjKzI3RWt5NGdxM1NpKzhLCm9RcVlpeEcyeHNHZTZSQjY5L0dkMStiQmdmeXdXK3dETGF4alpPZWZQYlJVTTJ5bUN1ai9VZ0VwVjdiakdseU0KZjFNZW1OSHFDa0sxaU9TRWtTb1FneEo0L2IrVGJlZDRISVA1UGVUa1l4YTBuckhIREtyT2dIekMzR200VHFERgoyNDFoWkNzRU9ZdXBLS3IwNUZPVGIvSzMzZXJ4QWdNQkFBR2pKekFsTUNNR0ExVWRFUVFjTUJxQ0RERTVNaTR4Ck5qZ3VNUzQwTW9jRU13OS85WWNFd0tnQktqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFvWlBkUDFGd1BMbEoKNUdOWXJJRENIeEpybXpiYUtlRHVBWGluWEtRNlBZMUFTcUozQlJYbXJRVy9lWHAwUk9Yd2lpWEllcUV5WlVWYQprczR6NkhqNWlHT2h6cUdaUW1DTXlqWlB3L2pKUU1CcEh4TjJzaXUvWXhuOE5nanppWThFNE9DdWJqYWQwcDVZCnYyZHZBQTltNmxnNEVzKzAvSTJwUmd3ajNwNFRaREFQZEZqSWF6d3ozU21jRGcyM0tzWkVFb05Vb2FpVkdPTVQKY2ppU1N6QUx2N25KQVZteDI3dGtaOGxoQnNZaStkTmp3Y3lqeVlPcmg4Q25JTWFId2N3RnpsVlpyemhld1VwaApkUHY3Nk9zK2IxR2RqYWg1YnhFcUtmSDZVQkdYbU83ZnFJRnhnclZuZjEvYWRxRHNmcTQrb256QXFhbms2Zzc5CjdUekRWUkFHMHc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1731"
+      - "1071"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:16 GMT
+      - Tue, 20 Feb 2024 14:16:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4529,7 +4529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f2699a06-1102-4092-bc9c-d98c4a8cb356
+      - ed18d234-9648-4c15-aa53-9a5075c44bae
     status: 200 OK
     code: 200
     duration: ""
@@ -4538,23 +4538,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e0a34b56-b006-48fe-b123-62541f35fcbb&resource_type=rdb_instance
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
+    method: DELETE
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "26"
+      - "1074"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:16 GMT
+      - Tue, 20 Feb 2024 14:16:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4562,7 +4562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ceccc769-c071-42b4-b456-c8bb05e48fd3
+      - e8c49524-fa1f-46c5-bef1-cfb297858eae
     status: 200 OK
     code: 200
     duration: ""
@@ -4571,23 +4571,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-20T14:11:20.489958Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1030"
+      - "1074"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:17 GMT
+      - Tue, 20 Feb 2024 14:16:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4595,7 +4595,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5d1e25f-c7e3-484b-87b5-e3d7282c311f
+      - 5d594885-56c3-44c4-bf56-86c65edd05fc
     status: 200 OK
     code: 200
     duration: ""
@@ -4604,9 +4604,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/ed86be17-32e1-4c40-af44-0f7ab98de215
+    url: https://api.scaleway.com/vpc/v2/regions/nl-ams/private-networks/e409e337-e21b-408c-826c-bfe506d5a3e7
     method: DELETE
   response:
     body: ""
@@ -4616,9 +4616,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:17 GMT
+      - Tue, 20 Feb 2024 14:16:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4626,7 +4626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc511ed1-a454-4de9-8e54-3f6b1146b8c8
+      - ec84bbbb-87f9-4080-8298-6a3e84784dec
     status: 204 No Content
     code: 204
     duration: ""
@@ -4635,78 +4635,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1033"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:19:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d1280e18-2e20-4efb-9cab-c3aaf4fe71cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:13:12.830442Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e0a34b56-b006-48fe-b123-62541f35fcbb","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-private-network","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume","rdb_pn"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
-    headers:
-      Content-Length:
-      - "1033"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:19:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f7cc9eb2-c47e-4cee-9737-9dbe78e2b3c8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"e0a34b56-b006-48fe-b123-62541f35fcbb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4715,9 +4649,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:47 GMT
+      - Tue, 20 Feb 2024 14:16:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4725,7 +4659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63099567-6313-4666-b6ce-715966b265de
+      - 4449c698-37ff-43e9-8a30-e4cd8b6a7bff
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4734,12 +4668,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/e0a34b56-b006-48fe-b123-62541f35fcbb
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/eb25bfb2-524f-472b-9a7d-c16b83b256de
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"e0a34b56-b006-48fe-b123-62541f35fcbb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"eb25bfb2-524f-472b-9a7d-c16b83b256de","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -4748,9 +4682,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:57 GMT
+      - Tue, 20 Feb 2024 14:16:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4758,7 +4692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d533841-ffa5-4bf8-93e1-7de732ea69d8
+      - 66df5ff2-68c0-4939-9bc9-17a124e5cd1c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-basic.cassette.yaml
@@ -318,9 +318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:49 GMT
+      - Fri, 23 Feb 2024 13:56:33 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2dd2348-a3c8-421a-a0e1-319b42d63603
+      - 767fb844-f893-4d5a-9226-9b1615f24e86
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-basic","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -353,9 +353,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4507eba0-eec1-4758-877e-2b49bcbea853
+      - 329c3ac4-5b89-4344-b1f9-9482402e41aa
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -386,9 +386,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f2ec62c-31a3-433b-bdcd-4fd48f0e8db4
+      - 9d572cf1-0cde-4a62-be39-b0d986edeafc
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -419,9 +419,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:26 GMT
+      - Fri, 23 Feb 2024 13:57:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d30bd953-a745-4f66-84aa-d94161c6060b
+      - 5bee814b-6422-4a65-bfe4-2968ce48be58
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -452,9 +452,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:56 GMT
+      - Fri, 23 Feb 2024 13:57:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31f9c56a-eca6-493b-a781-5eccb4e1abf0
+      - dbe54b3b-17d3-4723-a042-06c7d0969636
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -485,9 +485,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:28 GMT
+      - Fri, 23 Feb 2024 13:58:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08806816-94fc-4f56-b209-9628ee163702
+      - ad5c81f6-96ba-4c80-936c-4c1765e78199
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -518,9 +518,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:58 GMT
+      - Fri, 23 Feb 2024 13:58:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7335e115-2868-458f-9126-c6724ba6db55
+      - 97a50987-107e-49f7-9da1-20199746b44c
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -551,9 +551,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:29 GMT
+      - Fri, 23 Feb 2024 13:59:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec8be8b1-ac13-4e9b-b90e-c4a9dbf4d16c
+      - 66550b74-152c-4881-ac7a-b08a81449381
     status: 200 OK
     code: 200
     duration: ""
@@ -572,10 +572,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "790"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3bb3cf19-41a5-4238-a120-65c46225a05a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1065"
@@ -584,9 +617,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:59 GMT
+      - Fri, 23 Feb 2024 14:00:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -594,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d26ebb9f-07e9-44fb-8cfc-e6e8f03199b1
+      - 2ce83d2c-3ecd-4922-8a2c-d1598d44b09b
     status: 200 OK
     code: 200
     duration: ""
@@ -605,21 +638,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752},"endpoints":[{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752}],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528},"endpoints":[{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528}],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1282"
+      - "1280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:29 GMT
+      - Fri, 23 Feb 2024 14:00:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -627,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f43a818f-eaa9-4161-934a-f9bd27c8dd5b
+      - a99a5dac-102a-4360-9413-fe0defcd2473
     status: 200 OK
     code: 200
     duration: ""
@@ -638,21 +671,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYmhLQm5zMXhxaUpSSVZWakFzSitwVHAwZ3dBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qYzFPVm9YRFRNME1ESXhPREU0TWpjMU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdZbTR0Z2FrY3pJQU95R0VIYXV1alUvNUxlRGdkRlZmM2JGeUhXdGFiYVFPeXI0RE9GUWoKeTNWanB4K1hvU0hmRUZlcWw0SCtYdkw4MXlManBlcEw1YWNjUkQvTlkwWkIyOXNRMk93cHVTSmtva3hCVXo2bwpTTXhOWVB2UVdIY1RMeGVVV1BNQ0JYVWpQam9XUTlQbkQ3ckZxSjZMSlZEWmhNaU41dGZzM1RHQ0VPZ0lCQmQvCktFR05vRDc5U25pSFZpb3Q1SkVoeWZVUmoxSytudGVzem5hYjhBTDlaRFF0dVBha0lZWTh2dVU2YzBxbkYxUTEKSmdvM0pCZkFCVGUrdnpab3hLemNqNDVOSHoxQklrMlVheUZhcXdnUEJYU3d3ZW4wL2o1aUhNN3ArNkY2Ty9rWApybDA2ZE9rYnh3a3B0UVFkZG82WjlmcW1TRURIZmJoNDNRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFsWlRVd1lqY3paQzB3WXpkaUxUUTJNR1V0T0RJeU1TMHoKTW1VM1ltRXlObVl4WVdZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbFpUVXdZamN6WkMwd1l6ZGlMVFEyTUdVdE9ESXlNUzB6TW1VM1ltRXlObVl4WVdZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZVlkdUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFFM0tFRkV6OHJKa0ZNRVRGSmNTU0NLMFJncHB3Y1dYRkJuZGpXSzYrYnVXRmR2ZGtTYzBocGpNcmhiKwpDY1QvUndaRklWZE5LckJKOTRMcUhmZFlTZFlEbTJGbUUyamxtODhXZi9ZelZRMWFpb3NGNXJHa0dKY2VrL01rClE5d2dDcnRKaTkxdEh5eFZWZUxTYTdyN2xIdmhWWExsaTE3T0x5SEswSkNMbzdyT0l1QUN1TWprdkl4SFlZZ2wKNHZkNmJuRndYYUhCZkZVUjlxZ1BUTXpSUXM1WkZ1QUVQY0NVUmlxR3dMVGxTODlrSHFJVDdUbzNZQVI1TEd2YQpTVHlDMHhScWd3VFdWeFpGaVBsM0E4QVU5Vmw5UkorR0QrdDhNeHc3RWNJUjE4bDArMEkzSSsyNmtYTlNIcVhGCmorY2RMTjJrU00vNEJxSEN6T0pmNGRFUE1CWT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWm9NbFRRZ2lSaGdQZVNpdjQyUFl1TEpSMFI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qUXdNakl6TVRNMU9UVXpXaGNOTXpRd01qSXdNVE0xT1RVeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU54bHVjYll0Qkg5czhIQi9RZ1FMOFhjYll3eUxIOGFWS1lDeHBYSjU2L3ZETGZUclNMdXg1ajkKZW0rSUdHZ2xIc21ydGJDOURSbzdkcWhuaTRVcjNuc1h5SlFKTDkzL0hiQWxXTlhrL3l6N1lGV3loc3NKdXpLSwp4M1JVSDlMWVF0RE92Y012QUxQSHFLS1MxalV6K0FONVNzbU1MRGo0ZDUvRGgxaFJWMTN4M1k3aElRMThRVWFNCms3bStlOFkrMFZMaDNYMktBS3JMeTNRRnZtMFJqeDhFUEJZVUFUUmNmQVltVkJKa3RlaUxGQmZMdUhBY1VkbGgKQ2VXZy9NUWNXM3Y0Q1JRa2JxN1N3THZja3lTbExUZVU1eFU4ZTB1TWplZGdZemcxdVl5VW1Sb2tqR1U0THcwZQpJR3JKRW5sWXVsYW9OWXB0OTFXVzhBNmlJNUVmTVU4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNakV6Z2p4eWR5MDBObUUzTnpjd05pMDJNVEZoTFRSaVltUXRZbVZtWmkxak1EWTAKTVRNek1UQTBPRGt1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHlNVE9DUEhKMwpMVFEyWVRjM056QTJMVFl4TVdFdE5HSmlaQzFpWldabUxXTXdOalF4TXpNeE1EUTRPUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy9zR0ljRU01OEsxWWNFTTU4SzFUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKelFmeE9wemRqdlRtZzFhalc2WTkyZGVBQ09IZHBXVDg1bDhRS1BRN3llVGVqdXFBY2Q4SjVPdE02VFVUemZTeApKRVoydEZVWm52NHZIZ2p6aGY4WDBwZ3d4NVU3aG5QRzdoN1RkWC9PTG90S2NxUEVLTWNoSTlGQmEzUHhlVENuCm9FeVQ3SGxyN3VMNVR1dkwrTkJrUklEL21OK0J6Wk9JdzNSQVN3UldrZEdzUlp5enIyVFZXcVlYVnA4Wi96YVEKYkY2Vk91Qy9LQTFCMi9idG02cHdpbGlkSEtjeDNUNWt4THVBVGhjM0hLMnZyL3lNVDZmUVoxWmhIaEZ4TDZTcApLajRYTDlDUHpVdlhQL2dpUVp3alhiSk1BUVVEZ09IK2Q0MCtRb3VLNTczTzlKVitJdlNtcnNKSXFITmg4MWt4CmVJSnhZbysxYVhWWThDS3dzek5VNlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:29 GMT
+      - Fri, 23 Feb 2024 14:00:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -660,45 +693,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45c13dc2-bdb5-4d49-a6fe-4443662cb3ed
+      - 85092351-f0db-46f7-8f99-5ff953ab35f6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ee50b73d-0c7b-460e-8221-32e7ba26f1af&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:28:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 470d20f2-33d7-4f3f-8172-c0a1481cd423
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
+    body: '{"instance_id":"46a77706-611a-4bbd-beff-c06413310489","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -709,7 +709,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "177"
@@ -718,9 +718,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:30 GMT
+      - Fri, 23 Feb 2024 14:00:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -728,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0577246a-4a26-49f8-af71-3b72d9035f5c
+      - be2b53e3-edb7-4eb3-a219-bb64ffae37fe
     status: 200 OK
     code: 200
     duration: ""
@@ -739,10 +739,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"endpoints":[],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "177"
@@ -751,9 +751,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:30 GMT
+      - Fri, 23 Feb 2024 14:00:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10c97770-d331-4913-b185-6116881da054
+      - f2573a70-98b0-4885-b718-b003c47b812e
     status: 200 OK
     code: 200
     duration: ""
@@ -772,10 +772,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"endpoints":[],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "177"
@@ -784,9 +784,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:00 GMT
+      - Fri, 23 Feb 2024 14:01:14 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -794,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee4206e5-76a7-4cb8-93d9-90c7b246778f
+      - a8fadced-34d8-4753-be5e-c30d483db292
     status: 200 OK
     code: 200
     duration: ""
@@ -805,21 +805,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "291"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:31 GMT
+      - Fri, 23 Feb 2024 14:01:46 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3dc63b9c-ebfc-4cd8-b35e-5e9ee23f4fbf
+      - 3faca8d1-ef59-4be5-9de6-617b905e16e0
     status: 200 OK
     code: 200
     duration: ""
@@ -838,21 +838,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "291"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:01 GMT
+      - Fri, 23 Feb 2024 14:02:16 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b582914-d212-41fb-89c2-af4cfec0c1f8
+      - 81429247-b1ac-4b21-a3a1-cfec49648a85
     status: 200 OK
     code: 200
     duration: ""
@@ -871,21 +871,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "291"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:31 GMT
+      - Fri, 23 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -893,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08092f41-7211-4888-9a22-fd9caf50e7ca
+      - 48cf7870-b400-4873-8fe7-6c9db24ef4f9
     status: 200 OK
     code: 200
     duration: ""
@@ -904,21 +904,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "284"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:03:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -926,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78b61767-0102-488e-b0ed-30f7f071b2cf
+      - be30859d-5021-4ede-82b4-b641a2c1dead
     status: 200 OK
     code: 200
     duration: ""
@@ -937,21 +937,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "284"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:03:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -959,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46fb498b-9740-4fe9-84ef-93d494ee97b1
+      - 0828efc6-e8c3-4c77-a3be-86ae3e0b3494
     status: 200 OK
     code: 200
     duration: ""
@@ -970,21 +970,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ee50b73d-0c7b-460e-8221-32e7ba26f1af&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "27"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:03:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -992,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59a83cd9-973b-4e95-8189-5f4ad5ae0a30
+      - 499a64bd-d822-4f85-a3e8-93f96f5a6bfb
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,21 +1003,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528},"endpoints":[{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528}],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "284"
+      - "1563"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:03:23 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1025,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37e99dd0-6120-4168-925c-15d825793feb
+      - 509f4785-3464-4e83-b01c-3595d09e7e0a
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,21 +1036,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752},"endpoints":[{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752}],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWm9NbFRRZ2lSaGdQZVNpdjQyUFl1TEpSMFI0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eU1UTXdIaGNOCk1qUXdNakl6TVRNMU9UVXpXaGNOTXpRd01qSXdNVE0xT1RVeldqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakl4TXpDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU54bHVjYll0Qkg5czhIQi9RZ1FMOFhjYll3eUxIOGFWS1lDeHBYSjU2L3ZETGZUclNMdXg1ajkKZW0rSUdHZ2xIc21ydGJDOURSbzdkcWhuaTRVcjNuc1h5SlFKTDkzL0hiQWxXTlhrL3l6N1lGV3loc3NKdXpLSwp4M1JVSDlMWVF0RE92Y012QUxQSHFLS1MxalV6K0FONVNzbU1MRGo0ZDUvRGgxaFJWMTN4M1k3aElRMThRVWFNCms3bStlOFkrMFZMaDNYMktBS3JMeTNRRnZtMFJqeDhFUEJZVUFUUmNmQVltVkJKa3RlaUxGQmZMdUhBY1VkbGgKQ2VXZy9NUWNXM3Y0Q1JRa2JxN1N3THZja3lTbExUZVU1eFU4ZTB1TWplZGdZemcxdVl5VW1Sb2tqR1U0THcwZQpJR3JKRW5sWXVsYW9OWXB0OTFXVzhBNmlJNUVmTVU4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNakV6Z2p4eWR5MDBObUUzTnpjd05pMDJNVEZoTFRSaVltUXRZbVZtWmkxak1EWTAKTVRNek1UQTBPRGt1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHlNVE9DUEhKMwpMVFEyWVRjM056QTJMVFl4TVdFdE5HSmlaQzFpWldabUxXTXdOalF4TXpNeE1EUTRPUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0UxQy9zR0ljRU01OEsxWWNFTTU4SzFUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKelFmeE9wemRqdlRtZzFhalc2WTkyZGVBQ09IZHBXVDg1bDhRS1BRN3llVGVqdXFBY2Q4SjVPdE02VFVUemZTeApKRVoydEZVWm52NHZIZ2p6aGY4WDBwZ3d4NVU3aG5QRzdoN1RkWC9PTG90S2NxUEVLTWNoSTlGQmEzUHhlVENuCm9FeVQ3SGxyN3VMNVR1dkwrTkJrUklEL21OK0J6Wk9JdzNSQVN3UldrZEdzUlp5enIyVFZXcVlYVnA4Wi96YVEKYkY2Vk91Qy9LQTFCMi9idG02cHdpbGlkSEtjeDNUNWt4THVBVGhjM0hLMnZyL3lNVDZmUVoxWmhIaEZ4TDZTcApLajRYTDlDUHpVdlhQL2dpUVp3alhiSk1BUVVEZ09IK2Q0MCtRb3VLNTczTzlKVitJdlNtcnNKSXFITmg4MWt4CmVJSnhZbysxYVhWWThDS3dzek5VNlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1566"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:03:24 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1058,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76034a84-dc77-4b85-958f-c768469afcb3
+      - 931af65e-93fa-47f2-bedc-92b415d185f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,21 +1069,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVYmhLQm5zMXhxaUpSSVZWakFzSitwVHAwZ3dBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qYzFPVm9YRFRNME1ESXhPREU0TWpjMU9Wb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdZbTR0Z2FrY3pJQU95R0VIYXV1alUvNUxlRGdkRlZmM2JGeUhXdGFiYVFPeXI0RE9GUWoKeTNWanB4K1hvU0hmRUZlcWw0SCtYdkw4MXlManBlcEw1YWNjUkQvTlkwWkIyOXNRMk93cHVTSmtva3hCVXo2bwpTTXhOWVB2UVdIY1RMeGVVV1BNQ0JYVWpQam9XUTlQbkQ3ckZxSjZMSlZEWmhNaU41dGZzM1RHQ0VPZ0lCQmQvCktFR05vRDc5U25pSFZpb3Q1SkVoeWZVUmoxSytudGVzem5hYjhBTDlaRFF0dVBha0lZWTh2dVU2YzBxbkYxUTEKSmdvM0pCZkFCVGUrdnpab3hLemNqNDVOSHoxQklrMlVheUZhcXdnUEJYU3d3ZW4wL2o1aUhNN3ArNkY2Ty9rWApybDA2ZE9rYnh3a3B0UVFkZG82WjlmcW1TRURIZmJoNDNRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFsWlRVd1lqY3paQzB3WXpkaUxUUTJNR1V0T0RJeU1TMHoKTW1VM1ltRXlObVl4WVdZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxbFpUVXdZamN6WkMwd1l6ZGlMVFEyTUdVdE9ESXlNUzB6TW1VM1ltRXlObVl4WVdZdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQkRPZVlkdUhCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFFM0tFRkV6OHJKa0ZNRVRGSmNTU0NLMFJncHB3Y1dYRkJuZGpXSzYrYnVXRmR2ZGtTYzBocGpNcmhiKwpDY1QvUndaRklWZE5LckJKOTRMcUhmZFlTZFlEbTJGbUUyamxtODhXZi9ZelZRMWFpb3NGNXJHa0dKY2VrL01rClE5d2dDcnRKaTkxdEh5eFZWZUxTYTdyN2xIdmhWWExsaTE3T0x5SEswSkNMbzdyT0l1QUN1TWprdkl4SFlZZ2wKNHZkNmJuRndYYUhCZkZVUjlxZ1BUTXpSUXM1WkZ1QUVQY0NVUmlxR3dMVGxTODlrSHFJVDdUbzNZQVI1TEd2YQpTVHlDMHhScWd3VFdWeFpGaVBsM0E4QVU5Vmw5UkorR0QrdDhNeHc3RWNJUjE4bDArMEkzSSsyNmtYTlNIcVhGCmorY2RMTjJrU00vNEJxSEN6T0pmNGRFUE1CWT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "2013"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:03:26 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1091,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 339f59b6-aa4b-4b63-8df5-05709fd92100
+      - dc5735bb-f46e-4557-9cc5-e3dfb59afee3
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,21 +1102,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ee50b73d-0c7b-460e-8221-32e7ba26f1af&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "27"
+      - "283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:03:26 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1124,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a8e3115-e49c-4f97-9527-29915373bf3f
+      - fe1a516e-9326-45e3-b7f6-6ee518de3563
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,120 +1135,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
-    method: GET
-  response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 978ec2dc-3f82-4321-87a2-5bfafb50fffd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ee50b73d-0c7b-460e-8221-32e7ba26f1af&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8f10c5d3-fd80-4ab8-b0f4-58c2425b0595
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
-    method: GET
-  response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:31:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b2b7a017-0038-4db2-b87a-fb7469c7f7e5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: DELETE
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "287"
+      - "286"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:03 GMT
+      - Fri, 23 Feb 2024 14:03:26 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1256,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 176d877c-5c6f-4f91-998b-88bfce89cdd7
+      - 0a2e35f5-c7cc-4144-a425-24e0422ec372
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,21 +1168,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"3180df63-ea07-434b-9e70-b0eeb2675d77","ip":"51.158.119.207","name":null,"port":5432}],"id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","instance_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"7235905a-062b-487e-be6c-5df69f70fad4","ip":"212.47.235.64","name":null,"port":5432}],"id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","instance_id":"46a77706-611a-4bbd-beff-c06413310489","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
-      - "287"
+      - "286"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:03 GMT
+      - Fri, 23 Feb 2024 14:03:26 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1289,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74d7bf7f-0890-4097-8699-95551260072c
+      - 117785ff-660d-405c-b93b-1801c2f816af
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,10 +1201,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1312,9 +1213,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:33 GMT
+      - Fri, 23 Feb 2024 14:03:56 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1322,7 +1223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53da28c5-8687-4038-81b6-23239005b5bd
+      - 3a6f3d35-f9ea-486a-9510-d7c4b5ae891a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1333,21 +1234,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752},"endpoints":[{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752}],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528},"endpoints":[{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528}],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1282"
+      - "1280"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:33 GMT
+      - Fri, 23 Feb 2024 14:03:57 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1355,7 +1256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8a45775-9e92-4459-bba4-9c8670a06837
+      - 197304ec-c7c7-4dd2-adc2-af8152000e8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1366,21 +1267,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752},"endpoints":[{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752}],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528},"endpoints":[{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528}],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1285"
+      - "1283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:34 GMT
+      - Fri, 23 Feb 2024 14:03:57 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1388,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 126b1bf6-925b-4225-98f1-cb8040bdfcc3
+      - 609ba64f-d1c8-4c57-9beb-2e8bfcf4281b
     status: 200 OK
     code: 200
     duration: ""
@@ -1399,21 +1300,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.975290Z","endpoint":{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752},"endpoints":[{"id":"8764cc97-191d-4636-9c79-3c548a11ab2a","ip":"51.159.207.148","load_balancer":{},"name":null,"port":1752}],"engine":"PostgreSQL-15","id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.393607Z","endpoint":{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528},"endpoints":[{"id":"1fc82e0d-4068-43b8-a73e-eac0df2296cb","ip":"51.159.10.213","load_balancer":{},"name":null,"port":2528}],"engine":"PostgreSQL-15","id":"46a77706-611a-4bbd-beff-c06413310489","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-basic","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","minimal"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1285"
+      - "1283"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:34 GMT
+      - Fri, 23 Feb 2024 14:03:57 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1421,7 +1322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0da2924-f58d-40a9-96e8-ed504ee7db2c
+      - 42edfeb0-ab76-4948-8f66-32b31ea03ab1
     status: 200 OK
     code: 200
     duration: ""
@@ -1432,10 +1333,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"46a77706-611a-4bbd-beff-c06413310489","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1444,9 +1345,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:04 GMT
+      - Fri, 23 Feb 2024 14:04:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1454,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a34fc4e1-a35f-4f8e-9494-915410f59bbb
+      - a6c6997f-f2a0-462a-b91f-9ec6e9a96415
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1465,10 +1366,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ee50b73d-0c7b-460e-8221-32e7ba26f1af
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/46a77706-611a-4bbd-beff-c06413310489
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"ee50b73d-0c7b-460e-8221-32e7ba26f1af","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"46a77706-611a-4bbd-beff-c06413310489","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1477,9 +1378,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:04 GMT
+      - Fri, 23 Feb 2024 14:04:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1487,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5246f510-3e6f-45c5-aa95-5dc650e1e908
+      - 214213a0-12b2-4080-bffd-c178be74b9db
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1498,10 +1399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/784dd1b0-41e4-45cc-a544-c425a2f8862b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/48d0e7a0-6eec-49b5-b53a-e9b4c45afa50
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"784dd1b0-41e4-45cc-a544-c425a2f8862b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"48d0e7a0-6eec-49b5-b53a-e9b4c45afa50","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1510,9 +1411,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:04 GMT
+      - Fri, 23 Feb 2024 14:04:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1520,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e2c7369-c980-41c2-b6f6-7854b8e0d7d8
+      - 4fc62670-3f72-4cd0-830d-7346f166c752
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-different-zone.cassette.yaml
@@ -2,42 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
-    method: POST
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "915"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7993e9a5-10cc-4732-a6fd-cc181ea71f56
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"test-rdb-rr-different-zone","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    body: '{"name":"test-rdb-rr-different-zone","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -48,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -57,9 +22,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -67,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d09cb0c3-cfe1-43e1-a9fe-23cbe627d312
+      - a3cfe2dd-8aef-4946-9175-6bf2d9f07bb1
     status: 200 OK
     code: 200
     duration: ""
@@ -78,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -90,9 +55,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,21 +65,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 763aa0fb-470d-4716-8eb5-45bbfcabec72
+      - 85921846-9a03-4acc-80ab-d2cd2a48a5d7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-different-zone","engine":"PostgreSQL-14","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
+    method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "915"
@@ -123,9 +90,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -133,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6e90cea-1e09-40f4-a84f-3b375a99c7d2
+      - 50d0d606-179a-4b9b-842e-3d859782092a
     status: 200 OK
     code: 200
     duration: ""
@@ -144,10 +111,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "915"
@@ -156,9 +123,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:24 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -166,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d908d8cc-44ee-46ef-a2bf-17c6bb35c201
+      - 2a94819a-8928-4abc-aa4b-b88c4e6171c6
     status: 200 OK
     code: 200
     duration: ""
@@ -177,10 +144,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "915"
@@ -189,9 +156,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:55 GMT
+      - Fri, 23 Feb 2024 13:57:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -199,7 +166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a94d024-7917-4245-815f-84d5bca54785
+      - 212e2b9c-0001-4f31-9be3-22630cb8a965
     status: 200 OK
     code: 200
     duration: ""
@@ -210,10 +177,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "915"
@@ -222,9 +189,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:26 GMT
+      - Fri, 23 Feb 2024 13:57:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -232,7 +199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - efb4dbde-4532-4a24-8c3f-b08e9882fb08
+      - cf176327-c088-4252-90b3-22b114c6f1e5
     status: 200 OK
     code: 200
     duration: ""
@@ -243,10 +210,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "915"
@@ -255,9 +222,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:56 GMT
+      - Fri, 23 Feb 2024 13:58:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -265,7 +232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2154cb16-d4f4-4d17-93ec-09a9c0af1946
+      - 9aa395ab-024d-426a-9942-19780494107a
     status: 200 OK
     code: 200
     duration: ""
@@ -276,10 +243,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "915"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:58:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c9f5183-bea2-4f80-8e46-74441a32ee59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "915"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0a372c0d-c48b-4961-8813-3cbf8f6919f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1190"
@@ -288,9 +321,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:26 GMT
+      - Fri, 23 Feb 2024 13:59:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -298,7 +331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37c9ef1d-5cd6-4b7b-b870-28b2a024fe51
+      - 1b9402e9-9c80-48b7-b2fc-9795731ee6ea
     status: 200 OK
     code: 200
     duration: ""
@@ -309,21 +342,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1411"
+      - "1407"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:57 GMT
+      - Fri, 23 Feb 2024 14:00:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -331,7 +364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 883e795d-bbf1-4bd6-8f6c-534b5a8a78f7
+      - b8a18b41-4b83-4ff7-800b-2bf8e4943e7f
     status: 200 OK
     code: 200
     duration: ""
@@ -342,21 +375,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVTWdjQ0t4L0NtQ0R4cDFTRHRWWENwRjM4V0t3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpFeE9ESTNNalJhRncwek5EQXlNVGd4T0RJM01qUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRFBxdVljQ3VEQUhBSmoxT2NwSlZaam9JYU1GRjg1WlVVNFFFVHdWazZ0ZGF1bk9VZW8KdDN1cVdRTTlOM1R3SHlGWGZjQ3FscGQ4ZmhReExSZzA2MnBXQWhlUjlCSithRzluemxEZU5Ub2hObFNGZ2VMVQo3MVpkbE92aG1GUW5qN0lDZEplbnp6OEdGcmVKZG50V1FrSTdPWGY2WVFYeTcya09VUE55d3hlL0NLVDlLMm5XCmc1WW54d3IwUTdtbTUvTndkeGwwQ1BKWXQwZ2RvZHAzcldTTE5TYVVEVWJnNFQ3QzVGOVA3VWw1Q29maGZZSWEKT01id0NQN3ovMThSNWFxS1oxQUM4OUR2ZVFJVFltblJ2RlY5TDBEYStyc2lnd0VVb2NSQ0pXajFTcHpXT2Z1ZQpwSDdtWHdQQllVSEVZNmIxZnBjYklZSGt3T3p3dkxacHNuSVpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwelpXUTBNVGc1TkMwd09UZ3lMVFJtTXpjdE9EbGoKWVMwMFl6QXdNVEF3TjJKa1kyRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNMlZrTkRFNE9UUXRNRGs0TWkwMFpqTTNMVGc1WTJFdE5HTXdNREV3TURkaVpHTmhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVBlaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFqMGpvS01IbGE4MUZJKzJvaWRDOXFuZ2RldDZ5U1RxWUswamVraUtIVzVRdi9xOXVsQWh6dQpqelNyL1Niam5FcE1YUDVHZ3Axczg2OFcvTzQzMStSbFdhU096V3E3NEtWdXZGKzEzYVNkVDJPd3YyRUFHL3FMCmthelkrV3Z0ejRwUUdibFlJd1Jrb2x0MXVNZ2loRTExUHllUHFXWURUK2hrM21Ra1BlK2pyZkxOa09aRkRJRGoKSDJPd1F2QUVlc3ZIemplTEFKTVRsN3ZZZHpxRlU4dXg5Z0VtVW02cHR4R2pWSUxYV0ZvL2lhQWF0UU5QM1RoNQpzWmxFZHNraDYzN0RmMGNqT3Vib25PVzFZN0lFVmYvT1pVZzFZSlVkTU15TmxBZGZOYkZLMVJ6NVgveDdDN3poCkJjcEtSTTRwRWo2NUpsVUV3dHE5VDNsVDdtaEE0L3N1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVTHNabHdlUjgyOWtXb3VBOUNuVzluL0lMbFZVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU1qVXdIaGNOCk1qUXdNakl6TVRNMU9UTTVXaGNOTXpRd01qSXdNVE0xT1RNNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl5TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtdXdvcXpMZGlTRkRnL2wrZ3pXalZ6aEJjRmhCSlh0aENPWVZIbHNCRDc2cEJkSUwvU2hRaSsKOXlCL1puQTlNZHljSkZGUmY0Vm9ETE9JaG5XTTlVMzB3dmZWUjkxeUszaWZISGM0Z1VxZXVpNGZnSkZ1SDRyQwp4Um9VdGozakZka0FZZlRWQ0drNXZ0b0UzcllUT205c0FzaVl3ZGVrMlFRSGRaVUx5cmQ4U2FjRUtxWDlhclhmCmt6V2YvdGF0YVQzSXhNMEd1dG1NZm9kZ1Vram43SzEvR0lLcU9Ici92Qk5rTDlDOHArN05YRmlEeWJZUzZMaVkKMDFnUnVrdld2c055SUJsMXdRK2Y2VjlQKzZkQVo4YWpJSjZiMXRUdk0yb25lam9VZDZzdFl1SHZjcHJabmhGeApJQ09EYnpkRGE4eWpPQkFtYXhlaFJWeFJDVWxJMGtNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNakkxZ2p4eWR5MHhOV1ZpWVRobVl5MWlOVE14TFRRMFptWXRPREUzTmkxbU1ERXgKTmpJMU1HRTNOMkl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNaldDUEhKMwpMVEUxWldKaE9HWmpMV0kxTXpFdE5EUm1aaTA0TVRjMkxXWXdNVEUyTWpVd1lUYzNZaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk5TDRjRU01OUs0WWNFTTU5SzRUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKRzBzbTJZTEx0MXJOY0poYzVxTnJRdmhyK3UzVm8rT1kwZU1nOU5RaGVJaWlFNHBld3RrUWdrZzk5bUJQSm92VAo4SXpnU21VVFpRekpyN1ZQWlJiUDBZNVlDZTdkSEZoN2NXcVBZRm5OWmdMZVVabkpjYWdKU0dUQ2k2N09HWS9oCmZ6cEFjTEFpUERMbjVJSnBtSFZJZ21COEtCbzRGK2FrMEtKLzRxekZJZkRndTVsS1E5aWhuQi9xbHRZTlVQNHgKaTlEaFpSbXNmV0NRZmZUQVpsaXRSUFNxK2h2a1ErWWhERGF4bFIwSzdYam5sSGdJV3IzUVlERWZMeUdGWTVkWQpKNEMxV2Z2SElhek5uUEJkWVAyRVhpZjRKTTJxeGFkSndhdnMza1FqUStjQy9waUhxZU5ZK08ya3VqcFNOWFdHCkRsb2NjWUlmRzRPQTdSbnhJbWFxSEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2017"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:57 GMT
+      - Fri, 23 Feb 2024 14:00:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -364,45 +397,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe6fae74-a3c1-4f1a-bab8-dd857df62e00
+      - 526b7a5f-07bd-4fbe-98a8-0ad882e6a67b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:27:57 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6f4dcef7-3886-4f9e-ba61-73aedb77ec3a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","endpoint_spec":[{"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","ipam_config":{}}}],"same_zone":true}'
+    body: '{"instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","endpoint_spec":[{"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","ipam_config":{}}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -413,7 +413,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "399"
@@ -422,9 +422,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:58 GMT
+      - Fri, 23 Feb 2024 14:00:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -432,7 +432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 062c26fa-17e0-4f8b-83a4-0fd15f5fc075
+      - 54f71029-9417-4d5a-8dc7-d485d9f4a242
     status: 200 OK
     code: 200
     duration: ""
@@ -443,10 +443,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "399"
@@ -455,9 +455,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:58 GMT
+      - Fri, 23 Feb 2024 14:00:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -465,7 +465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a026cfb-f046-4b5f-acf4-696a30062d8f
+      - 88fa083b-6eea-47df-b8e7-f0902eb42d2c
     status: 200 OK
     code: 200
     duration: ""
@@ -476,10 +476,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "399"
@@ -488,9 +488,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:28 GMT
+      - Fri, 23 Feb 2024 14:00:38 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -498,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ead25af-0dcc-43f3-9cfe-f29476b61cbe
+      - a83e7563-82ab-40b6-8ba2-1d851df7a1a3
     status: 200 OK
     code: 200
     duration: ""
@@ -509,10 +509,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "399"
@@ -521,9 +521,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:58 GMT
+      - Fri, 23 Feb 2024 14:01:14 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -531,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9b433ec-0776-462f-86f3-38e6f38ed380
+      - 9211943e-83dd-4abe-a551-e84d61228e73
     status: 200 OK
     code: 200
     duration: ""
@@ -542,10 +542,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "399"
@@ -554,9 +554,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:28 GMT
+      - Fri, 23 Feb 2024 14:01:46 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -564,7 +564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10eb0444-0629-40ea-9aeb-6c511cd8acc2
+      - e9960309-8da6-4079-8af6-e300591ec0ed
     status: 200 OK
     code: 200
     duration: ""
@@ -575,10 +575,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "399"
@@ -587,9 +587,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:58 GMT
+      - Fri, 23 Feb 2024 14:02:17 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -597,7 +597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 721c39de-86eb-46fb-aeb7-84e79abcd2a0
+      - 326e0381-b76f-4daa-b490-3c55da1227a2
     status: 200 OK
     code: 200
     duration: ""
@@ -608,43 +608,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"initializing"}'
-    headers:
-      Content-Length:
-      - "399"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:30:28 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c4e63c91-e3ff-4a75-9833-aad087326944
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -653,9 +620,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -663,7 +630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3ca9c86-52df-44fd-a635-3475f7772500
+      - b5833420-b7b3-4d20-9b3a-50c571d12f5b
     status: 200 OK
     code: 200
     duration: ""
@@ -674,10 +641,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -686,9 +653,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -696,7 +663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87454b5b-46d3-4913-9e08-d9c3f1af36f9
+      - b40e7e1f-ee11-4f29-9e83-a6131807c340
     status: 200 OK
     code: 200
     duration: ""
@@ -707,10 +674,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=15eba8fc-b531-44ff-8176-f0116250a77b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-23T14:00:07.817592Z","id":"5402017b-71f8-4ea9-b889-b83382ab4528","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"15eba8fc-b531-44ff-8176-f0116250a77b","mac_address":"02:00:00:18:94:D3","name":"read-replica-50e92804","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:00:56.149574Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -719,9 +686,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -729,7 +696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1d29f6f-d4fd-4d0b-8674-59da6c685093
+      - 729f5f34-923c-4419-8725-d0b83e094362
     status: 200 OK
     code: 200
     duration: ""
@@ -740,10 +707,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -752,9 +719,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -762,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c89873de-78d7-4d31-aba1-8859fd7a053b
+      - 29dd713e-60c2-4f90-82b9-5b1cfca8cf0a
     status: 200 OK
     code: 200
     duration: ""
@@ -773,10 +740,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -785,9 +752,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -795,7 +762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91eeb8f0-90dc-47ce-88f6-c8a69d669b59
+      - b35a31bd-9867-461f-875b-bf05cc1169bd
     status: 200 OK
     code: 200
     duration: ""
@@ -806,10 +773,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -818,9 +785,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -828,7 +795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1287ea6-0cc2-43ec-b8a4-ccf62e31d251
+      - 8bdd9b67-d8d5-488c-acf3-b30c72ea5714
     status: 200 OK
     code: 200
     duration: ""
@@ -839,21 +806,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1803"
+      - "1799"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -861,7 +828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08dd2f48-de17-4812-b3ac-887f5f9a9616
+      - cc3fe8f7-4f08-45cf-98a8-54becd3c2a1f
     status: 200 OK
     code: 200
     duration: ""
@@ -872,21 +839,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVTWdjQ0t4L0NtQ0R4cDFTRHRWWENwRjM4V0t3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpFeE9ESTNNalJhRncwek5EQXlNVGd4T0RJM01qUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRFBxdVljQ3VEQUhBSmoxT2NwSlZaam9JYU1GRjg1WlVVNFFFVHdWazZ0ZGF1bk9VZW8KdDN1cVdRTTlOM1R3SHlGWGZjQ3FscGQ4ZmhReExSZzA2MnBXQWhlUjlCSithRzluemxEZU5Ub2hObFNGZ2VMVQo3MVpkbE92aG1GUW5qN0lDZEplbnp6OEdGcmVKZG50V1FrSTdPWGY2WVFYeTcya09VUE55d3hlL0NLVDlLMm5XCmc1WW54d3IwUTdtbTUvTndkeGwwQ1BKWXQwZ2RvZHAzcldTTE5TYVVEVWJnNFQ3QzVGOVA3VWw1Q29maGZZSWEKT01id0NQN3ovMThSNWFxS1oxQUM4OUR2ZVFJVFltblJ2RlY5TDBEYStyc2lnd0VVb2NSQ0pXajFTcHpXT2Z1ZQpwSDdtWHdQQllVSEVZNmIxZnBjYklZSGt3T3p3dkxacHNuSVpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwelpXUTBNVGc1TkMwd09UZ3lMVFJtTXpjdE9EbGoKWVMwMFl6QXdNVEF3TjJKa1kyRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNMlZrTkRFNE9UUXRNRGs0TWkwMFpqTTNMVGc1WTJFdE5HTXdNREV3TURkaVpHTmhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVBlaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFqMGpvS01IbGE4MUZJKzJvaWRDOXFuZ2RldDZ5U1RxWUswamVraUtIVzVRdi9xOXVsQWh6dQpqelNyL1Niam5FcE1YUDVHZ3Axczg2OFcvTzQzMStSbFdhU096V3E3NEtWdXZGKzEzYVNkVDJPd3YyRUFHL3FMCmthelkrV3Z0ejRwUUdibFlJd1Jrb2x0MXVNZ2loRTExUHllUHFXWURUK2hrM21Ra1BlK2pyZkxOa09aRkRJRGoKSDJPd1F2QUVlc3ZIemplTEFKTVRsN3ZZZHpxRlU4dXg5Z0VtVW02cHR4R2pWSUxYV0ZvL2lhQWF0UU5QM1RoNQpzWmxFZHNraDYzN0RmMGNqT3Vib25PVzFZN0lFVmYvT1pVZzFZSlVkTU15TmxBZGZOYkZLMVJ6NVgveDdDN3poCkJjcEtSTTRwRWo2NUpsVUV3dHE5VDNsVDdtaEE0L3N1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVTHNabHdlUjgyOWtXb3VBOUNuVzluL0lMbFZVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU1qVXdIaGNOCk1qUXdNakl6TVRNMU9UTTVXaGNOTXpRd01qSXdNVE0xT1RNNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl5TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtdXdvcXpMZGlTRkRnL2wrZ3pXalZ6aEJjRmhCSlh0aENPWVZIbHNCRDc2cEJkSUwvU2hRaSsKOXlCL1puQTlNZHljSkZGUmY0Vm9ETE9JaG5XTTlVMzB3dmZWUjkxeUszaWZISGM0Z1VxZXVpNGZnSkZ1SDRyQwp4Um9VdGozakZka0FZZlRWQ0drNXZ0b0UzcllUT205c0FzaVl3ZGVrMlFRSGRaVUx5cmQ4U2FjRUtxWDlhclhmCmt6V2YvdGF0YVQzSXhNMEd1dG1NZm9kZ1Vram43SzEvR0lLcU9Ici92Qk5rTDlDOHArN05YRmlEeWJZUzZMaVkKMDFnUnVrdld2c055SUJsMXdRK2Y2VjlQKzZkQVo4YWpJSjZiMXRUdk0yb25lam9VZDZzdFl1SHZjcHJabmhGeApJQ09EYnpkRGE4eWpPQkFtYXhlaFJWeFJDVWxJMGtNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNakkxZ2p4eWR5MHhOV1ZpWVRobVl5MWlOVE14TFRRMFptWXRPREUzTmkxbU1ERXgKTmpJMU1HRTNOMkl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNaldDUEhKMwpMVEUxWldKaE9HWmpMV0kxTXpFdE5EUm1aaTA0TVRjMkxXWXdNVEUyTWpVd1lUYzNZaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk5TDRjRU01OUs0WWNFTTU5SzRUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKRzBzbTJZTEx0MXJOY0poYzVxTnJRdmhyK3UzVm8rT1kwZU1nOU5RaGVJaWlFNHBld3RrUWdrZzk5bUJQSm92VAo4SXpnU21VVFpRekpyN1ZQWlJiUDBZNVlDZTdkSEZoN2NXcVBZRm5OWmdMZVVabkpjYWdKU0dUQ2k2N09HWS9oCmZ6cEFjTEFpUERMbjVJSnBtSFZJZ21COEtCbzRGK2FrMEtKLzRxekZJZkRndTVsS1E5aWhuQi9xbHRZTlVQNHgKaTlEaFpSbXNmV0NRZmZUQVpsaXRSUFNxK2h2a1ErWWhERGF4bFIwSzdYam5sSGdJV3IzUVlERWZMeUdGWTVkWQpKNEMxV2Z2SElhek5uUEJkWVAyRVhpZjRKTTJxeGFkSndhdnMza1FqUStjQy9waUhxZU5ZK08ya3VqcFNOWFdHCkRsb2NjWUlmRzRPQTdSbnhJbWFxSEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2017"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -894,7 +861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5a8ca9e-a90a-490f-980b-dc2924af9102
+      - fc698055-bf0b-4367-9534-7417abba3192
     status: 200 OK
     code: 200
     duration: ""
@@ -905,43 +872,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "548"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 44a2e0c1-c387-4901-9107-2535eb53e80d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -950,9 +884,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -960,7 +894,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16e136da-0667-41f1-89a0-8a0e0efbfe2d
+      - f4113a4f-9282-42ce-a31e-d27dafbfc12f
     status: 200 OK
     code: 200
     duration: ""
@@ -971,10 +905,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=15eba8fc-b531-44ff-8176-f0116250a77b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-23T14:00:07.817592Z","id":"5402017b-71f8-4ea9-b889-b83382ab4528","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"15eba8fc-b531-44ff-8176-f0116250a77b","mac_address":"02:00:00:18:94:D3","name":"read-replica-50e92804","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:00:56.149574Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -983,9 +917,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -993,7 +927,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac544f0d-94c9-4f42-8180-ccd78ec8be53
+      - 2bd9b5d7-14ed-473d-bc0e-c821c7879e80
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,10 +938,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -1016,9 +950,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1026,7 +960,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fea17067-1fe6-45ca-bdac-a54f9af1009b
+      - 9f425967-b239-47fe-a4b2-85c64e76863f
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,21 +971,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1803"
+      - "1799"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1059,7 +993,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1c1e50f-03dc-4d66-9662-20cebda18a9b
+      - e9044e93-c524-44f3-85da-174e08e2819c
     status: 200 OK
     code: 200
     duration: ""
@@ -1070,21 +1004,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVTWdjQ0t4L0NtQ0R4cDFTRHRWWENwRjM4V0t3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpFeE9ESTNNalJhRncwek5EQXlNVGd4T0RJM01qUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRFBxdVljQ3VEQUhBSmoxT2NwSlZaam9JYU1GRjg1WlVVNFFFVHdWazZ0ZGF1bk9VZW8KdDN1cVdRTTlOM1R3SHlGWGZjQ3FscGQ4ZmhReExSZzA2MnBXQWhlUjlCSithRzluemxEZU5Ub2hObFNGZ2VMVQo3MVpkbE92aG1GUW5qN0lDZEplbnp6OEdGcmVKZG50V1FrSTdPWGY2WVFYeTcya09VUE55d3hlL0NLVDlLMm5XCmc1WW54d3IwUTdtbTUvTndkeGwwQ1BKWXQwZ2RvZHAzcldTTE5TYVVEVWJnNFQ3QzVGOVA3VWw1Q29maGZZSWEKT01id0NQN3ovMThSNWFxS1oxQUM4OUR2ZVFJVFltblJ2RlY5TDBEYStyc2lnd0VVb2NSQ0pXajFTcHpXT2Z1ZQpwSDdtWHdQQllVSEVZNmIxZnBjYklZSGt3T3p3dkxacHNuSVpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwelpXUTBNVGc1TkMwd09UZ3lMVFJtTXpjdE9EbGoKWVMwMFl6QXdNVEF3TjJKa1kyRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNMlZrTkRFNE9UUXRNRGs0TWkwMFpqTTNMVGc1WTJFdE5HTXdNREV3TURkaVpHTmhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVBlaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFqMGpvS01IbGE4MUZJKzJvaWRDOXFuZ2RldDZ5U1RxWUswamVraUtIVzVRdi9xOXVsQWh6dQpqelNyL1Niam5FcE1YUDVHZ3Axczg2OFcvTzQzMStSbFdhU096V3E3NEtWdXZGKzEzYVNkVDJPd3YyRUFHL3FMCmthelkrV3Z0ejRwUUdibFlJd1Jrb2x0MXVNZ2loRTExUHllUHFXWURUK2hrM21Ra1BlK2pyZkxOa09aRkRJRGoKSDJPd1F2QUVlc3ZIemplTEFKTVRsN3ZZZHpxRlU4dXg5Z0VtVW02cHR4R2pWSUxYV0ZvL2lhQWF0UU5QM1RoNQpzWmxFZHNraDYzN0RmMGNqT3Vib25PVzFZN0lFVmYvT1pVZzFZSlVkTU15TmxBZGZOYkZLMVJ6NVgveDdDN3poCkJjcEtSTTRwRWo2NUpsVUV3dHE5VDNsVDdtaEE0L3N1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVTHNabHdlUjgyOWtXb3VBOUNuVzluL0lMbFZVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU1qVXdIaGNOCk1qUXdNakl6TVRNMU9UTTVXaGNOTXpRd01qSXdNVE0xT1RNNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl5TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtdXdvcXpMZGlTRkRnL2wrZ3pXalZ6aEJjRmhCSlh0aENPWVZIbHNCRDc2cEJkSUwvU2hRaSsKOXlCL1puQTlNZHljSkZGUmY0Vm9ETE9JaG5XTTlVMzB3dmZWUjkxeUszaWZISGM0Z1VxZXVpNGZnSkZ1SDRyQwp4Um9VdGozakZka0FZZlRWQ0drNXZ0b0UzcllUT205c0FzaVl3ZGVrMlFRSGRaVUx5cmQ4U2FjRUtxWDlhclhmCmt6V2YvdGF0YVQzSXhNMEd1dG1NZm9kZ1Vram43SzEvR0lLcU9Ici92Qk5rTDlDOHArN05YRmlEeWJZUzZMaVkKMDFnUnVrdld2c055SUJsMXdRK2Y2VjlQKzZkQVo4YWpJSjZiMXRUdk0yb25lam9VZDZzdFl1SHZjcHJabmhGeApJQ09EYnpkRGE4eWpPQkFtYXhlaFJWeFJDVWxJMGtNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNakkxZ2p4eWR5MHhOV1ZpWVRobVl5MWlOVE14TFRRMFptWXRPREUzTmkxbU1ERXgKTmpJMU1HRTNOMkl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNaldDUEhKMwpMVEUxWldKaE9HWmpMV0kxTXpFdE5EUm1aaTA0TVRjMkxXWXdNVEUyTWpVd1lUYzNZaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk5TDRjRU01OUs0WWNFTTU5SzRUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKRzBzbTJZTEx0MXJOY0poYzVxTnJRdmhyK3UzVm8rT1kwZU1nOU5RaGVJaWlFNHBld3RrUWdrZzk5bUJQSm92VAo4SXpnU21VVFpRekpyN1ZQWlJiUDBZNVlDZTdkSEZoN2NXcVBZRm5OWmdMZVVabkpjYWdKU0dUQ2k2N09HWS9oCmZ6cEFjTEFpUERMbjVJSnBtSFZJZ21COEtCbzRGK2FrMEtKLzRxekZJZkRndTVsS1E5aWhuQi9xbHRZTlVQNHgKaTlEaFpSbXNmV0NRZmZUQVpsaXRSUFNxK2h2a1ErWWhERGF4bFIwSzdYam5sSGdJV3IzUVlERWZMeUdGWTVkWQpKNEMxV2Z2SElhek5uUEJkWVAyRVhpZjRKTTJxeGFkSndhdnMza1FqUStjQy9waUhxZU5ZK08ya3VqcFNOWFdHCkRsb2NjWUlmRzRPQTdSbnhJbWFxSEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2017"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:02:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1092,7 +1026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81b3d11a-ce5e-4e13-be89-9ad564ab363b
+      - acaa2436-3fa6-430e-9150-81a8b1b08a54
     status: 200 OK
     code: 200
     duration: ""
@@ -1103,43 +1037,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "548"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff00ada1-6fbd-4f3b-a0a7-caa484e13fd1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -1148,9 +1049,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:02:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1158,7 +1059,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05791682-a942-453b-9d3c-e76ff972dac9
+      - 3d16f6b7-6c3a-4714-862a-e2172b5b261c
     status: 200 OK
     code: 200
     duration: ""
@@ -1169,10 +1070,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=15eba8fc-b531-44ff-8176-f0116250a77b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-23T14:00:07.817592Z","id":"5402017b-71f8-4ea9-b889-b83382ab4528","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"15eba8fc-b531-44ff-8176-f0116250a77b","mac_address":"02:00:00:18:94:D3","name":"read-replica-50e92804","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:00:56.149574Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -1181,9 +1082,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:02:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1191,7 +1092,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7bcbe70-13e9-4dd2-b04f-693d67af79cf
+      - a126265f-5a10-4473-a30d-312398ba9ad0
     status: 200 OK
     code: 200
     duration: ""
@@ -1202,10 +1103,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -1214,9 +1115,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:01 GMT
+      - Fri, 23 Feb 2024 14:02:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1224,7 +1125,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63214375-9bcd-45fa-937f-ae6dc30130fc
+      - a808515d-ac71-40d5-a447-ce8366736279
     status: 200 OK
     code: 200
     duration: ""
@@ -1235,10 +1136,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -1247,9 +1148,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:01 GMT
+      - Fri, 23 Feb 2024 14:02:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1257,7 +1158,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94e2c1e2-1956-49bd-b722-22f2bb7b70c7
+      - ebf9ab14-5c12-43dd-a213-ed3310378f6b
     status: 200 OK
     code: 200
     duration: ""
@@ -1268,10 +1169,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -1280,9 +1181,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:01 GMT
+      - Fri, 23 Feb 2024 14:02:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1290,7 +1191,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11f876bf-31d5-4888-938f-788865f772e2
+      - e6b1237b-1b98-475e-8dd0-5fb1b7b6bec8
     status: 200 OK
     code: 200
     duration: ""
@@ -1301,21 +1202,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1803"
+      - "1799"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:01 GMT
+      - Fri, 23 Feb 2024 14:02:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1323,7 +1224,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fbb6def-2709-4cd4-9af1-cc237c96a7b7
+      - 380bc3ba-e7cc-4e0c-a4af-a930b5dc348f
     status: 200 OK
     code: 200
     duration: ""
@@ -1334,21 +1235,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVTWdjQ0t4L0NtQ0R4cDFTRHRWWENwRjM4V0t3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpFeE9ESTNNalJhRncwek5EQXlNVGd4T0RJM01qUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRFBxdVljQ3VEQUhBSmoxT2NwSlZaam9JYU1GRjg1WlVVNFFFVHdWazZ0ZGF1bk9VZW8KdDN1cVdRTTlOM1R3SHlGWGZjQ3FscGQ4ZmhReExSZzA2MnBXQWhlUjlCSithRzluemxEZU5Ub2hObFNGZ2VMVQo3MVpkbE92aG1GUW5qN0lDZEplbnp6OEdGcmVKZG50V1FrSTdPWGY2WVFYeTcya09VUE55d3hlL0NLVDlLMm5XCmc1WW54d3IwUTdtbTUvTndkeGwwQ1BKWXQwZ2RvZHAzcldTTE5TYVVEVWJnNFQ3QzVGOVA3VWw1Q29maGZZSWEKT01id0NQN3ovMThSNWFxS1oxQUM4OUR2ZVFJVFltblJ2RlY5TDBEYStyc2lnd0VVb2NSQ0pXajFTcHpXT2Z1ZQpwSDdtWHdQQllVSEVZNmIxZnBjYklZSGt3T3p3dkxacHNuSVpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwelpXUTBNVGc1TkMwd09UZ3lMVFJtTXpjdE9EbGoKWVMwMFl6QXdNVEF3TjJKa1kyRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNMlZrTkRFNE9UUXRNRGs0TWkwMFpqTTNMVGc1WTJFdE5HTXdNREV3TURkaVpHTmhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVBlaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFqMGpvS01IbGE4MUZJKzJvaWRDOXFuZ2RldDZ5U1RxWUswamVraUtIVzVRdi9xOXVsQWh6dQpqelNyL1Niam5FcE1YUDVHZ3Axczg2OFcvTzQzMStSbFdhU096V3E3NEtWdXZGKzEzYVNkVDJPd3YyRUFHL3FMCmthelkrV3Z0ejRwUUdibFlJd1Jrb2x0MXVNZ2loRTExUHllUHFXWURUK2hrM21Ra1BlK2pyZkxOa09aRkRJRGoKSDJPd1F2QUVlc3ZIemplTEFKTVRsN3ZZZHpxRlU4dXg5Z0VtVW02cHR4R2pWSUxYV0ZvL2lhQWF0UU5QM1RoNQpzWmxFZHNraDYzN0RmMGNqT3Vib25PVzFZN0lFVmYvT1pVZzFZSlVkTU15TmxBZGZOYkZLMVJ6NVgveDdDN3poCkJjcEtSTTRwRWo2NUpsVUV3dHE5VDNsVDdtaEE0L3N1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVTHNabHdlUjgyOWtXb3VBOUNuVzluL0lMbFZVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU1qVXdIaGNOCk1qUXdNakl6TVRNMU9UTTVXaGNOTXpRd01qSXdNVE0xT1RNNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl5TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtdXdvcXpMZGlTRkRnL2wrZ3pXalZ6aEJjRmhCSlh0aENPWVZIbHNCRDc2cEJkSUwvU2hRaSsKOXlCL1puQTlNZHljSkZGUmY0Vm9ETE9JaG5XTTlVMzB3dmZWUjkxeUszaWZISGM0Z1VxZXVpNGZnSkZ1SDRyQwp4Um9VdGozakZka0FZZlRWQ0drNXZ0b0UzcllUT205c0FzaVl3ZGVrMlFRSGRaVUx5cmQ4U2FjRUtxWDlhclhmCmt6V2YvdGF0YVQzSXhNMEd1dG1NZm9kZ1Vram43SzEvR0lLcU9Ici92Qk5rTDlDOHArN05YRmlEeWJZUzZMaVkKMDFnUnVrdld2c055SUJsMXdRK2Y2VjlQKzZkQVo4YWpJSjZiMXRUdk0yb25lam9VZDZzdFl1SHZjcHJabmhGeApJQ09EYnpkRGE4eWpPQkFtYXhlaFJWeFJDVWxJMGtNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNakkxZ2p4eWR5MHhOV1ZpWVRobVl5MWlOVE14TFRRMFptWXRPREUzTmkxbU1ERXgKTmpJMU1HRTNOMkl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNaldDUEhKMwpMVEUxWldKaE9HWmpMV0kxTXpFdE5EUm1aaTA0TVRjMkxXWXdNVEUyTWpVd1lUYzNZaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk5TDRjRU01OUs0WWNFTTU5SzRUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKRzBzbTJZTEx0MXJOY0poYzVxTnJRdmhyK3UzVm8rT1kwZU1nOU5RaGVJaWlFNHBld3RrUWdrZzk5bUJQSm92VAo4SXpnU21VVFpRekpyN1ZQWlJiUDBZNVlDZTdkSEZoN2NXcVBZRm5OWmdMZVVabkpjYWdKU0dUQ2k2N09HWS9oCmZ6cEFjTEFpUERMbjVJSnBtSFZJZ21COEtCbzRGK2FrMEtKLzRxekZJZkRndTVsS1E5aWhuQi9xbHRZTlVQNHgKaTlEaFpSbXNmV0NRZmZUQVpsaXRSUFNxK2h2a1ErWWhERGF4bFIwSzdYam5sSGdJV3IzUVlERWZMeUdGWTVkWQpKNEMxV2Z2SElhek5uUEJkWVAyRVhpZjRKTTJxeGFkSndhdnMza1FqUStjQy9waUhxZU5ZK08ya3VqcFNOWFdHCkRsb2NjWUlmRzRPQTdSbnhJbWFxSEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2017"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:01 GMT
+      - Fri, 23 Feb 2024 14:02:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1356,7 +1257,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6276ac4b-48ec-4a2d-bb48-edb7e3738a7c
+      - 42588122-d974-4f26-aa15-69832bf57163
     status: 200 OK
     code: 200
     duration: ""
@@ -1367,43 +1268,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "548"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:31:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e41d71f2-c998-476d-bb7f-afe0b8b5162c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -1412,9 +1280,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:01 GMT
+      - Fri, 23 Feb 2024 14:02:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1422,7 +1290,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d17d4618-cee9-46ac-8560-7fec244c6794
+      - 45389821-c137-4a88-8735-46bfc0920b19
     status: 200 OK
     code: 200
     duration: ""
@@ -1433,10 +1301,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=15eba8fc-b531-44ff-8176-f0116250a77b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-23T14:00:07.817592Z","id":"5402017b-71f8-4ea9-b889-b83382ab4528","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"15eba8fc-b531-44ff-8176-f0116250a77b","mac_address":"02:00:00:18:94:D3","name":"read-replica-50e92804","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:00:56.149574Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -1445,9 +1313,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:01 GMT
+      - Fri, 23 Feb 2024 14:02:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1455,7 +1323,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 573e21df-0363-4dac-9f73-492d33c81104
+      - 6bdebfa5-2f32-4874-b2ab-2bd9afd893d9
     status: 200 OK
     code: 200
     duration: ""
@@ -1466,10 +1334,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -1478,9 +1346,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:02:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1488,7 +1356,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5413b45c-cb28-4c53-9fbb-94a454f254cc
+      - 75a6b5cd-8c69-4648-b1b2-e32e3c94b62e
     status: 200 OK
     code: 200
     duration: ""
@@ -1499,21 +1367,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1803"
+      - "1799"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:02:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1521,7 +1389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 447fab53-34be-4711-a11a-aa928cc3eef7
+      - 5bce334a-c8af-451b-9e38-4532201af578
     status: 200 OK
     code: 200
     duration: ""
@@ -1532,21 +1400,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVTWdjQ0t4L0NtQ0R4cDFTRHRWWENwRjM4V0t3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpFeE9ESTNNalJhRncwek5EQXlNVGd4T0RJM01qUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRFBxdVljQ3VEQUhBSmoxT2NwSlZaam9JYU1GRjg1WlVVNFFFVHdWazZ0ZGF1bk9VZW8KdDN1cVdRTTlOM1R3SHlGWGZjQ3FscGQ4ZmhReExSZzA2MnBXQWhlUjlCSithRzluemxEZU5Ub2hObFNGZ2VMVQo3MVpkbE92aG1GUW5qN0lDZEplbnp6OEdGcmVKZG50V1FrSTdPWGY2WVFYeTcya09VUE55d3hlL0NLVDlLMm5XCmc1WW54d3IwUTdtbTUvTndkeGwwQ1BKWXQwZ2RvZHAzcldTTE5TYVVEVWJnNFQ3QzVGOVA3VWw1Q29maGZZSWEKT01id0NQN3ovMThSNWFxS1oxQUM4OUR2ZVFJVFltblJ2RlY5TDBEYStyc2lnd0VVb2NSQ0pXajFTcHpXT2Z1ZQpwSDdtWHdQQllVSEVZNmIxZnBjYklZSGt3T3p3dkxacHNuSVpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwelpXUTBNVGc1TkMwd09UZ3lMVFJtTXpjdE9EbGoKWVMwMFl6QXdNVEF3TjJKa1kyRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNMlZrTkRFNE9UUXRNRGs0TWkwMFpqTTNMVGc1WTJFdE5HTXdNREV3TURkaVpHTmhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVBlaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFqMGpvS01IbGE4MUZJKzJvaWRDOXFuZ2RldDZ5U1RxWUswamVraUtIVzVRdi9xOXVsQWh6dQpqelNyL1Niam5FcE1YUDVHZ3Axczg2OFcvTzQzMStSbFdhU096V3E3NEtWdXZGKzEzYVNkVDJPd3YyRUFHL3FMCmthelkrV3Z0ejRwUUdibFlJd1Jrb2x0MXVNZ2loRTExUHllUHFXWURUK2hrM21Ra1BlK2pyZkxOa09aRkRJRGoKSDJPd1F2QUVlc3ZIemplTEFKTVRsN3ZZZHpxRlU4dXg5Z0VtVW02cHR4R2pWSUxYV0ZvL2lhQWF0UU5QM1RoNQpzWmxFZHNraDYzN0RmMGNqT3Vib25PVzFZN0lFVmYvT1pVZzFZSlVkTU15TmxBZGZOYkZLMVJ6NVgveDdDN3poCkJjcEtSTTRwRWo2NUpsVUV3dHE5VDNsVDdtaEE0L3N1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVTHNabHdlUjgyOWtXb3VBOUNuVzluL0lMbFZVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU1qVXdIaGNOCk1qUXdNakl6TVRNMU9UTTVXaGNOTXpRd01qSXdNVE0xT1RNNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl5TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtdXdvcXpMZGlTRkRnL2wrZ3pXalZ6aEJjRmhCSlh0aENPWVZIbHNCRDc2cEJkSUwvU2hRaSsKOXlCL1puQTlNZHljSkZGUmY0Vm9ETE9JaG5XTTlVMzB3dmZWUjkxeUszaWZISGM0Z1VxZXVpNGZnSkZ1SDRyQwp4Um9VdGozakZka0FZZlRWQ0drNXZ0b0UzcllUT205c0FzaVl3ZGVrMlFRSGRaVUx5cmQ4U2FjRUtxWDlhclhmCmt6V2YvdGF0YVQzSXhNMEd1dG1NZm9kZ1Vram43SzEvR0lLcU9Ici92Qk5rTDlDOHArN05YRmlEeWJZUzZMaVkKMDFnUnVrdld2c055SUJsMXdRK2Y2VjlQKzZkQVo4YWpJSjZiMXRUdk0yb25lam9VZDZzdFl1SHZjcHJabmhGeApJQ09EYnpkRGE4eWpPQkFtYXhlaFJWeFJDVWxJMGtNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNakkxZ2p4eWR5MHhOV1ZpWVRobVl5MWlOVE14TFRRMFptWXRPREUzTmkxbU1ERXgKTmpJMU1HRTNOMkl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNaldDUEhKMwpMVEUxWldKaE9HWmpMV0kxTXpFdE5EUm1aaTA0TVRjMkxXWXdNVEUyTWpVd1lUYzNZaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk5TDRjRU01OUs0WWNFTTU5SzRUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKRzBzbTJZTEx0MXJOY0poYzVxTnJRdmhyK3UzVm8rT1kwZU1nOU5RaGVJaWlFNHBld3RrUWdrZzk5bUJQSm92VAo4SXpnU21VVFpRekpyN1ZQWlJiUDBZNVlDZTdkSEZoN2NXcVBZRm5OWmdMZVVabkpjYWdKU0dUQ2k2N09HWS9oCmZ6cEFjTEFpUERMbjVJSnBtSFZJZ21COEtCbzRGK2FrMEtKLzRxekZJZkRndTVsS1E5aWhuQi9xbHRZTlVQNHgKaTlEaFpSbXNmV0NRZmZUQVpsaXRSUFNxK2h2a1ErWWhERGF4bFIwSzdYam5sSGdJV3IzUVlERWZMeUdGWTVkWQpKNEMxV2Z2SElhek5uUEJkWVAyRVhpZjRKTTJxeGFkSndhdnMza1FqUStjQy9waUhxZU5ZK08ya3VqcFNOWFdHCkRsb2NjWUlmRzRPQTdSbnhJbWFxSEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2017"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:02:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1554,7 +1422,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14dc64d0-64ce-4862-b6da-f3a3574864ca
+      - 981625d6-eaa9-4ce9-95d4-fb2b8ea46c34
     status: 200 OK
     code: 200
     duration: ""
@@ -1565,43 +1433,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "548"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4cefdf0-61f1-416c-a341-8fe637bd343c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -1610,9 +1445,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:02:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1620,7 +1455,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3caa2f0a-a656-4f67-bf93-a06ec722940d
+      - f9ead7df-1497-422b-bb6a-2687b799f350
     status: 200 OK
     code: 200
     duration: ""
@@ -1631,10 +1466,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=15eba8fc-b531-44ff-8176-f0116250a77b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.2/22","created_at":"2024-02-21T18:27:57.987939Z","id":"802071ae-b0f9-4f71-8cb8-4a5cb9be0591","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:18:8A:0C","name":"read-replica-4c8d0fd3","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:28:37.216169Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.2/22","created_at":"2024-02-23T14:00:07.817592Z","id":"5402017b-71f8-4ea9-b889-b83382ab4528","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"15eba8fc-b531-44ff-8176-f0116250a77b","mac_address":"02:00:00:18:94:D3","name":"read-replica-50e92804","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:00:56.149574Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -1643,9 +1478,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:02:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1653,7 +1488,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d06bd716-b4d3-4a31-be99-f9f79e48a44d
+      - b85f1159-3a64-401e-be04-d9a574474cf3
     status: 200 OK
     code: 200
     duration: ""
@@ -1664,10 +1499,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -1676,9 +1511,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:02 GMT
+      - Fri, 23 Feb 2024 14:02:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1686,7 +1521,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4448b6e-ebc1-4ace-952f-26cf312c590a
+      - 0c64686a-48b3-4937-b2c8-4a9a101f6059
     status: 200 OK
     code: 200
     duration: ""
@@ -1697,10 +1532,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "395"
@@ -1709,9 +1544,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:03 GMT
+      - Fri, 23 Feb 2024 14:02:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1719,7 +1554,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c56e3c83-89bd-4d84-9f82-bcf3197075a3
+      - 2c2669db-96fe-4234-b92d-210ec711065e
     status: 200 OK
     code: 200
     duration: ""
@@ -1730,10 +1565,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"endpoints":[{"id":"0d431bbc-dfc2-4237-8c6f-935f387b27e9","ip":"172.16.84.2","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.2/22","zone":"fr-par-1"}}],"id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"7dea928e-c22e-4517-b92b-46c825479676","ip":"172.16.24.2","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.2/22","zone":"fr-par-1"}}],"id":"50e92804-e73e-4169-bb87-abc6b88718f0","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "395"
@@ -1742,9 +1577,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:03 GMT
+      - Fri, 23 Feb 2024 14:02:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1752,7 +1587,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 484d8bf1-3af9-4a9b-96ec-d7eb27ede750
+      - 4cde8e9c-d632-44f4-a2a2-044eb1b6cb3b
     status: 200 OK
     code: 200
     duration: ""
@@ -1763,10 +1598,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/4c8d0fd3-cdc3-4436-89ad-0cfb5d375194
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/50e92804-e73e-4169-bb87-abc6b88718f0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"4c8d0fd3-cdc3-4436-89ad-0cfb5d375194","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"50e92804-e73e-4169-bb87-abc6b88718f0","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1775,9 +1610,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:33 GMT
+      - Fri, 23 Feb 2024 14:03:25 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1785,12 +1620,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d190d5c-f41e-4639-86c9-e71bc0d54b78
+      - 4d2f643c-b877-4ae9-a184-3de64230fb4c
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","endpoint_spec":[{"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","ipam_config":{}}}],"same_zone":false}'
+    body: '{"instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","endpoint_spec":[{"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","ipam_config":{}}}],"same_zone":false}'
     form: {}
     headers:
       Content-Type:
@@ -1801,7 +1636,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
       - "400"
@@ -1810,9 +1645,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:34 GMT
+      - Fri, 23 Feb 2024 14:03:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1820,7 +1655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf007f82-9d81-4b1a-aa7d-f0c7caa89571
+      - 9f22931a-765b-4a1d-8008-a2e9ee7c9d55
     status: 200 OK
     code: 200
     duration: ""
@@ -1831,10 +1666,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
       - "400"
@@ -1843,9 +1678,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:34 GMT
+      - Fri, 23 Feb 2024 14:03:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1853,7 +1688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41fd624b-a51f-4398-b0d6-88e958c74e42
+      - c3c38a40-36f0-4325-9f51-700ac356aea3
     status: 200 OK
     code: 200
     duration: ""
@@ -1864,10 +1699,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
       - "400"
@@ -1876,9 +1711,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:04 GMT
+      - Fri, 23 Feb 2024 14:03:57 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1886,7 +1721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93a41369-306c-4da2-90fd-9b3c4b88a644
+      - 9a7b97af-2e37-48a5-8bee-99326a07d5cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1897,10 +1732,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"provisioning"}'
     headers:
       Content-Length:
       - "400"
@@ -1909,9 +1744,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:34 GMT
+      - Fri, 23 Feb 2024 14:04:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1919,7 +1754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecdd11e6-c71c-45bd-b600-972dc1dfccef
+      - f90f3795-464d-4754-919a-60fcd007934a
     status: 200 OK
     code: 200
     duration: ""
@@ -1930,10 +1765,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"initializing"}'
     headers:
       Content-Length:
       - "400"
@@ -1942,9 +1777,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:05 GMT
+      - Fri, 23 Feb 2024 14:04:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1952,7 +1787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b53f7fb4-fa74-4258-a56a-8dafcfee831a
+      - 95b75e2d-9edf-429f-89d3-66a99973b635
     status: 200 OK
     code: 200
     duration: ""
@@ -1963,43 +1798,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"initializing"}'
-    headers:
-      Content-Length:
-      - "400"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:33:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 676d2aba-96f5-4a3b-b83f-38f4f85b3dcb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
       - "393"
@@ -2008,9 +1810,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:05 GMT
+      - Fri, 23 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2018,7 +1820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b229d255-51c4-4c6f-a012-49056efce740
+      - 847abe19-b821-41d5-ac99-0539380ab1fc
     status: 200 OK
     code: 200
     duration: ""
@@ -2029,10 +1831,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
       - "393"
@@ -2041,9 +1843,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:05 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2051,7 +1853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ff211ff-de87-4f24-a735-2cb367949fc5
+      - 2315c7b3-e7e2-474e-9695-43141f7fc00b
     status: 200 OK
     code: 200
     duration: ""
@@ -2062,10 +1864,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=15eba8fc-b531-44ff-8176-f0116250a77b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.3/22","created_at":"2024-02-21T18:31:34.109361Z","id":"f6785843-7419-422a-8993-8529810b7796","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:24:85:E4","name":"read-replica-d3a45c31","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:32:05.197186Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.3/22","created_at":"2024-02-23T14:03:27.457564Z","id":"afeded0a-3db4-4f1d-a318-aedd9aa38c02","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"15eba8fc-b531-44ff-8176-f0116250a77b","mac_address":"02:00:00:24:8C:BD","name":"read-replica-cd23e046","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:03:59.402955Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -2074,9 +1876,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:05 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2084,7 +1886,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe82e911-9324-42c4-b3d5-21965090aa6b
+      - 7aa1fb0a-37a2-4d5d-baf4-c21d2e965a0a
     status: 200 OK
     code: 200
     duration: ""
@@ -2095,10 +1897,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
       - "393"
@@ -2107,9 +1909,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:05 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2117,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9186c48e-53ce-45ac-850a-5690eb70af78
+      - 3abbd1eb-f912-4bf1-98b4-e3d4d7f23d4e
     status: 200 OK
     code: 200
     duration: ""
@@ -2128,10 +1930,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -2140,9 +1942,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:05 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2150,7 +1952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9b20557-ebce-4a9b-90a8-4fb384576726
+      - a58489c2-2d26-43fe-9e5e-6661010947ff
     status: 200 OK
     code: 200
     duration: ""
@@ -2161,10 +1963,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.734271Z","dhcp_enabled":true,"id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","name":"test-rdb-rr-different-zone","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.734271Z","id":"2580e7ab-fb53-40dc-b5a4-e3813323158f","subnet":"172.16.84.0/22","updated_at":"2024-02-21T18:24:51.734271Z"},{"created_at":"2024-02-21T18:24:51.734271Z","id":"b8cfb70a-5107-42ff-acc1-49e6e2752531","subnet":"fd5f:519c:6d46:1a29::/64","updated_at":"2024-02-21T18:24:51.734271Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.734271Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:34.919270Z","dhcp_enabled":true,"id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","name":"test-rdb-rr-different-zone","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:34.919270Z","id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c","subnet":"172.16.24.0/22","updated_at":"2024-02-23T13:56:34.919270Z"},{"created_at":"2024-02-23T13:56:34.919270Z","id":"64b53137-021d-4ddf-9b0b-867d1e8162f1","subnet":"fd63:256c:45f7:46a3::/64","updated_at":"2024-02-23T13:56:34.919270Z"}],"tags":[],"updated_at":"2024-02-23T13:56:34.919270Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
       - "727"
@@ -2173,9 +1975,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:05 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2183,7 +1985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ea4c099-2a1e-4a4f-bf95-91049d837566
+      - 51861fa9-9a9a-4202-89cf-1f51aa14b24a
     status: 200 OK
     code: 200
     duration: ""
@@ -2194,21 +1996,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1804"
+      - "1800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:06 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2216,7 +2018,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11927d6a-b9cc-41a1-824a-424fe4c0ccbf
+      - 7372e8ff-8ddb-4a4e-b29f-53d0d9786d0c
     status: 200 OK
     code: 200
     duration: ""
@@ -2227,21 +2029,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVTWdjQ0t4L0NtQ0R4cDFTRHRWWENwRjM4V0t3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpFeE9ESTNNalJhRncwek5EQXlNVGd4T0RJM01qUmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRRFBxdVljQ3VEQUhBSmoxT2NwSlZaam9JYU1GRjg1WlVVNFFFVHdWazZ0ZGF1bk9VZW8KdDN1cVdRTTlOM1R3SHlGWGZjQ3FscGQ4ZmhReExSZzA2MnBXQWhlUjlCSithRzluemxEZU5Ub2hObFNGZ2VMVQo3MVpkbE92aG1GUW5qN0lDZEplbnp6OEdGcmVKZG50V1FrSTdPWGY2WVFYeTcya09VUE55d3hlL0NLVDlLMm5XCmc1WW54d3IwUTdtbTUvTndkeGwwQ1BKWXQwZ2RvZHAzcldTTE5TYVVEVWJnNFQ3QzVGOVA3VWw1Q29maGZZSWEKT01id0NQN3ovMThSNWFxS1oxQUM4OUR2ZVFJVFltblJ2RlY5TDBEYStyc2lnd0VVb2NSQ0pXajFTcHpXT2Z1ZQpwSDdtWHdQQllVSEVZNmIxZnBjYklZSGt3T3p3dkxacHNuSVpBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkwelpXUTBNVGc1TkMwd09UZ3lMVFJtTXpjdE9EbGoKWVMwMFl6QXdNVEF3TjJKa1kyRXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RNMlZrTkRFNE9UUXRNRGs0TWkwMFpqTTNMVGc1WTJFdE5HTXdNREV3TURkaVpHTmhMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3U2pySVBlaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFqMGpvS01IbGE4MUZJKzJvaWRDOXFuZ2RldDZ5U1RxWUswamVraUtIVzVRdi9xOXVsQWh6dQpqelNyL1Niam5FcE1YUDVHZ3Axczg2OFcvTzQzMStSbFdhU096V3E3NEtWdXZGKzEzYVNkVDJPd3YyRUFHL3FMCmthelkrV3Z0ejRwUUdibFlJd1Jrb2x0MXVNZ2loRTExUHllUHFXWURUK2hrM21Ra1BlK2pyZkxOa09aRkRJRGoKSDJPd1F2QUVlc3ZIemplTEFKTVRsN3ZZZHpxRlU4dXg5Z0VtVW02cHR4R2pWSUxYV0ZvL2lhQWF0UU5QM1RoNQpzWmxFZHNraDYzN0RmMGNqT3Vib25PVzFZN0lFVmYvT1pVZzFZSlVkTU15TmxBZGZOYkZLMVJ6NVgveDdDN3poCkJjcEtSTTRwRWo2NUpsVUV3dHE5VDNsVDdtaEE0L3N1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVTHNabHdlUjgyOWtXb3VBOUNuVzluL0lMbFZVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU1qVXdIaGNOCk1qUXdNakl6TVRNMU9UTTVXaGNOTXpRd01qSXdNVE0xT1RNNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl5TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUxtdXdvcXpMZGlTRkRnL2wrZ3pXalZ6aEJjRmhCSlh0aENPWVZIbHNCRDc2cEJkSUwvU2hRaSsKOXlCL1puQTlNZHljSkZGUmY0Vm9ETE9JaG5XTTlVMzB3dmZWUjkxeUszaWZISGM0Z1VxZXVpNGZnSkZ1SDRyQwp4Um9VdGozakZka0FZZlRWQ0drNXZ0b0UzcllUT205c0FzaVl3ZGVrMlFRSGRaVUx5cmQ4U2FjRUtxWDlhclhmCmt6V2YvdGF0YVQzSXhNMEd1dG1NZm9kZ1Vram43SzEvR0lLcU9Ici92Qk5rTDlDOHArN05YRmlEeWJZUzZMaVkKMDFnUnVrdld2c055SUJsMXdRK2Y2VjlQKzZkQVo4YWpJSjZiMXRUdk0yb25lam9VZDZzdFl1SHZjcHJabmhGeApJQ09EYnpkRGE4eWpPQkFtYXhlaFJWeFJDVWxJMGtNQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNakkxZ2p4eWR5MHhOV1ZpWVRobVl5MWlOVE14TFRRMFptWXRPREUzTmkxbU1ERXgKTmpJMU1HRTNOMkl1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNaldDUEhKMwpMVEUxWldKaE9HWmpMV0kxTXpFdE5EUm1aaTA0TVRjMkxXWXdNVEUyTWpVd1lUYzNZaTV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk5TDRjRU01OUs0WWNFTTU5SzRUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKRzBzbTJZTEx0MXJOY0poYzVxTnJRdmhyK3UzVm8rT1kwZU1nOU5RaGVJaWlFNHBld3RrUWdrZzk5bUJQSm92VAo4SXpnU21VVFpRekpyN1ZQWlJiUDBZNVlDZTdkSEZoN2NXcVBZRm5OWmdMZVVabkpjYWdKU0dUQ2k2N09HWS9oCmZ6cEFjTEFpUERMbjVJSnBtSFZJZ21COEtCbzRGK2FrMEtKLzRxekZJZkRndTVsS1E5aWhuQi9xbHRZTlVQNHgKaTlEaFpSbXNmV0NRZmZUQVpsaXRSUFNxK2h2a1ErWWhERGF4bFIwSzdYam5sSGdJV3IzUVlERWZMeUdGWTVkWQpKNEMxV2Z2SElhek5uUEJkWVAyRVhpZjRKTTJxeGFkSndhdnMza1FqUStjQy9waUhxZU5ZK08ya3VqcFNOWFdHCkRsb2NjWUlmRzRPQTdSbnhJbWFxSEE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2017"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:06 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2249,7 +2051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9749a28-4c3c-4e09-946d-853dc1c27da4
+      - 4ab73582-a148-4548-aab0-29920d7876f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2260,43 +2062,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.3/22","created_at":"2024-02-21T18:31:34.109361Z","id":"f6785843-7419-422a-8993-8529810b7796","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:24:85:E4","name":"read-replica-d3a45c31","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:32:05.197186Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "548"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:34:06 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 656ecd17-56f2-4c4e-a3bf-180e732df49b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
       - "393"
@@ -2305,9 +2074,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:06 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2315,7 +2084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fe8e1a4-ae24-4809-b873-32e92c0bee23
+      - 30146df4-6de0-406a-8159-adc65ad1f9d9
     status: 200 OK
     code: 200
     duration: ""
@@ -2326,10 +2095,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3ed41894-0982-4f37-89ca-4c001007bdca&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=15eba8fc-b531-44ff-8176-f0116250a77b&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.84.3/22","created_at":"2024-02-21T18:31:34.109361Z","id":"f6785843-7419-422a-8993-8529810b7796","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"3ed41894-0982-4f37-89ca-4c001007bdca","mac_address":"02:00:00:24:85:E4","name":"read-replica-d3a45c31","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"2580e7ab-fb53-40dc-b5a4-e3813323158f"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:32:05.197186Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.24.3/22","created_at":"2024-02-23T14:03:27.457564Z","id":"afeded0a-3db4-4f1d-a318-aedd9aa38c02","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"15eba8fc-b531-44ff-8176-f0116250a77b","mac_address":"02:00:00:24:8C:BD","name":"read-replica-cd23e046","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"e9a25eae-6e26-4b7b-b079-da58f3dfe61c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:03:59.402955Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -2338,9 +2107,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:06 GMT
+      - Fri, 23 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2348,7 +2117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38df48d9-bccf-4678-b3f8-930f34b9e129
+      - 69cd9fce-28dc-49b3-b255-dea02297797d
     status: 200 OK
     code: 200
     duration: ""
@@ -2359,10 +2128,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"ready"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"ready"}'
     headers:
       Content-Length:
       - "393"
@@ -2371,9 +2140,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:06 GMT
+      - Fri, 23 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2381,7 +2150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acb94241-31d9-4132-a73b-af981014147f
+      - f2640aa0-299f-4f6c-aedd-7259d01dbb9c
     status: 200 OK
     code: 200
     duration: ""
@@ -2392,10 +2161,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
       - "396"
@@ -2404,9 +2173,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:07 GMT
+      - Fri, 23 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2414,7 +2183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d2773bf-32d9-4ee6-928d-44ead6d04949
+      - be8b2db0-11dd-4efe-a321-77757027ca04
     status: 200 OK
     code: 200
     duration: ""
@@ -2425,10 +2194,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"75b0b2cc-cbe2-47a9-973d-73f384378aea","ip":"172.16.84.3","name":null,"port":5432,"private_network":{"private_network_id":"f2848f3a-ce13-4f64-a098-417cbc8093e9","service_ip":"172.16.84.3/22","zone":"fr-par-1"}}],"id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","instance_id":"3ed41894-0982-4f37-89ca-4c001007bdca","region":"fr-par","same_zone":false,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"b50dc433-83f9-493f-843b-090dce6f2add","ip":"172.16.24.3","name":null,"port":5432,"private_network":{"private_network_id":"8d9395ce-6de0-4cbc-83cf-1b527615fbeb","service_ip":"172.16.24.3/22","zone":"fr-par-1"}}],"id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","instance_id":"15eba8fc-b531-44ff-8176-f0116250a77b","region":"fr-par","same_zone":false,"status":"deleting"}'
     headers:
       Content-Length:
       - "396"
@@ -2437,9 +2206,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:07 GMT
+      - Fri, 23 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2447,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be8d48ed-69f0-4799-a772-ab5f24064aab
+      - 9fdd2d41-f357-4f13-805d-a0f14a4fe744
     status: 200 OK
     code: 200
     duration: ""
@@ -2458,10 +2227,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -2470,9 +2239,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:37 GMT
+      - Fri, 23 Feb 2024 14:06:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2480,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57aa9eb5-79ce-480a-8297-98edd5840fdd
+      - fd324ff3-a79a-4200-8612-9889d980673a
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2491,21 +2260,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1411"
+      - "1407"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:37 GMT
+      - Fri, 23 Feb 2024 14:06:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2513,7 +2282,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e079d128-421f-4fec-a334-6ded5e55162e
+      - 38ff82b1-58a9-4bc0-8c1c-7a11cf1b6d09
     status: 200 OK
     code: 200
     duration: ""
@@ -2524,21 +2293,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1414"
+      - "1410"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:38 GMT
+      - Fri, 23 Feb 2024 14:06:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2546,7 +2315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f300999-f8b3-4d20-a7a4-02069c1265bc
+      - 1310740a-eb42-4d72-a091-7de711760aa8
     status: 200 OK
     code: 200
     duration: ""
@@ -2557,21 +2326,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.905137Z","endpoint":{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881},"endpoints":[{"id":"52e1cb05-64dd-4485-bfa6-11cc6a517fb8","ip":"195.154.197.252","load_balancer":{},"name":null,"port":26881}],"engine":"PostgreSQL-14","id":"3ed41894-0982-4f37-89ca-4c001007bdca","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.162687Z","endpoint":{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275},"endpoints":[{"id":"9ab34e11-7864-4aaf-b785-21792d0b6902","ip":"51.159.74.225","load_balancer":{},"name":null,"port":20275}],"engine":"PostgreSQL-14","id":"15eba8fc-b531-44ff-8176-f0116250a77b","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-different-zone","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","different-zone"],"upgradable_version":[{"id":"f70a484b-31e2-4bd4-aefb-8eb15eb667d8","minor_version":"15.6","name":"PostgreSQL-15","version":"15"}],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1414"
+      - "1410"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:38 GMT
+      - Fri, 23 Feb 2024 14:06:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2579,7 +2348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e587b2c-fbee-4fcd-8b88-2e6c520845d3
+      - b0724ecb-55e9-4d5e-9ce4-f9c2590418aa
     status: 200 OK
     code: 200
     duration: ""
@@ -2590,7 +2359,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/f2848f3a-ce13-4f64-a098-417cbc8093e9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/8d9395ce-6de0-4cbc-83cf-1b527615fbeb
     method: DELETE
   response:
     body: ""
@@ -2600,9 +2369,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:38 GMT
+      - Fri, 23 Feb 2024 14:06:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2610,7 +2379,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1256a909-3bcb-4b3d-a7b5-f3fc33136e5b
+      - bfceb4a7-e5d8-4590-b7d9-170db55005ce
     status: 204 No Content
     code: 204
     duration: ""
@@ -2621,10 +2390,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"3ed41894-0982-4f37-89ca-4c001007bdca","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"15eba8fc-b531-44ff-8176-f0116250a77b","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2633,9 +2402,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:13 GMT
+      - Fri, 23 Feb 2024 14:06:31 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2643,7 +2412,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29fc977e-89d7-47c9-965d-4e4c926e3174
+      - da84f148-41b0-4eee-91e1-cc8c92001e1c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2654,10 +2423,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/3ed41894-0982-4f37-89ca-4c001007bdca
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/15eba8fc-b531-44ff-8176-f0116250a77b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"3ed41894-0982-4f37-89ca-4c001007bdca","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"15eba8fc-b531-44ff-8176-f0116250a77b","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2666,9 +2435,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:15 GMT
+      - Fri, 23 Feb 2024 14:06:31 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2676,7 +2445,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 215498e8-e6c4-496b-bb56-0d11ff0c1d68
+      - d4d842cb-b244-4a7f-abce-6ee935464d53
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2687,10 +2456,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d3a45c31-5ddf-469e-9e66-2f70816559d8
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/cd23e046-1e85-4638-8fc8-ba94a7a7b3ea
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"d3a45c31-5ddf-469e-9e66-2f70816559d8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"cd23e046-1e85-4638-8fc8-ba94a7a7b3ea","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -2699,9 +2468,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:20 GMT
+      - Fri, 23 Feb 2024 14:06:31 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2709,7 +2478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c8d37d6-b932-4cb3-ba0d-d0254174f503
+      - f01c451e-0866-4b67-b4af-b1c00a8b21eb
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-multiple-endpoints.cassette.yaml
@@ -318,9 +318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:50 GMT
+      - Fri, 23 Feb 2024 13:56:33 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53f43ea0-2322-4309-9e9f-ddd43bf0044c
+      - 88093b98-17a7-415a-b8ae-a3eaa9adc017
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-multiple-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-multiple-endpoints","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "814"
@@ -353,9 +353,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,12 +363,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3753776a-efe1-4101-ba16-e6494de1f226
+      - d3064ee1-d88e-4656-ac60-18f4e0d4aad3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-gifted-carson","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    body: '{"name":"tf-pn-stupefied-wright","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -379,18 +379,18 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.620409Z","dhcp_enabled":true,"id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","name":"tf-pn-gifted-carson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.620409Z","id":"1208cfab-0b56-4e3a-91d6-7e1390c9d7db","subnet":"172.16.44.0/22","updated_at":"2024-02-21T18:24:51.620409Z"},{"created_at":"2024-02-21T18:24:51.620409Z","id":"683d2bad-8ef7-4ec4-aec1-7010f7a5da3e","subnet":"fd5f:519c:6d46:27af::/64","updated_at":"2024-02-21T18:24:51.620409Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.620409Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:35.109297Z","dhcp_enabled":true,"id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","name":"tf-pn-stupefied-wright","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.109297Z","id":"f8d82682-3b75-4c60-8f6b-07de6e2e2ca0","subnet":"172.16.16.0/22","updated_at":"2024-02-23T13:56:35.109297Z"},{"created_at":"2024-02-23T13:56:35.109297Z","id":"07f1ad4f-7e5c-4df9-8f5a-5483a8459af8","subnet":"fd63:256c:45f7:e5b1::/64","updated_at":"2024-02-23T13:56:35.109297Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.109297Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -398,7 +398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80d833ec-9563-45e0-b523-0033f5599e58
+      - a1df8811-74e1-4ad2-8429-da197da3f312
     status: 200 OK
     code: 200
     duration: ""
@@ -409,43 +409,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6dce9966-6b81-452d-b67f-7cf899a2d3e6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.620409Z","dhcp_enabled":true,"id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","name":"tf-pn-gifted-carson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.620409Z","id":"1208cfab-0b56-4e3a-91d6-7e1390c9d7db","subnet":"172.16.44.0/22","updated_at":"2024-02-21T18:24:51.620409Z"},{"created_at":"2024-02-21T18:24:51.620409Z","id":"683d2bad-8ef7-4ec4-aec1-7010f7a5da3e","subnet":"fd5f:519c:6d46:27af::/64","updated_at":"2024-02-21T18:24:51.620409Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.620409Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "720"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1bc73453-e40b-43b6-b7ba-8ba52d3ca9b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "814"
@@ -454,9 +421,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -464,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aff9dbdb-bcf1-410b-864a-36767a53f91f
+      - f62c0e7e-30e7-49b3-9388-5753e8e00742
     status: 200 OK
     code: 200
     duration: ""
@@ -475,10 +442,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecc633db-5843-4f7f-aa8f-a7e46026e0cd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2024-02-23T13:56:35.109297Z","dhcp_enabled":true,"id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","name":"tf-pn-stupefied-wright","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.109297Z","id":"f8d82682-3b75-4c60-8f6b-07de6e2e2ca0","subnet":"172.16.16.0/22","updated_at":"2024-02-23T13:56:35.109297Z"},{"created_at":"2024-02-23T13:56:35.109297Z","id":"07f1ad4f-7e5c-4df9-8f5a-5483a8459af8","subnet":"fd63:256c:45f7:e5b1::/64","updated_at":"2024-02-23T13:56:35.109297Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.109297Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "723"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:56:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 911f1e32-9ced-436d-ae54-d356bc7de5dc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "814"
@@ -487,9 +487,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:25 GMT
+      - Fri, 23 Feb 2024 13:57:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f74660aa-78c8-41df-ba56-7ded20bd7816
+      - 119b458a-5946-4561-8c6c-e7bbd451df47
     status: 200 OK
     code: 200
     duration: ""
@@ -508,10 +508,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "814"
@@ -520,9 +520,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:56 GMT
+      - Fri, 23 Feb 2024 13:57:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdb24d90-224b-42f5-bac6-ae32abf3abde
+      - cb4d222b-2eea-4d9e-a8cc-4e442451af05
     status: 200 OK
     code: 200
     duration: ""
@@ -541,10 +541,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "814"
@@ -553,9 +553,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:28 GMT
+      - Fri, 23 Feb 2024 13:58:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eeed0209-bdac-450b-9b3d-f9675054d214
+      - 5cb72e0f-7737-4ec5-9cb2-bf1195b0b6d4
     status: 200 OK
     code: 200
     duration: ""
@@ -574,10 +574,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "814"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:58:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 46dd93c7-24cc-483a-b203-fa7753bb4f65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "814"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 39132e1f-8dd9-4230-b200-033c2eacf691
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "814"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5e4422dd-ebdf-41ca-b6b9-5600df23e0ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1089"
@@ -586,9 +685,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:58 GMT
+      - Fri, 23 Feb 2024 14:00:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -596,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3fecec7-e806-4915-9a2a-5ed8d879abf5
+      - 628ec983-967e-4c77-bd57-bdaea23a7a92
     status: 200 OK
     code: 200
     duration: ""
@@ -607,21 +706,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838},"endpoints":[{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838}],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487},"endpoints":[{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487}],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1302"
+      - "1308"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:29 GMT
+      - Fri, 23 Feb 2024 14:00:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -629,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ddf726ce-bf37-42e6-b022-918e282bb0ba
+      - a34cfb29-7cdd-4a2d-88bf-9cba9ff287f9
     status: 200 OK
     code: 200
     duration: ""
@@ -640,21 +739,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQ5RENDQXR5Z0F3SUJBZ0lVSVBUUSt6T01JUldRWlJNdzMzSm8vRkN4TEU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEkwCk1ESXlNVEU0TWpjd09Gb1hEVE0wTURJeE9ERTRNamN3T0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFsMEVlaXF0aWQzV001K0dRSUJ3djQ2LzR0QlhKdXpZekhSYWpkZUhZV3A2KzZZOE9jQXYva2pzN1B6OG4KNGFSM0NQUEJENnVtRWJ3bU9qUWxxVTNJQnFYbGFXeFJkT3FHNGl3MFBXYWxYaUtXZzdxM0JiYW1qNmJYTjBYMAp0VXcwRTdRVVVONWsxeXdMOUhJNk1RVHFTOGNXMUtrV2x5NzN5aDA3RnBxTHpjTXpsc2tIcWZQOFQxR0xibGptCjJjNlRPUEg5UTdkVEwzTnc2SHFTbGhjaHBsNHVlajY3b21ZbVRWdkUyVnYwZGZqK0pLNlptZElycERhV2JnYlYKZktoZTg1azBQbm5uR1RkOTU3VWpvdi9hRFZFQjAvVjFNd2ttNEdMbThvQW5XeXU2SDBGU3hKMENVTkNDdFpTcwpBZXQvMjYrcmdSRXRvV3dnNmxxa2NYS0ZBd0lEQVFBQm80RzVNSUcyTUlHekJnTlZIUkVFZ2Fzd2dhaUNDelV4CkxqRTFPUzQ1TGpnNGdqeHlkeTB4TW1Fek5tVmxNUzB5TURGbUxUUmxOV0l0WW1ObE15MDROakExTTJJMU9ESXcKWmpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NDelV4TGpFMU9TNDVMamc0Z2p4eWR5MHhNbUV6Tm1WbApNUzB5TURGbUxUUmxOV0l0WW1ObE15MDROakExTTJJMU9ESXdaall1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2CmRXU0hCTlF2K0hlSEJET2ZDVmlIQkRPZkNWZ3dEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBQ2RWWFRHbHM0NkQKS1o1N2RCQTJ5RUZxc0wrdlUrU0hkSWg3dU5xN2dXdWora2NUR1A5NEQwcmdtR0loRTd2MlBZQVB4MHVIdUJqSApQOTVYNTdia3lQdEc1VTFPMU5rRXdPbXV0aVJyQi82aXViQUdsSEM0NjlJRHJaSE9QeDExUTR3SkZOcENLSFE2Ckw1cll0QjEwUWsrdEgxaEF5eVl1WkxCREtFcHRtSU5vTjgrWmVCWm5EbGdua3BodHFKajRCcmI2MVJKemdmZU8KRjVMaGhpRVBQMHhtYm1iMm1QandZUithU0x0d0grZnpGem1DZEFmWU9HSjhaNmpwMDFxdDlWTEN3b2dMMnRYZApzWXd6a291SUJ6bU5haFRQdDRtczliaXFMc2grYUtzbk5WZjA2V09zdDlsVHRzK1RYRXJFL3l3WkFBOXB0TllECmJCN3FWanZPaFF3PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZkYzSUJBbXVhWG5VWWxCRFVOeG9HL3lFVEhVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpNeE5EQXdNVGRhRncwek5EQXlNakF4TkRBd01UZGFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3B0a0U3V25TaHJOUDNyR3FySjlWZ1dPUVJTNFcyV0J0eGxXNWxWSytjS3FxQ2RibXMKenZ2ZEsxTmVNZ2VwcGFLN3J5UWkwS2pEUUhVWW9pbzAvTzloNk8rSGk5cWVkQ3c5YnVNQW1YOGxrQ0lzbE9hbQo4R3NvWlRZMzVVbGl2K1Rud2lYd1JzaVZIeXBRbXBxOEVKdWNNWlFraFo4a0JWVzFYcnRVTUwzRGZ3czZPK2Q2CmliNTBrYnpBWDBTSFV6NDNlb0YrQWJMUnMwYy9DT0VueUl0ZURMLzV2WjVYdFoyTFY4WFZEM1VhYnRpMEU1bXEKRnRaSFJPanlLQzRnRWFlQVhFU1VBdkpyOGJ5SllPeWhBVzY5NlQwWWJETnQrMmRGOUdueUVjdU85Smc3ZTB0TAo4dFZiNEplT1pPU1dJSHo3TkgyMVUxSXpRTmgvemEveVNWemxBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbE1tRTJaR1kyTlMwNU1XRmhMVFJoWWpNdFlUZ3oKWlMweE1qUmtPVEF5WVRrNFlqQXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaVEpoTm1SbU5qVXRPVEZoWVMwMFlXSXpMV0U0TTJVdE1USTBaRGt3TW1FNU9HSXdMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3ZlaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNGREh3YzluRWVYazY2d0t0TGtGbUluNERlNE5RaVJCbmxNUEtVTGl6VHk4ajNzdkU2WHZoQgpzSFlPc0x4TDF0dEJBc00wblFqaWUrcEpQYWc3RG5nQlhMWEZXc3p6MFZ1dXdEOCt3WlNuY3ZrNnVlRnlPVk1mCm10dDh0RE56a0Rwa1h1eUcwTXhEUlBnMENpZXR0b2xJWkhwMklTNWhBK1hwdVB5Z09teW8yd2Q1c2pDbHBUanIKYjBiY2xpVWM3K2cwMVBKYVRrdTVhVU5JbVhNUndSU3lxZngzeE43bitSRjVFQWdCR25ITTR2MUcrazBVYTdiRgp2TklHcnVzNHdFYXd3VVVnZHRVNUE1OTdJeDFzZndNTWFCRERrMm1MakVBTFF0b1UvR1dMRnRCMXdLUzRmU2xBCkNRM3JDc1BVZ0NVam50QWVwR1YvOElGamhibnd4N3dGCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1993"
+      - "2017"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:29 GMT
+      - Fri, 23 Feb 2024 14:00:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -662,45 +761,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1102e69-459c-4f70-8370-0219e56dde38
+      - bf958ba5-5c64-47f0-9320-32626afc0764
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=12a36ee1-201f-4e5b-bce3-86053b5820f6&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:27:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 58b0c6fb-ef9d-49bb-9161-761b5884aeb9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
+    body: '{"instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","endpoint_spec":[{"direct_access":{}},{"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -711,7 +777,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "395"
@@ -720,9 +786,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:30 GMT
+      - Fri, 23 Feb 2024 14:00:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -730,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 988cfb77-9bdc-4f75-9bb5-fee39e80ce44
+      - c44bfa65-2f3d-46d6-8d8b-fb2c501c315c
     status: 200 OK
     code: 200
     duration: ""
@@ -741,10 +807,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "395"
@@ -753,9 +819,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:30 GMT
+      - Fri, 23 Feb 2024 14:00:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -763,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbb1589a-0cb5-4d0e-91c9-4f3605159265
+      - c6f38677-7861-4248-b3f7-e07771367833
     status: 200 OK
     code: 200
     duration: ""
@@ -774,10 +840,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "395"
@@ -786,9 +852,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:00 GMT
+      - Fri, 23 Feb 2024 14:01:13 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -796,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52f0bd0b-9bcc-4d65-9326-ae99d65a83ea
+      - eebb09dc-88c4-486a-986b-b6571df70aa5
     status: 200 OK
     code: 200
     duration: ""
@@ -807,10 +873,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "395"
@@ -819,9 +885,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:30 GMT
+      - Fri, 23 Feb 2024 14:01:45 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -829,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b16adeb-ecb5-4e9b-9ce5-05bb8d0470cc
+      - 952849df-4672-4389-94f8-638cac7f7745
     status: 200 OK
     code: 200
     duration: ""
@@ -840,10 +906,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "510"
@@ -852,9 +918,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:00 GMT
+      - Fri, 23 Feb 2024 14:02:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -862,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1051f412-6a8b-4225-b19f-f1dbb6da5ef1
+      - 45f6bf48-5efd-406c-aae7-53e7a488db1e
     status: 200 OK
     code: 200
     duration: ""
@@ -873,10 +939,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "510"
@@ -885,9 +951,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:30 GMT
+      - Fri, 23 Feb 2024 14:02:45 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -895,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77387a84-9d88-40f1-8253-0d1fc222017c
+      - 9c1732a3-c11b-4671-878b-1627b5928c42
     status: 200 OK
     code: 200
     duration: ""
@@ -906,10 +972,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "503"
@@ -918,9 +984,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:00 GMT
+      - Fri, 23 Feb 2024 14:03:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -928,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 862b4848-5dc7-408e-a25e-009f5ee8ccde
+      - be113432-6964-4f3d-8277-3af2e2cf4625
     status: 200 OK
     code: 200
     duration: ""
@@ -939,10 +1005,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "503"
@@ -951,9 +1017,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:00 GMT
+      - Fri, 23 Feb 2024 14:03:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -961,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b478fcc5-a332-4e19-89be-7f75a19fc495
+      - c3f8b404-e9ca-44e7-8a66-a63700f13e25
     status: 200 OK
     code: 200
     duration: ""
@@ -972,7 +1038,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=12a36ee1-201f-4e5b-bce3-86053b5820f6&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2a6df65-91aa-4ab3-a83e-124d902a98b0&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -984,9 +1050,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:00 GMT
+      - Fri, 23 Feb 2024 14:03:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -994,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fed1ac1-3934-4e57-b20d-4eba085f692b
+      - be829793-4db3-4993-bcb4-c929c93747e8
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,10 +1071,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "503"
@@ -1017,9 +1083,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:01 GMT
+      - Fri, 23 Feb 2024 14:03:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1027,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 806d5ec7-703d-4a62-aee2-aaa7de40d816
+      - 95cef9cf-300e-4b1c-9f96-8eeca2acc9c3
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,21 +1104,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6dce9966-6b81-452d-b67f-7cf899a2d3e6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecc633db-5843-4f7f-aa8f-a7e46026e0cd
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.620409Z","dhcp_enabled":true,"id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","name":"tf-pn-gifted-carson","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.620409Z","id":"1208cfab-0b56-4e3a-91d6-7e1390c9d7db","subnet":"172.16.44.0/22","updated_at":"2024-02-21T18:24:51.620409Z"},{"created_at":"2024-02-21T18:24:51.620409Z","id":"683d2bad-8ef7-4ec4-aec1-7010f7a5da3e","subnet":"fd5f:519c:6d46:27af::/64","updated_at":"2024-02-21T18:24:51.620409Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.620409Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:35.109297Z","dhcp_enabled":true,"id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","name":"tf-pn-stupefied-wright","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.109297Z","id":"f8d82682-3b75-4c60-8f6b-07de6e2e2ca0","subnet":"172.16.16.0/22","updated_at":"2024-02-23T13:56:35.109297Z"},{"created_at":"2024-02-23T13:56:35.109297Z","id":"07f1ad4f-7e5c-4df9-8f5a-5483a8459af8","subnet":"fd63:256c:45f7:e5b1::/64","updated_at":"2024-02-23T13:56:35.109297Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.109297Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "720"
+      - "723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:01 GMT
+      - Fri, 23 Feb 2024 14:03:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1060,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43b93107-4346-4045-8b57-b6c0817dd113
+      - 3941b3b3-7fd2-439d-b18d-0e7d2f8b9490
     status: 200 OK
     code: 200
     duration: ""
@@ -1071,21 +1137,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838},"endpoints":[{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838}],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487},"endpoints":[{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487}],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1805"
+      - "1811"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:01 GMT
+      - Fri, 23 Feb 2024 14:03:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1093,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9efbce10-28ff-4bfe-8e89-a9c82c19147c
+      - dc1513da-fdfb-420f-961d-e5a4f75cdc4f
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,21 +1170,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQ5RENDQXR5Z0F3SUJBZ0lVSVBUUSt6T01JUldRWlJNdzMzSm8vRkN4TEU0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pVeExqRTFPUzQ1TGpnNE1CNFhEVEkwCk1ESXlNVEU0TWpjd09Gb1hEVE0wTURJeE9ERTRNamN3T0Zvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6VXhMakUxT1M0NUxqZzRNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFsMEVlaXF0aWQzV001K0dRSUJ3djQ2LzR0QlhKdXpZekhSYWpkZUhZV3A2KzZZOE9jQXYva2pzN1B6OG4KNGFSM0NQUEJENnVtRWJ3bU9qUWxxVTNJQnFYbGFXeFJkT3FHNGl3MFBXYWxYaUtXZzdxM0JiYW1qNmJYTjBYMAp0VXcwRTdRVVVONWsxeXdMOUhJNk1RVHFTOGNXMUtrV2x5NzN5aDA3RnBxTHpjTXpsc2tIcWZQOFQxR0xibGptCjJjNlRPUEg5UTdkVEwzTnc2SHFTbGhjaHBsNHVlajY3b21ZbVRWdkUyVnYwZGZqK0pLNlptZElycERhV2JnYlYKZktoZTg1azBQbm5uR1RkOTU3VWpvdi9hRFZFQjAvVjFNd2ttNEdMbThvQW5XeXU2SDBGU3hKMENVTkNDdFpTcwpBZXQvMjYrcmdSRXRvV3dnNmxxa2NYS0ZBd0lEQVFBQm80RzVNSUcyTUlHekJnTlZIUkVFZ2Fzd2dhaUNDelV4CkxqRTFPUzQ1TGpnNGdqeHlkeTB4TW1Fek5tVmxNUzB5TURGbUxUUmxOV0l0WW1ObE15MDROakExTTJJMU9ESXcKWmpZdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NDelV4TGpFMU9TNDVMamc0Z2p4eWR5MHhNbUV6Tm1WbApNUzB5TURGbUxUUmxOV0l0WW1ObE15MDROakExTTJJMU9ESXdaall1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2CmRXU0hCTlF2K0hlSEJET2ZDVmlIQkRPZkNWZ3dEUVlKS29aSWh2Y05BUUVMQlFBRGdnRUJBQ2RWWFRHbHM0NkQKS1o1N2RCQTJ5RUZxc0wrdlUrU0hkSWg3dU5xN2dXdWora2NUR1A5NEQwcmdtR0loRTd2MlBZQVB4MHVIdUJqSApQOTVYNTdia3lQdEc1VTFPMU5rRXdPbXV0aVJyQi82aXViQUdsSEM0NjlJRHJaSE9QeDExUTR3SkZOcENLSFE2Ckw1cll0QjEwUWsrdEgxaEF5eVl1WkxCREtFcHRtSU5vTjgrWmVCWm5EbGdua3BodHFKajRCcmI2MVJKemdmZU8KRjVMaGhpRVBQMHhtYm1iMm1QandZUithU0x0d0grZnpGem1DZEFmWU9HSjhaNmpwMDFxdDlWTEN3b2dMMnRYZApzWXd6a291SUJ6bU5haFRQdDRtczliaXFMc2grYUtzbk5WZjA2V09zdDlsVHRzK1RYRXJFL3l3WkFBOXB0TllECmJCN3FWanZPaFF3PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVZkYzSUJBbXVhWG5VWWxCRFVOeG9HL3lFVEhVd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpNeE5EQXdNVGRhRncwek5EQXlNakF4TkRBd01UZGFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQ3B0a0U3V25TaHJOUDNyR3FySjlWZ1dPUVJTNFcyV0J0eGxXNWxWSytjS3FxQ2RibXMKenZ2ZEsxTmVNZ2VwcGFLN3J5UWkwS2pEUUhVWW9pbzAvTzloNk8rSGk5cWVkQ3c5YnVNQW1YOGxrQ0lzbE9hbQo4R3NvWlRZMzVVbGl2K1Rud2lYd1JzaVZIeXBRbXBxOEVKdWNNWlFraFo4a0JWVzFYcnRVTUwzRGZ3czZPK2Q2CmliNTBrYnpBWDBTSFV6NDNlb0YrQWJMUnMwYy9DT0VueUl0ZURMLzV2WjVYdFoyTFY4WFZEM1VhYnRpMEU1bXEKRnRaSFJPanlLQzRnRWFlQVhFU1VBdkpyOGJ5SllPeWhBVzY5NlQwWWJETnQrMmRGOUdueUVjdU85Smc3ZTB0TAo4dFZiNEplT1pPU1dJSHo3TkgyMVUxSXpRTmgvemEveVNWemxBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbE1tRTJaR1kyTlMwNU1XRmhMVFJoWWpNdFlUZ3oKWlMweE1qUmtPVEF5WVRrNFlqQXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaVEpoTm1SbU5qVXRPVEZoWVMwMFlXSXpMV0U0TTJVdE1USTBaRGt3TW1FNU9HSXdMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3VFVMK3ZlaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUNGREh3YzluRWVYazY2d0t0TGtGbUluNERlNE5RaVJCbmxNUEtVTGl6VHk4ajNzdkU2WHZoQgpzSFlPc0x4TDF0dEJBc00wblFqaWUrcEpQYWc3RG5nQlhMWEZXc3p6MFZ1dXdEOCt3WlNuY3ZrNnVlRnlPVk1mCm10dDh0RE56a0Rwa1h1eUcwTXhEUlBnMENpZXR0b2xJWkhwMklTNWhBK1hwdVB5Z09teW8yd2Q1c2pDbHBUanIKYjBiY2xpVWM3K2cwMVBKYVRrdTVhVU5JbVhNUndSU3lxZngzeE43bitSRjVFQWdCR25ITTR2MUcrazBVYTdiRgp2TklHcnVzNHdFYXd3VVVnZHRVNUE1OTdJeDFzZndNTWFCRERrMm1MakVBTFF0b1UvR1dMRnRCMXdLUzRmU2xBCkNRM3JDc1BVZ0NVam50QWVwR1YvOElGamhibnd4N3dGCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1993"
+      - "2017"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:01 GMT
+      - Fri, 23 Feb 2024 14:03:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1126,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41c4efc0-96db-4951-b4ce-69a021c3e720
+      - 0e0591ac-f14c-43fe-ab8c-f10cdf6cb814
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,7 +1203,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=12a36ee1-201f-4e5b-bce3-86053b5820f6&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "503"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 608cb8e0-1de3-41ae-a07a-9d269a2c9f36
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=e2a6df65-91aa-4ab3-a83e-124d902a98b0&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1149,9 +1248,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:01 GMT
+      - Fri, 23 Feb 2024 14:03:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1159,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45d2daca-39f9-4cbb-88a7-8574bddc1236
+      - 738fd898-fd90-4b68-9a40-c7086c012f71
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,10 +1269,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "503"
@@ -1182,9 +1281,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:01 GMT
+      - Fri, 23 Feb 2024 14:03:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1192,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67af99f9-ef3f-4ab7-b69a-46581b83f644
+      - 9d394055-c21d-42ec-b213-0701f3a7bb93
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,76 +1302,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=12a36ee1-201f-4e5b-bce3-86053b5820f6&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:30:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8b650a62-518e-44aa-a600-22c671439f33
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "503"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:30:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9aa15356-070b-4c91-91e2-ae94077f1cfe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "506"
@@ -1281,9 +1314,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:02 GMT
+      - Fri, 23 Feb 2024 14:03:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1291,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b0efd01-3747-4fb7-a922-633fdcc86201
+      - 3f505f1f-0570-4078-9779-96fd2835167e
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,10 +1335,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"endpoints":[{"id":"2866e659-978d-40ba-88e1-3bb4a557d0c8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"6dce9966-6b81-452d-b67f-7cf899a2d3e6","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"7cc0f0a6-1558-4a06-9dcb-eeea5e913121","ip":"212.47.251.35","name":null,"port":5432}],"id":"73176ffc-930f-465f-a597-860584a21d7b","instance_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"5f88fca5-442f-4522-9857-36840fbc823e","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ecc633db-5843-4f7f-aa8f-a7e46026e0cd","service_ip":"10.12.1.0/20","zone":"fr-par-1"}},{"direct_access":{},"id":"fecb78b3-e976-4132-bb51-6ce8fe5de115","ip":"212.47.229.74","name":null,"port":5432}],"id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","instance_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "506"
@@ -1314,9 +1347,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:02 GMT
+      - Fri, 23 Feb 2024 14:03:24 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1324,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 737930da-0dbd-4ac5-af37-01004878e559
+      - 8c85a18b-a537-4ace-8a58-54765d298d08
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,10 +1368,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"73176ffc-930f-465f-a597-860584a21d7b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1347,9 +1380,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:32 GMT
+      - Fri, 23 Feb 2024 14:03:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1357,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 337f7ef3-ffc6-4123-9ffd-a29270fdce6c
+      - cdf41fae-0905-4fc2-8478-ddb7dc92d264
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1368,21 +1401,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838},"endpoints":[{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838}],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487},"endpoints":[{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487}],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1302"
+      - "1308"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:32 GMT
+      - Fri, 23 Feb 2024 14:03:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1390,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3f6b10b-4794-4021-9c64-88b8d288e376
+      - b474fcb8-ef94-4c52-9931-bd822835a10b
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,21 +1434,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838},"endpoints":[{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838}],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487},"endpoints":[{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487}],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1305"
+      - "1311"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:33 GMT
+      - Fri, 23 Feb 2024 14:03:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1423,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0215db4d-90d9-4714-ba3b-1a9df6983e74
+      - 73b032b9-340b-4c7b-a3e0-81e2e1dacd60
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,21 +1467,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.874087Z","endpoint":{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838},"endpoints":[{"id":"ff7bbd69-7d70-4f88-99ac-982f3eeb5b0a","ip":"51.159.9.88","load_balancer":{},"name":null,"port":15838}],"engine":"PostgreSQL-15","id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.202551Z","endpoint":{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487},"endpoints":[{"id":"f99f7be6-ce24-4d58-be44-5ce7ac7e8998","ip":"195.154.197.252","load_balancer":{},"name":null,"port":7487}],"engine":"PostgreSQL-15","id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-multiple-endpoints","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","multiple-endpoints"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1305"
+      - "1311"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:33 GMT
+      - Fri, 23 Feb 2024 14:03:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1456,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b1154ef-c0e2-4f28-845d-ec7ddf485505
+      - ef46c34b-2339-442d-9429-e9da2d9cdc82
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,7 +1500,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6dce9966-6b81-452d-b67f-7cf899a2d3e6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ecc633db-5843-4f7f-aa8f-a7e46026e0cd
     method: DELETE
   response:
     body: ""
@@ -1477,9 +1510,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:33 GMT
+      - Fri, 23 Feb 2024 14:03:56 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1487,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb07bce7-7a48-4fb2-afe6-92ca57bdbd9d
+      - b9895d90-834a-4760-a183-cd7a5ab5e265
     status: 204 No Content
     code: 204
     duration: ""
@@ -1498,10 +1531,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1510,9 +1543,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:03 GMT
+      - Fri, 23 Feb 2024 14:04:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1520,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 851e0aad-d852-408d-8ebd-e904a20718d7
+      - 5b37ae24-b69a-4eb1-b598-cb2edfa1513f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1531,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/12a36ee1-201f-4e5b-bce3-86053b5820f6
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/e2a6df65-91aa-4ab3-a83e-124d902a98b0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"12a36ee1-201f-4e5b-bce3-86053b5820f6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"e2a6df65-91aa-4ab3-a83e-124d902a98b0","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1543,9 +1576,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:03 GMT
+      - Fri, 23 Feb 2024 14:04:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1553,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82f2322e-80f3-4d57-86dc-0ac6a6139816
+      - c73287fc-83c8-41f5-8d69-a664669f438c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1564,10 +1597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/73176ffc-930f-465f-a597-860584a21d7b
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/76dd0b35-0b11-4078-bd5a-aac3effc24b6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"73176ffc-930f-465f-a597-860584a21d7b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"76dd0b35-0b11-4078-bd5a-aac3effc24b6","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1576,9 +1609,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:03 GMT
+      - Fri, 23 Feb 2024 14:04:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1586,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f40908d4-a579-40d1-a17f-f321143d324d
+      - 8f41f9bf-9c58-456b-80a6-91cd738ab7e7
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-private-network.cassette.yaml
@@ -318,9 +318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:50 GMT
+      - Fri, 23 Feb 2024 13:56:33 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,47 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ef6a933-fa31-4a07-93a1-e716c2bf6832
+      - 2746f4a5-b9cd-4fbc-8e16-d113a4b54b1b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
-    method: POST
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "795"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a466ebde-8df1-414d-a58d-c9d9b39b0898
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-pn-charming-yonath","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    body: '{"name":"tf-pn-epic-burnell","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -379,18 +344,18 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.882265Z","dhcp_enabled":true,"id":"e57cca2b-4850-4343-888c-3a42f0206288","name":"tf-pn-charming-yonath","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.882265Z","id":"a0fc427a-5a4e-4aad-96bd-d86f80005959","subnet":"172.16.76.0/22","updated_at":"2024-02-21T18:24:51.882265Z"},{"created_at":"2024-02-21T18:24:51.882265Z","id":"9429f4f0-5723-4df8-9e49-13b84a50d0fe","subnet":"fd5f:519c:6d46:de7f::/64","updated_at":"2024-02-21T18:24:51.882265Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.882265Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:35.185808Z","dhcp_enabled":true,"id":"ccdba967-d92c-4648-947b-9f7874f2aaef","name":"tf-pn-epic-burnell","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.185808Z","id":"49c4f800-97fa-4f4a-a0fb-3c4e4bd76f7a","subnet":"172.16.32.0/22","updated_at":"2024-02-23T13:56:35.185808Z"},{"created_at":"2024-02-23T13:56:35.185808Z","id":"39530717-533a-49f1-8fc0-6f012d4d5192","subnet":"fd63:256c:45f7:bbb8::/64","updated_at":"2024-02-23T13:56:35.185808Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.185808Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -398,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94214b40-e1b9-4750-8406-13ba909e26b8
+      - b7dda71f-84a3-4cfa-bc78-f18f183604d1
     status: 200 OK
     code: 200
     duration: ""
@@ -409,21 +374,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ccdba967-d92c-4648-947b-9f7874f2aaef
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"created_at":"2024-02-23T13:56:35.185808Z","dhcp_enabled":true,"id":"ccdba967-d92c-4648-947b-9f7874f2aaef","name":"tf-pn-epic-burnell","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.185808Z","id":"49c4f800-97fa-4f4a-a0fb-3c4e4bd76f7a","subnet":"172.16.32.0/22","updated_at":"2024-02-23T13:56:35.185808Z"},{"created_at":"2024-02-23T13:56:35.185808Z","id":"39530717-533a-49f1-8fc0-6f012d4d5192","subnet":"fd63:256c:45f7:bbb8::/64","updated_at":"2024-02-23T13:56:35.185808Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.185808Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "795"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -431,54 +396,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0391c22-276c-4264-b5b1-000e93a6ea92
+      - fec478ca-2a7d-4498-8e2f-e019cec8dfe3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e57cca2b-4850-4343-888c-3a42f0206288
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-21T18:24:51.882265Z","dhcp_enabled":true,"id":"e57cca2b-4850-4343-888c-3a42f0206288","name":"tf-pn-charming-yonath","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.882265Z","id":"a0fc427a-5a4e-4aad-96bd-d86f80005959","subnet":"172.16.76.0/22","updated_at":"2024-02-21T18:24:51.882265Z"},{"created_at":"2024-02-21T18:24:51.882265Z","id":"9429f4f0-5723-4df8-9e49-13b84a50d0fe","subnet":"fd5f:519c:6d46:de7f::/64","updated_at":"2024-02-21T18:24:51.882265Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.882265Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5ba4c597-ceb5-4d3f-965e-f34e99351380
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
-    method: GET
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
+    method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "795"
@@ -487,9 +421,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:25 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -497,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dfca9ed-8f76-4878-a8c8-9dfc8e790983
+      - f8202777-7af3-41fa-8fb4-acbd6cd8cb2d
     status: 200 OK
     code: 200
     duration: ""
@@ -508,10 +442,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "795"
@@ -520,9 +454,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:55 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -530,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3f6f476-2b8b-469c-bcab-70b1fc3ab245
+      - a0b1d043-b243-41e7-afcf-9d7345150854
     status: 200 OK
     code: 200
     duration: ""
@@ -541,10 +475,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "795"
@@ -553,9 +487,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:25 GMT
+      - Fri, 23 Feb 2024 13:57:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -563,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a71d95b-bc21-4f38-9028-8eeea9d20ed8
+      - 987c3981-3261-4fd4-bccf-6e8607ab70ac
     status: 200 OK
     code: 200
     duration: ""
@@ -574,10 +508,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "795"
@@ -586,9 +520,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:55 GMT
+      - Fri, 23 Feb 2024 13:57:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -596,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aae0d1e7-705c-4845-8e59-b1cbeb84215b
+      - ef204e60-486b-4f39-80d3-814a6611b7b1
     status: 200 OK
     code: 200
     duration: ""
@@ -607,10 +541,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "795"
@@ -619,9 +553,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:25 GMT
+      - Fri, 23 Feb 2024 13:58:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -629,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1693f3cd-b331-4265-887a-c8b986e0648b
+      - a232c27f-5a3c-4ec6-a07f-f70ceab3bcf5
     status: 200 OK
     code: 200
     duration: ""
@@ -640,10 +574,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "795"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:58:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 123c58b0-c33d-469d-9ccb-acfd5e9cf204
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "795"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ffb7f49e-e251-4938-bb28-b83077fc9216
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1070"
@@ -652,9 +652,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:56 GMT
+      - Fri, 23 Feb 2024 13:59:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -662,7 +662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a9d3ae0-2ac5-4481-8c56-e2eb02218918
+      - 564efb67-a2e7-48b5-a826-edd1a5aec5ff
     status: 200 OK
     code: 200
     duration: ""
@@ -673,21 +673,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569},"endpoints":[{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569}],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071},"endpoints":[{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071}],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1289"
+      - "1287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:26 GMT
+      - Fri, 23 Feb 2024 14:00:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -695,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b95c18ef-cee3-4b98-a5a3-65ec0f8392c8
+      - c793d9e1-aa6b-453e-9359-880b83bbc3f1
     status: 200 OK
     code: 200
     duration: ""
@@ -706,21 +706,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRTlrb0ZlVVlsQ2ZDeFAzMEtyWEZlam5nT1I4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpFeE9ESTNOREZhRncwek5EQXlNVGd4T0RJM05ERmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzdvS3h2MC9iNUluVGN0K2JvRE5KSTBXQTFYc054cUxibUo0RGpoKy9wTjlGQVA1ZDcKcGUwMm5YQ0JCM1orZlJsdEFoNnlTdEhPNGlLb2g5YWJhUlBNR1BOT2hkSDVVNjllZmtHUnNjYlp3WGdRMUphWgpQZXJ6SkIvYi9BT3BJVGpEMmwwN0J0bG1ONklKdG5iVmZEWHBabmJQWHQxc3Z3Zm94ZmF5WWxtOUd0ZExyTlg3Ck9FMTc1ZVZEYUEwc1Q1S2V4aTh5WVprVGtqQW14KzZ1bGpyZzE4N210czlhVXhVNHZTQmFibkpBOXNCLzUvTDMKSWZoRDVhSEtiL1l6ZG9DYUV0N1hLam9URFNJTEhrejExTk9JaHVmK0RiVndwLzRxUDh2YzFCM05waC9iTitpTgpya3N1alFVQmdWbGJIVDc0aHg4ZFE5c0pyNEt4aGloWnNYU0JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbFl6Y3pPREpqTVMwMU1HUTBMVFJrWmpndFlUbGwKWXkwMU16Tm1NR1F6TUdZNE5EUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaV00zTXpneVl6RXROVEJrTkMwMFpHWTRMV0U1WldNdE5UTXpaakJrTXpCbU9EUTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubTcwaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFBQWpzRXV0SHJJS0tqdDFzRUZNNG9tZGNqYXFFTXB0RDB6RWdneWJGVXFkYnhzYTM5SDBNcwpiR2NKNkc4K1MvM3k5d1dZWXhBbmRQOUgxZ0JEODZ4alQxSXNnb1BqLzZBN2NrN2hYdk0vcU15RUxPQmRuZ2xjCkk1WHA2RGJpM3hZemdsdWUxaFFmQzkyRzBzcTU1MmsyR0ZlV0pjWnNZdTM1SkpGNFArVE1aalp3cktpRjNwYWEKTGU0emRuWmdhSG1Yb1Z2Y0MzekRZaWRPaXdRMzd0aDFqTVRaQVdRRXV4ZW1RZzAzc2x0L0pEY2JGZXBmV0dHYQpNTWhsMmZHS0ZLRFg1cWJEeUpTM0pqT3JHc1hqOThJQWVXcWhMTzhsRUJwRnZLTmVjK1UwZlJIU1BBS0Z3WFNXClFVaWh1ZVlkTmdTZGI3RE8xQXRNbVMxekpUWUo1TmJSCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVSVBBZlYvWThxWUg1NjNnUlB5RTBYRUdad0tRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU1qVXdIaGNOCk1qUXdNakl6TVRNMU9UTTVXaGNOTXpRd01qSXdNVE0xT1RNNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl5TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2Qm11T1lGZ1NUa25BRTZlSXNBcEh5UXMxMklrQ1pzUjBaTkxjRWVoYjVMV2tFcmNqN25pVTYKL1BldjBEdVBBUG9odE9RNlJ4NHJIbmpLUG9iKzdXaS9rVUh5d0FvdlJPajhuMzlndEpJV1dTVU8xa05GRE9wQwpwK2QzdVBUK3dyUk1CS3k3Wk9pZDNvcFhDdDZuL2FNN05LSnJBNzBaRVFzK3R3eUF5MFZNbXlMZkl0M2RQWVRqCnd2bk8wdkNDdXZ3NmwvRWdkTlYydlBad3ZxMjd2TEtlS0grQitGSk9YN3hCajdEUkFmaHRsNkwwQWtvdmpockMKaC82Vi81c2RIL01ZK3hzdW4wbmlOUEROZDI2ZzB5T0poMTYwTXdyMDNSc2YrUUhPOUtSbDQxOE1MTzdZU05kLwpEcEhwTlB2NWtjczRSWkxOdTlWNmRBWE5NOTM1Tk0wQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNakkxZ2p4eWR5MDFPR0l3TURZMFlTMWlPVEl4TFRRMlptTXRZalF4WVMwMlpHUm0KTmpVNU9EQXdNRFV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNaldDUEhKMwpMVFU0WWpBd05qUmhMV0k1TWpFdE5EWm1ZeTFpTkRGaExUWmtaR1kyTlRrNE1EQXdOUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnkwN0ljRU01OUs0WWNFTTU5SzRUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKSXc2Q3dka3dNV0Rzdmc3Z2MyYXJTUU5FaTlKNkY4MGY3NktSSXpaMUV0cVlwMkZ4RlNCUUEvRGs2V2swZWlkZApkUHNvSVlrVjduWHJQczdsL1BLZ3B3RDFGSnZMdndiaTlURnZISUNsQTEwODBaS3BkVUg0L0k5V0lpTGdIWDRpCmNBWUdGYzhvU0kvKzlCeUFLOFdUSS83WjdLZUNnekFNdTVKeVV0TFJzT0Z6alV4b3krNlpQK2d6SUwwU292TGQKK2hDODlPZkxxMjF0MStDODg3S3hnS2hJeVRCZGE1NDRTdFZ0SGFLVzI4SE1kZVVxZm5wL2RiaTNtdE03VUhxNgphcEFXVnRIZXpSVmZYUXhUcCtWSWYwQ2RLRXYyRmFZVml0ZjhldlI2ZW80WUIrcHJqd3BaWVMvSEp1eElUZm9wCk9PcGV4OFc5NWZJSHdMUEkrWHNwNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2017"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:27 GMT
+      - Fri, 23 Feb 2024 14:00:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -728,45 +728,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b0d5952-e30a-4fbc-85d4-5954838c0824
+      - 96c469dc-bd4c-40ea-ab0d-6c978f69aea5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ec7382c1-50d4-4df8-a9ec-533f0d30f844&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:28:27 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5706d0c1-84eb-409e-98bd-ee77e4e01d3c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","endpoint_spec":[{"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
+    body: '{"instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","endpoint_spec":[{"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20"}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -777,7 +744,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "395"
@@ -786,9 +753,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:28 GMT
+      - Fri, 23 Feb 2024 14:00:07 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -796,7 +763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28a83665-73a2-4987-aa9d-95fce14073a0
+      - 23f8bb9b-d8d2-4ead-92cf-dc614d3af069
     status: 200 OK
     code: 200
     duration: ""
@@ -807,10 +774,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "395"
@@ -819,9 +786,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:28 GMT
+      - Fri, 23 Feb 2024 14:00:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -829,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 154be29f-a54c-442c-b5be-999a39f840b9
+      - a08faa57-1632-4c5e-921c-b97e9defd2ec
     status: 200 OK
     code: 200
     duration: ""
@@ -840,10 +807,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "395"
@@ -852,9 +819,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:58 GMT
+      - Fri, 23 Feb 2024 14:00:38 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -862,7 +829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4e52793-55e1-4453-9a85-caf457088398
+      - e2174dc0-55f8-4e08-8d01-41be62e36b87
     status: 200 OK
     code: 200
     duration: ""
@@ -873,10 +840,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "395"
@@ -885,9 +852,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:28 GMT
+      - Fri, 23 Feb 2024 14:01:11 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -895,7 +862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7652faf0-2445-4781-bdc6-aa2d4ecaed03
+      - 0bb71bc3-d4dd-49a6-b752-2b8b2d2b38fe
     status: 200 OK
     code: 200
     duration: ""
@@ -906,10 +873,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -918,9 +885,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:58 GMT
+      - Fri, 23 Feb 2024 14:01:44 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -928,7 +895,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c2b4986-a30d-4f3d-9b56-c8f05361f997
+      - ea169f87-d345-4ed3-bb64-e46a15ffea3d
     status: 200 OK
     code: 200
     duration: ""
@@ -939,10 +906,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -951,9 +918,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:28 GMT
+      - Fri, 23 Feb 2024 14:02:14 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -961,7 +928,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7fd68a41-505f-4e13-af14-dd34593827e1
+      - 4666579d-ff41-445b-8adb-4dbe4637aa0b
     status: 200 OK
     code: 200
     duration: ""
@@ -972,10 +939,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -984,9 +951,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:02:46 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -994,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 431ba8dc-6595-4dca-86fd-3e4e9719b8f8
+      - c117d642-c212-430a-a45b-09643168a6f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,10 +972,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -1017,9 +984,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:29 GMT
+      - Fri, 23 Feb 2024 14:03:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1027,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0910522d-9838-4cef-8d95-f9dbf16a495f
+      - 71092942-efae-4c4f-9500-8cc4265fe684
     status: 200 OK
     code: 200
     duration: ""
@@ -1038,43 +1005,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"initializing"}'
-    headers:
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:31:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 70a150d9-cdc9-4f1e-9f91-9b9b497af67e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -1083,9 +1017,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:29 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1093,7 +1027,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1076523d-31b5-4537-b9c8-534f307a77cb
+      - 24cfebc3-43a3-4dcd-8ed0-0c774b42fefc
     status: 200 OK
     code: 200
     duration: ""
@@ -1104,10 +1038,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -1116,9 +1050,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:29 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1126,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6fa2f80d-8a99-41eb-b99a-26f2d9bd44b6
+      - efadec05-fb1c-4edd-aa9a-5fe558cd95a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1137,7 +1071,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ec7382c1-50d4-4df8-a9ec-533f0d30f844&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=58b0064a-b921-46fc-b41a-6ddf65980005&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1149,9 +1083,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:29 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1159,7 +1093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5928c230-983f-4e9b-b85e-1e77acbdfce2
+      - efc5ab60-9ff0-4901-b1f7-f2de5c32ffb4
     status: 200 OK
     code: 200
     duration: ""
@@ -1170,10 +1104,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -1182,9 +1116,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:29 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1192,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da6e55b6-a5a7-4c66-aef2-f2470510d84d
+      - 171d39d2-92b2-4522-b5bd-dd3c6b4c7b05
     status: 200 OK
     code: 200
     duration: ""
@@ -1203,21 +1137,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e57cca2b-4850-4343-888c-3a42f0206288
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ccdba967-d92c-4648-947b-9f7874f2aaef
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:24:51.882265Z","dhcp_enabled":true,"id":"e57cca2b-4850-4343-888c-3a42f0206288","name":"tf-pn-charming-yonath","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:24:51.882265Z","id":"a0fc427a-5a4e-4aad-96bd-d86f80005959","subnet":"172.16.76.0/22","updated_at":"2024-02-21T18:24:51.882265Z"},{"created_at":"2024-02-21T18:24:51.882265Z","id":"9429f4f0-5723-4df8-9e49-13b84a50d0fe","subnet":"fd5f:519c:6d46:de7f::/64","updated_at":"2024-02-21T18:24:51.882265Z"}],"tags":[],"updated_at":"2024-02-21T18:24:51.882265Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T13:56:35.185808Z","dhcp_enabled":true,"id":"ccdba967-d92c-4648-947b-9f7874f2aaef","name":"tf-pn-epic-burnell","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.185808Z","id":"49c4f800-97fa-4f4a-a0fb-3c4e4bd76f7a","subnet":"172.16.32.0/22","updated_at":"2024-02-23T13:56:35.185808Z"},{"created_at":"2024-02-23T13:56:35.185808Z","id":"39530717-533a-49f1-8fc0-6f012d4d5192","subnet":"fd63:256c:45f7:bbb8::/64","updated_at":"2024-02-23T13:56:35.185808Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.185808Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:30 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1225,7 +1159,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6868aeb0-9660-4bca-b97a-9ffb3c238635
+      - a1ef52b2-4912-410b-86b2-9d0be79d4c0d
     status: 200 OK
     code: 200
     duration: ""
@@ -1236,21 +1170,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569},"endpoints":[{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569}],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071},"endpoints":[{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071}],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1677"
+      - "1675"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:30 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1258,7 +1192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e72fcd03-04e8-48c4-b90d-ce80f65bd2f9
+      - e265e876-5844-4867-8bb8-5bcc92684876
     status: 200 OK
     code: 200
     duration: ""
@@ -1269,21 +1203,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVCRENDQXV5Z0F3SUJBZ0lVRTlrb0ZlVVlsQ2ZDeFAzMEtyWEZlam5nT1I4d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4R0RBV0JnTlZCQU1NRHpFNU5TNHhOVFF1TVRrM0xqSTFNakFlCkZ3MHlOREF5TWpFeE9ESTNOREZhRncwek5EQXlNVGd4T0RJM05ERmFNRm94Q3pBSkJnTlZCQVlUQWtaU01RNHcKREFZRFZRUUlEQVZRWVhKcGN6RU9NQXdHQTFVRUJ3d0ZVR0Z5YVhNeEVUQVBCZ05WQkFvTUNGTmpZV3hsZDJGNQpNUmd3RmdZRFZRUUREQTh4T1RVdU1UVTBMakU1Tnk0eU5USXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCCkR3QXdnZ0VLQW9JQkFRQzdvS3h2MC9iNUluVGN0K2JvRE5KSTBXQTFYc054cUxibUo0RGpoKy9wTjlGQVA1ZDcKcGUwMm5YQ0JCM1orZlJsdEFoNnlTdEhPNGlLb2g5YWJhUlBNR1BOT2hkSDVVNjllZmtHUnNjYlp3WGdRMUphWgpQZXJ6SkIvYi9BT3BJVGpEMmwwN0J0bG1ONklKdG5iVmZEWHBabmJQWHQxc3Z3Zm94ZmF5WWxtOUd0ZExyTlg3Ck9FMTc1ZVZEYUEwc1Q1S2V4aTh5WVprVGtqQW14KzZ1bGpyZzE4N210czlhVXhVNHZTQmFibkpBOXNCLzUvTDMKSWZoRDVhSEtiL1l6ZG9DYUV0N1hLam9URFNJTEhrejExTk9JaHVmK0RiVndwLzRxUDh2YzFCM05waC9iTitpTgpya3N1alFVQmdWbGJIVDc0aHg4ZFE5c0pyNEt4aGloWnNYU0JBZ01CQUFHamdjRXdnYjR3Z2JzR0ExVWRFUVNCCnN6Q0JzSUlQTVRrMUxqRTFOQzR4T1RjdU1qVXlnanh5ZHkxbFl6Y3pPREpqTVMwMU1HUTBMVFJrWmpndFlUbGwKWXkwMU16Tm1NR1F6TUdZNE5EUXVjbVJpTG1aeUxYQmhjaTV6WTNjdVkyeHZkV1NDRHpFNU5TNHhOVFF1TVRrMwpMakkxTW9JOGNuY3RaV00zTXpneVl6RXROVEJrTkMwMFpHWTRMV0U1WldNdE5UTXpaakJrTXpCbU9EUTBMbkprCllpNW1jaTF3WVhJdWMyTjNMbU5zYjNWa2h3UXpubTcwaHdURG1zWDhod1REbXNYOE1BMEdDU3FHU0liM0RRRUIKQ3dVQUE0SUJBUUFBQWpzRXV0SHJJS0tqdDFzRUZNNG9tZGNqYXFFTXB0RDB6RWdneWJGVXFkYnhzYTM5SDBNcwpiR2NKNkc4K1MvM3k5d1dZWXhBbmRQOUgxZ0JEODZ4alQxSXNnb1BqLzZBN2NrN2hYdk0vcU15RUxPQmRuZ2xjCkk1WHA2RGJpM3hZemdsdWUxaFFmQzkyRzBzcTU1MmsyR0ZlV0pjWnNZdTM1SkpGNFArVE1aalp3cktpRjNwYWEKTGU0emRuWmdhSG1Yb1Z2Y0MzekRZaWRPaXdRMzd0aDFqTVRaQVdRRXV4ZW1RZzAzc2x0L0pEY2JGZXBmV0dHYQpNTWhsMmZHS0ZLRFg1cWJEeUpTM0pqT3JHc1hqOThJQWVXcWhMTzhsRUJwRnZLTmVjK1UwZlJIU1BBS0Z3WFNXClFVaWh1ZVlkTmdTZGI3RE8xQXRNbVMxekpUWUo1TmJSCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVSVBBZlYvWThxWUg1NjNnUlB5RTBYRUdad0tRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzQzTkM0eU1qVXdIaGNOCk1qUXdNakl6TVRNMU9UTTVXaGNOTXpRd01qSXdNVE0xT1RNNVdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqYzBMakl5TlRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQUp2Qm11T1lGZ1NUa25BRTZlSXNBcEh5UXMxMklrQ1pzUjBaTkxjRWVoYjVMV2tFcmNqN25pVTYKL1BldjBEdVBBUG9odE9RNlJ4NHJIbmpLUG9iKzdXaS9rVUh5d0FvdlJPajhuMzlndEpJV1dTVU8xa05GRE9wQwpwK2QzdVBUK3dyUk1CS3k3Wk9pZDNvcFhDdDZuL2FNN05LSnJBNzBaRVFzK3R3eUF5MFZNbXlMZkl0M2RQWVRqCnd2bk8wdkNDdXZ3NmwvRWdkTlYydlBad3ZxMjd2TEtlS0grQitGSk9YN3hCajdEUkFmaHRsNkwwQWtvdmpockMKaC82Vi81c2RIL01ZK3hzdW4wbmlOUEROZDI2ZzB5T0poMTYwTXdyMDNSc2YrUUhPOUtSbDQxOE1MTzdZU05kLwpEcEhwTlB2NWtjczRSWkxOdTlWNmRBWE5NOTM1Tk0wQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU56UXVNakkxZ2p4eWR5MDFPR0l3TURZMFlTMWlPVEl4TFRRMlptTXRZalF4WVMwMlpHUm0KTmpVNU9EQXdNRFV1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0M05DNHlNaldDUEhKMwpMVFU0WWpBd05qUmhMV0k1TWpFdE5EWm1ZeTFpTkRGaExUWmtaR1kyTlRrNE1EQXdOUzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnkwN0ljRU01OUs0WWNFTTU5SzRUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKSXc2Q3dka3dNV0Rzdmc3Z2MyYXJTUU5FaTlKNkY4MGY3NktSSXpaMUV0cVlwMkZ4RlNCUUEvRGs2V2swZWlkZApkUHNvSVlrVjduWHJQczdsL1BLZ3B3RDFGSnZMdndiaTlURnZISUNsQTEwODBaS3BkVUg0L0k5V0lpTGdIWDRpCmNBWUdGYzhvU0kvKzlCeUFLOFdUSS83WjdLZUNnekFNdTVKeVV0TFJzT0Z6alV4b3krNlpQK2d6SUwwU292TGQKK2hDODlPZkxxMjF0MStDODg3S3hnS2hJeVRCZGE1NDRTdFZ0SGFLVzI4SE1kZVVxZm5wL2RiaTNtdE03VUhxNgphcEFXVnRIZXpSVmZYUXhUcCtWSWYwQ2RLRXYyRmFZVml0ZjhldlI2ZW80WUIrcHJqd3BaWVMvSEp1eElUZm9wCk9PcGV4OFc5NWZJSHdMUEkrWHNwNVE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2017"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:30 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1291,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11a0958f-0a9f-4c1a-b938-9308b9bcc7a8
+      - b52b9725-ca13-4674-bb6f-1d64616acccc
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,7 +1236,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ec7382c1-50d4-4df8-a9ec-533f0d30f844&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "388"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:49 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 54c336dd-6e0c-449a-9024-60c8210093b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=58b0064a-b921-46fc-b41a-6ddf65980005&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1314,9 +1281,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:30 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1324,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05ecfaa2-bf7b-4309-abb3-3c740eedc53b
+      - 520af7fb-262f-4f34-9cb2-f2bb39314986
     status: 200 OK
     code: 200
     duration: ""
@@ -1335,10 +1302,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -1347,9 +1314,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:30 GMT
+      - Fri, 23 Feb 2024 14:03:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1357,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44666b8b-b82f-49d9-bd3c-08954b5486ba
+      - 44d7ddf2-9a94-4d07-a4fc-555806e681b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1368,76 +1335,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=ec7382c1-50d4-4df8-a9ec-533f0d30f844&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:32:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1195842c-e57b-484a-824b-311df46ae3b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "388"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:32:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b27a8c5d-ddf2-429c-9954-4c25e75c29e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "391"
@@ -1446,9 +1347,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:31 GMT
+      - Fri, 23 Feb 2024 14:03:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1456,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c611095b-d2c5-4194-b0b2-6c81287c9a32
+      - 34e9fd94-45e7-460e-bddb-bb70ae057e94
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,10 +1368,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"endpoints":[{"id":"28a94268-3e6a-4859-86cc-38c30242f240","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"e57cca2b-4850-4343-888c-3a42f0206288","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","instance_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"4eb2d942-f623-4e31-8755-5c9d4f630e29","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"ccdba967-d92c-4648-947b-9f7874f2aaef","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","instance_id":"58b0064a-b921-46fc-b41a-6ddf65980005","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "391"
@@ -1479,9 +1380,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:31 GMT
+      - Fri, 23 Feb 2024 14:03:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1489,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ef89adf-9957-4d9a-b9c0-2e467e9795c1
+      - 8a9f14b1-3b55-4d77-9395-7ce5d409b525
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,10 +1401,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1512,9 +1413,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:01 GMT
+      - Fri, 23 Feb 2024 14:04:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1522,7 +1423,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b5e6630-e640-47a8-8ab0-e551d70511f9
+      - 2e4b122b-d431-4589-a0cc-46cbf39b98f9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1533,21 +1434,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569},"endpoints":[{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569}],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071},"endpoints":[{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071}],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1289"
+      - "1287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:01 GMT
+      - Fri, 23 Feb 2024 14:04:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1555,7 +1456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6dc48e3-a1f0-4922-bf5f-cb28536456e9
+      - 0eac3971-6169-4da3-b0f3-1512575f1870
     status: 200 OK
     code: 200
     duration: ""
@@ -1566,21 +1467,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569},"endpoints":[{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569}],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071},"endpoints":[{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071}],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1292"
+      - "1290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:02 GMT
+      - Fri, 23 Feb 2024 14:04:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1588,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c5b4e3e-83cb-41e1-bbad-98de3737696c
+      - 6f7a7d44-a323-4f9c-81ac-2361328e5981
     status: 200 OK
     code: 200
     duration: ""
@@ -1599,21 +1500,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:51.986377Z","endpoint":{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569},"endpoints":[{"id":"8b7e144b-5925-46aa-a766-ae5fca0cafba","ip":"195.154.197.252","load_balancer":{},"name":null,"port":9569}],"engine":"PostgreSQL-15","id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.279043Z","endpoint":{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071},"endpoints":[{"id":"379c900a-a580-4f14-a494-e194e61ed5c1","ip":"51.159.74.225","load_balancer":{},"name":null,"port":28071}],"engine":"PostgreSQL-15","id":"58b0064a-b921-46fc-b41a-6ddf65980005","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","private-network"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1292"
+      - "1290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:02 GMT
+      - Fri, 23 Feb 2024 14:04:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1621,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f38558d-8587-4db1-bd5a-238509aa06c6
+      - 94cf1404-9391-42cb-ab46-1270cc5028c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1632,7 +1533,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/e57cca2b-4850-4343-888c-3a42f0206288
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ccdba967-d92c-4648-947b-9f7874f2aaef
     method: DELETE
   response:
     body: ""
@@ -1642,9 +1543,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:02 GMT
+      - Fri, 23 Feb 2024 14:04:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1652,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9dac9d9-78a7-4bab-8d14-e8961883cb62
+      - a9234ed0-60ad-4c22-840e-8b8e166279a3
     status: 204 No Content
     code: 204
     duration: ""
@@ -1663,10 +1564,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"58b0064a-b921-46fc-b41a-6ddf65980005","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1675,9 +1576,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:32 GMT
+      - Fri, 23 Feb 2024 14:04:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1685,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff508d11-ec1a-4c90-b13e-05dc9b8754a5
+      - 2d8494ae-bbe8-4003-8476-e9ed1e179825
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1696,10 +1597,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/ec7382c1-50d4-4df8-a9ec-533f0d30f844
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/58b0064a-b921-46fc-b41a-6ddf65980005
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"ec7382c1-50d4-4df8-a9ec-533f0d30f844","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"58b0064a-b921-46fc-b41a-6ddf65980005","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -1708,9 +1609,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:32 GMT
+      - Fri, 23 Feb 2024 14:04:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1718,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3669ed58-665e-4366-bf8e-38cd5414ba20
+      - 407e615b-496a-415e-ba24-80703b1b8b54
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1729,10 +1630,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/b1f627b6-5bf6-41fe-94ec-76282dcad28d
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/2f9b68f7-56a4-4028-9983-c84741ca40ea
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"b1f627b6-5bf6-41fe-94ec-76282dcad28d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"2f9b68f7-56a4-4028-9983-c84741ca40ea","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -1741,9 +1642,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:32 GMT
+      - Fri, 23 Feb 2024 14:04:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1751,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4c21b7a-9e76-4724-bcdc-72e53478d1f2
+      - e12cb8b6-9819-48b7-98ce-f7d463111623
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-update.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-update.cassette.yaml
@@ -318,9 +318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:50 GMT
+      - Fri, 23 Feb 2024 13:56:33 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,12 +328,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d30cae53-0165-49a5-abae-1989abc84e35
+      - 3355ed70-baa5-45f4-99ed-ca170f76d577
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-rdb-rr-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","update"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-update","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","update"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":null,"backup_same_region":false}'
     form: {}
     headers:
       Content-Type:
@@ -344,7 +344,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -353,9 +353,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 434134c1-5cc8-4809-a6e0-12a5045c8daa
+      - 919621ad-9a94-4055-bb0f-f55f2f95f71f
     status: 200 OK
     code: 200
     duration: ""
@@ -374,10 +374,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -386,9 +386,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:24:52 GMT
+      - Fri, 23 Feb 2024 13:56:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -396,7 +396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f83fffc9-0fe9-44da-88ac-235e78225846
+      - 52edcd0a-d089-4906-943c-3f73d682bade
     status: 200 OK
     code: 200
     duration: ""
@@ -407,10 +407,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -419,9 +419,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:25 GMT
+      - Fri, 23 Feb 2024 13:57:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -429,7 +429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d65292e1-ef53-4b4b-b8a8-b3338c528dd5
+      - 43928ee6-23d2-4bd5-b57b-7b9f009b2dd9
     status: 200 OK
     code: 200
     duration: ""
@@ -440,10 +440,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -452,9 +452,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:25:55 GMT
+      - Fri, 23 Feb 2024 13:57:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -462,7 +462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ffa4b3e-c253-4df4-9ce8-ee18da78fcec
+      - f4078e5c-582d-4859-9569-4d52f6ce06f1
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -485,9 +485,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:25 GMT
+      - Fri, 23 Feb 2024 13:58:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -495,7 +495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b00e2e26-ee59-4165-aef1-baa321f067bf
+      - 31cfa0d5-214a-4d94-a92c-ef8ee40f704a
     status: 200 OK
     code: 200
     duration: ""
@@ -506,10 +506,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -518,9 +518,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:26:55 GMT
+      - Fri, 23 Feb 2024 13:58:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -528,7 +528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f8e9d06-f9e0-481c-ad94-5b6edd41dd2a
+      - e9768fb2-b5bf-467c-bfe4-6f2120d7f1d6
     status: 200 OK
     code: 200
     duration: ""
@@ -539,10 +539,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "790"
@@ -551,9 +551,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:27:26 GMT
+      - Fri, 23 Feb 2024 13:59:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -561,7 +561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b9fa6d8-ebb0-4315-9a3a-06c34f275d47
+      - 0c4f2714-cc1d-41c9-93c7-513265cec772
     status: 200 OK
     code: 200
     duration: ""
@@ -572,43 +572,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "790"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:27:56 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 371a3ce8-da0e-4f51-b4db-53c2a709f1b6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
       - "1065"
@@ -617,9 +584,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:26 GMT
+      - Fri, 23 Feb 2024 13:59:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -627,7 +594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0a8ff83-756c-4e6f-af0b-dbcf940ea71c
+      - 580a4769-0dcc-4129-ac28-e736ed34c094
     status: 200 OK
     code: 200
     duration: ""
@@ -638,21 +605,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1284"
+      - "1282"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:56 GMT
+      - Fri, 23 Feb 2024 14:00:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -660,7 +627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3648cdfc-9d30-44cd-b69e-1f437621bf6e
+      - 6a59291b-df25-4d3f-97d0-474e4f178402
     status: 200 OK
     code: 200
     duration: ""
@@ -671,21 +638,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:56 GMT
+      - Fri, 23 Feb 2024 14:00:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -693,45 +660,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ed68955-9173-4730-880e-1650e0146ddd
+      - d75796d6-50f7-483f-b7d6-28db536e8de5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:28:56 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9517d9b5-45ac-4ac3-9835-2e5e8b7fdf09
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"instance_id":"da68cc82-6010-4167-a577-034bee58968a","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
+    body: '{"instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","endpoint_spec":[{"direct_access":{}}],"same_zone":true}'
     form: {}
     headers:
       Content-Type:
@@ -742,7 +676,7 @@ interactions:
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
     method: POST
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "177"
@@ -751,9 +685,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:57 GMT
+      - Fri, 23 Feb 2024 14:00:07 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -761,7 +695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd060a3c-2157-4e95-a991-1865b20e6bd0
+      - 038121bd-9091-4ea6-b24e-0e07c9f8f399
     status: 200 OK
     code: 200
     duration: ""
@@ -772,10 +706,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
       - "177"
@@ -784,9 +718,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:28:57 GMT
+      - Fri, 23 Feb 2024 14:00:07 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -794,7 +728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46b9380e-18be-4430-a59e-d7685c166f2a
+      - 2baee65f-60e8-4b82-ab46-07e4cb01e933
     status: 200 OK
     code: 200
     duration: ""
@@ -805,21 +739,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "291"
+      - "177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:27 GMT
+      - Fri, 23 Feb 2024 14:00:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -827,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 314ff2d6-b952-40d8-89ff-7ee797176130
+      - 21a17c0e-8b74-4816-89d3-625e2436bab3
     status: 200 OK
     code: 200
     duration: ""
@@ -838,21 +772,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "291"
+      - "177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:29:57 GMT
+      - Fri, 23 Feb 2024 14:01:11 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -860,7 +794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6dc4537-f3af-42f1-a2a6-4a3bcd4a156e
+      - e970f8c8-ff25-4fd8-b15d-d3d137ca29c4
     status: 200 OK
     code: 200
     duration: ""
@@ -871,21 +805,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"provisioning"}'
     headers:
       Content-Length:
-      - "291"
+      - "177"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:28 GMT
+      - Fri, 23 Feb 2024 14:01:44 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -893,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a860a8f-d5a4-45b7-9005-6c36c07bf131
+      - 31668c5b-9b47-4d55-9391-0609ab5e597b
     status: 200 OK
     code: 200
     duration: ""
@@ -904,21 +838,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "284"
+      - "292"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:02:14 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -926,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a6db5d6-f812-46f6-8e2f-fbc311089149
+      - c7ab114c-4838-486a-a009-e22b5c68dbc5
     status: 200 OK
     code: 200
     duration: ""
@@ -937,21 +871,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "284"
+      - "292"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:02:44 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -959,7 +893,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48cd4dd0-ab7d-45a8-8d59-523ccfeb3a7f
+      - 10685349-d2aa-419b-a22c-e369786d9825
     status: 200 OK
     code: 200
     duration: ""
@@ -970,21 +904,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "27"
+      - "292"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:03:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -992,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca00503f-4f0a-4a18-be5d-7926543c27d3
+      - 546c4b3f-b0cc-4ca6-bc79-ed37440159c1
     status: 200 OK
     code: 200
     duration: ""
@@ -1003,21 +937,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "284"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:03:47 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1025,7 +959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 429e2ad4-8b0a-46a0-8d22-5d0e317cbf6e
+      - 27df3967-166a-4523-8d69-c30bce02d3f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1036,21 +970,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "1568"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:03:48 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1058,7 +992,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ab9a84d-3370-4ce1-b6fb-24ef6cc73f8c
+      - a73f57f5-d8b5-4b2a-8c26-4b98f2ec68ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,21 +1003,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "2013"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:03:48 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1091,7 +1025,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73e6e3f6-cc88-437f-811b-e98f0388ae02
+      - 50afb712-9c42-4b7d-9d01-d24ad5dbf2be
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,21 +1036,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "27"
+      - "1567"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:03:48 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1124,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 187d8fbd-4fd3-4be6-ac5f-4e514462780b
+      - c46a9f01-a727-4f57-b171-26dfb2abd342
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,21 +1069,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "284"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:03:48 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1157,7 +1091,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffb2c730-a05f-4e53-a3af-86de31b6a0b2
+      - d74e1826-24fa-4429-8f5d-16c1b2c68c3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1168,21 +1102,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "27"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:58 GMT
+      - Fri, 23 Feb 2024 14:03:48 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1190,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bedbae2-d274-4768-8999-d2d61662b63d
+      - 2be06df4-6ada-4378-bdd4-9cb3669a9728
     status: 200 OK
     code: 200
     duration: ""
@@ -1201,21 +1135,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1568"
+      - "1567"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1223,7 +1157,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e62260fb-2b68-4691-a78c-b059f278a4b1
+      - b59e4426-278e-4502-be44-1fa2aa428f0d
     status: 200 OK
     code: 200
     duration: ""
@@ -1234,21 +1168,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1256,7 +1190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43fcd166-034a-4bf2-bbd1-78c1f20fae2a
+      - 4aecae9a-5eff-4030-80ab-79fe0e9b8357
     status: 200 OK
     code: 200
     duration: ""
@@ -1267,21 +1201,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "27"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1289,78 +1223,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb2ee90e-2b5d-4454-ba9a-57160d8209c8
+      - 73ae56e3-9cc8-47cd-8adf-1108591a62a0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "284"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c1ee2e63-8f2b-4439-9ec5-1bcf9a7247d3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:30:59 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3daada94-9c03-4050-92a3-53007af09691
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-pn-quizzical-tharp","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    body: '{"name":"tf-pn-great-hugle","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -1371,18 +1239,18 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1390,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d094a90-4344-48e1-8c0a-469a6ac1a9f1
+      - 2aa2ce8f-6d3e-4595-8d57-0072b2e5cdc4
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,21 +1269,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:03:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1423,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d364fddc-0218-4f53-9ffb-130d03172861
+      - 7a49f844-102b-4b40-a28d-c2105ce6e171
     status: 200 OK
     code: 200
     duration: ""
@@ -1434,21 +1302,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "284"
+      - "285"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:03:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1456,7 +1324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bab57dc9-9ce0-4ace-9d10-4184cc7fd421
+      - b26c2c7d-ee2a-4493-b1e4-0257dd8296dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1467,7 +1335,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/d14324c2-540d-4fca-b690-c381f6be6887
     method: DELETE
   response:
     body: ""
@@ -1477,9 +1345,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:03:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1487,7 +1355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb6a80e4-00b1-4f2e-81a1-85877ea571e0
+      - 94da81f2-eb6d-405e-b601-bd1fc304eaa1
     status: 204 No Content
     code: 204
     duration: ""
@@ -1498,21 +1366,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"direct_access":{},"id":"b81a9287-9c0b-4e1d-b971-5ec76fdc7ed9","ip":"163.172.158.98","name":null,"port":5432}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[{"direct_access":{},"id":"d14324c2-540d-4fca-b690-c381f6be6887","ip":"163.172.172.221","name":null,"port":5432}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
-      - "290"
+      - "291"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:00 GMT
+      - Fri, 23 Feb 2024 14:03:50 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1520,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 92b5bd7c-f464-4e71-85b6-6399dc93de3b
+      - c5676fb7-047b-47a8-b114-fe3c5c4083b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,10 +1399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -1543,9 +1411,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:30 GMT
+      - Fri, 23 Feb 2024 14:04:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1553,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac8c05b6-85f5-4d76-a221-49c5b695753c
+      - 080f1bb1-07fd-4a3f-8662-019d458c475e
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,10 +1432,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -1576,9 +1444,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:31 GMT
+      - Fri, 23 Feb 2024 14:04:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1586,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f407c4b-673f-4f09-bc00-3437363786db
+      - a2c18b97-1366-4d83-98a1-db0a41fd5036
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,10 +1465,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -1609,9 +1477,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:31 GMT
+      - Fri, 23 Feb 2024 14:04:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1619,12 +1487,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39e1e9f5-aec1-4445-a20e-0b6cf91641ca
+      - a2a2660c-75bf-4f36-962a-a233b95f17cd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20"}}]}'
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20"}}]}'
     form: {}
     headers:
       Content-Type:
@@ -1632,10 +1500,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -1644,9 +1512,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:31 GMT
+      - Fri, 23 Feb 2024 14:04:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1654,7 +1522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc816bb8-2cb7-427b-9ab1-05560bbbd5d9
+      - 07820cad-d2bf-4a87-8972-e93391d83e5b
     status: 200 OK
     code: 200
     duration: ""
@@ -1665,10 +1533,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -1677,9 +1545,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:31:31 GMT
+      - Fri, 23 Feb 2024 14:04:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1687,7 +1555,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 426ee88c-5180-4900-9cb0-093666c383a4
+      - 26d5292a-0a17-4e2f-8db2-b82adee4e4f8
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,10 +1566,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -1710,9 +1578,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:01 GMT
+      - Fri, 23 Feb 2024 14:04:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1720,7 +1588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a8bd08b-ec70-4cc7-afda-d81d23f2e9f7
+      - 40f99009-f95f-4acb-ba3f-7c14b22b7e6d
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,10 +1599,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -1743,9 +1611,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:02 GMT
+      - Fri, 23 Feb 2024 14:04:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1753,7 +1621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2463b219-7845-4628-b197-896601996e26
+      - f9d00cbb-b108-4b1d-ba5a-39ea97a376d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,7 +1632,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1776,9 +1644,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:02 GMT
+      - Fri, 23 Feb 2024 14:04:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1786,7 +1654,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f2197aa-8022-424b-b09b-8f9743522994
+      - 4fe3c19d-db2e-4866-bba9-b7bae3188281
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,10 +1665,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -1809,9 +1677,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:02 GMT
+      - Fri, 23 Feb 2024 14:04:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1819,7 +1687,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1880d99a-8f4b-4c58-a031-bb70b40680a0
+      - 306ef68c-a425-4932-a6aa-1a3ad4de08bd
     status: 200 OK
     code: 200
     duration: ""
@@ -1830,21 +1698,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:02 GMT
+      - Fri, 23 Feb 2024 14:04:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1852,7 +1720,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ae56bba-802d-4ab7-9f8b-69896217aa02
+      - 5b35de92-baa9-4ff6-89ba-e14a8540c6f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1863,21 +1731,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1672"
+      - "1670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:02 GMT
+      - Fri, 23 Feb 2024 14:04:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1885,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d453d3b5-2f41-4b15-9d7a-4385fffcdcdf
+      - b8d32b1d-424d-475d-ac83-b7e9745c4770
     status: 200 OK
     code: 200
     duration: ""
@@ -1896,21 +1764,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:02 GMT
+      - Fri, 23 Feb 2024 14:04:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1918,7 +1786,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 828d4367-29d1-41fb-a788-8036503d7626
+      - 0e7e665b-175e-4c6f-b294-eba8282cb530
     status: 200 OK
     code: 200
     duration: ""
@@ -1929,7 +1797,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "388"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 29a0bbf8-94b2-4cbc-b0d5-81a3667fb40d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -1941,9 +1842,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:02 GMT
+      - Fri, 23 Feb 2024 14:04:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1951,7 +1852,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f87cc1f-419f-4f8c-b24d-1b9dae46f182
+      - 4801ed6c-b4b4-43d5-897d-428c74b99459
     status: 200 OK
     code: 200
     duration: ""
@@ -1962,10 +1863,109 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9c6be0ac-44c9-4a89-a165-fee4ebef464e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - da4926ca-5358-4f3a-addd-d159933fc463
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2009"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2d7b7f34-2c6d-4e09-8b3c-424e1daefa6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -1974,9 +1974,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:03 GMT
+      - Fri, 23 Feb 2024 14:04:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1984,7 +1984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71174597-b50e-43f3-a376-66a85a59d8ab
+      - a6e64ca2-51ca-4129-9523-ab60341fa7a8
     status: 200 OK
     code: 200
     duration: ""
@@ -1995,7 +1995,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -2007,9 +2007,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:03 GMT
+      - Fri, 23 Feb 2024 14:04:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2017,7 +2017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8534c099-6634-4229-b2df-5fa790699dcc
+      - 111d3bbd-76fe-439f-8dba-d95b936bc12d
     status: 200 OK
     code: 200
     duration: ""
@@ -2028,142 +2028,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4b0139a2-fcd0-41b9-9b77-dcb66501cd6e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de03633b-6449-417c-9aef-449a4118ccfa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2013"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 358393cc-6a8d-4c53-a881-5dd409682446
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff3f0ca4-7082-4a2d-a99e-395ecc40c6a5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -2172,9 +2040,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:03 GMT
+      - Fri, 23 Feb 2024 14:04:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2182,7 +2050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 90eb8a8a-0406-4103-aa12-f550a7f61021
+      - 1f64c79e-185a-4229-9702-c755dc1e90b3
     status: 200 OK
     code: 200
     duration: ""
@@ -2193,73 +2061,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 63537015-807d-4355-a2f8-99aa234491ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "388"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:32:04 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1107fd6e-6240-455c-bde3-e352729049fa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/3bbdcd2b-3a6f-431e-9398-07b80c149569
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/dffe3a4d-81da-4ecf-9737-bcf58351c36c
     method: DELETE
   response:
     body: ""
@@ -2269,9 +2071,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:04 GMT
+      - Fri, 23 Feb 2024 14:04:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2279,7 +2081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b799292-8c87-441a-8140-f913e9aa185e
+      - 24446202-b1e5-46ca-a14e-0db93ea65816
     status: 204 No Content
     code: 204
     duration: ""
@@ -2290,10 +2092,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3bbdcd2b-3a6f-431e-9398-07b80c149569","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[{"id":"dffe3a4d-81da-4ecf-9737-bcf58351c36c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
       - "394"
@@ -2302,9 +2104,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:04 GMT
+      - Fri, 23 Feb 2024 14:04:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2312,7 +2114,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 414e46b6-9158-4a1a-b0a8-6db71b59804f
+      - c9db5d8d-4080-4b59-9758-791245ab4a41
     status: 200 OK
     code: 200
     duration: ""
@@ -2323,10 +2125,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -2335,9 +2137,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:34 GMT
+      - Fri, 23 Feb 2024 14:05:26 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2345,7 +2147,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60212ca1-03d1-4607-89ca-3e1d5e180cdf
+      - 37cdc9ff-58cb-4cd3-9dc2-930ffba153a9
     status: 200 OK
     code: 200
     duration: ""
@@ -2356,10 +2158,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -2368,9 +2170,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:34 GMT
+      - Fri, 23 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2378,12 +2180,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8606a8ce-e19e-4ee2-87c5-400309d4de7d
+      - 22a1b291-67fa-48a8-8aac-ffa08e0f8420
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","ipam_config":{}}}]}'
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","ipam_config":{}}}]}'
     form: {}
     headers:
       Content-Type:
@@ -2391,10 +2193,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "399"
@@ -2403,9 +2205,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:35 GMT
+      - Fri, 23 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2413,7 +2215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4b901e1-3408-4750-aab5-c5b8778e4fe0
+      - 455ce728-0b71-4ec3-8220-3cd1f210524b
     status: 200 OK
     code: 200
     duration: ""
@@ -2424,10 +2226,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "399"
@@ -2436,9 +2238,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:32:35 GMT
+      - Fri, 23 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2446,7 +2248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04f9f3a5-46e5-4c88-b559-cb92a1f7f298
+      - e47938fe-130c-4687-b746-f490784c96f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2457,10 +2259,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -2469,9 +2271,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:05 GMT
+      - Fri, 23 Feb 2024 14:05:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2479,7 +2281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50d191b6-d320-4423-9c62-851394fc9d89
+      - c48397d6-a51d-4c12-b184-a0f0ada0d424
     status: 200 OK
     code: 200
     duration: ""
@@ -2490,10 +2292,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -2502,9 +2304,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:05 GMT
+      - Fri, 23 Feb 2024 14:05:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2512,7 +2314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99963b43-ee12-405e-91ef-fbf6b999f40d
+      - 178042a4-ec1c-4008-9116-40ee8a2f37ca
     status: 200 OK
     code: 200
     duration: ""
@@ -2523,10 +2325,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.88.3/22","created_at":"2024-02-21T18:32:35.023360Z","id":"cbd2a836-9432-463e-bc18-bd5500965540","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:17","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:32:36.158076Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.36.3/22","created_at":"2024-02-23T14:05:28.122588Z","id":"6b6792d8-bed9-4cd6-b32d-b63ae7c4c8f7","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"437e0d18-ee40-47db-954a-a43176faa05d","mac_address":"02:00:00:18:94:E1","name":"read-replica-d9b1bbbd","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:05:29.133221Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -2535,9 +2337,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:05 GMT
+      - Fri, 23 Feb 2024 14:05:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2545,7 +2347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f089ad3e-bd1d-4260-8dc1-1ef330cd45f3
+      - 92594270-4046-4f61-9512-e827134245e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2556,10 +2358,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -2568,9 +2370,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2578,7 +2380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12f0a586-3552-4c2e-8678-88a86d977082
+      - 60ae1fe6-4652-4cb6-8fa3-563afe7bfa2a
     status: 200 OK
     code: 200
     duration: ""
@@ -2589,21 +2391,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2611,7 +2413,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18cb6cdc-175a-4293-a7ac-c8aa5d6ae60b
+      - 0476fc49-c188-4eea-8fa3-be0b50ad8056
     status: 200 OK
     code: 200
     duration: ""
@@ -2622,21 +2424,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1676"
+      - "1674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2644,7 +2446,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00809ff0-74ad-4373-927b-7083d4a485c9
+      - 4e2e212d-0f7c-4d12-8fe7-901b14ccd3d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2655,21 +2457,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2677,7 +2479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a33f2786-ba07-4084-bb87-77e34cd5d7bf
+      - 336f0aaf-6aaa-4fe2-9793-6b778c84f145
     status: 200 OK
     code: 200
     duration: ""
@@ -2688,43 +2490,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.88.3/22","created_at":"2024-02-21T18:32:35.023360Z","id":"cbd2a836-9432-463e-bc18-bd5500965540","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:17","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:32:36.158076Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "548"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a699004-a981-4ec9-922a-2c349d7daebb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -2733,9 +2502,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2743,7 +2512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f433526-a17a-43a6-bc7a-011589a17c5a
+      - c16923ff-488d-425b-a49a-f5a64e10c9d5
     status: 200 OK
     code: 200
     duration: ""
@@ -2754,10 +2523,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.88.3/22","created_at":"2024-02-21T18:32:35.023360Z","id":"cbd2a836-9432-463e-bc18-bd5500965540","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:17","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:32:36.158076Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.36.3/22","created_at":"2024-02-23T14:05:28.122588Z","id":"6b6792d8-bed9-4cd6-b32d-b63ae7c4c8f7","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"437e0d18-ee40-47db-954a-a43176faa05d","mac_address":"02:00:00:18:94:E1","name":"read-replica-d9b1bbbd","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:05:29.133221Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -2766,9 +2535,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2776,7 +2545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff26372d-ccb1-4cce-b31a-1070543465ef
+      - fe7a8041-abc3-4b6a-9c3b-7af7bde9681d
     status: 200 OK
     code: 200
     duration: ""
@@ -2787,21 +2556,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2809,7 +2578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3aaa4ff9-4004-4d30-a155-4654fee304a3
+      - 4482ca0c-1303-4970-863a-25158d03c54f
     status: 200 OK
     code: 200
     duration: ""
@@ -2820,21 +2589,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1676"
+      - "1674"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2842,7 +2611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18c4fcc8-b865-4397-bec3-e8aa58c1bbb7
+      - ebbe0ec4-d4dc-4a3d-853f-50bae35a9cf4
     status: 200 OK
     code: 200
     duration: ""
@@ -2853,21 +2622,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:06 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2875,7 +2644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a8941ecb-58ff-4239-b5a6-c1e26df96c10
+      - 400bef74-afe7-46ab-80c9-cc08a694b768
     status: 200 OK
     code: 200
     duration: ""
@@ -2886,43 +2655,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.88.3/22","created_at":"2024-02-21T18:32:35.023360Z","id":"cbd2a836-9432-463e-bc18-bd5500965540","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:17","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:32:36.158076Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "548"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:33:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 45f1d2fb-05d6-49c5-96f1-7ee5334d9b56
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -2931,9 +2667,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:07 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2941,7 +2677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3230689-4e29-4c45-ae43-75a4a894bd1c
+      - 4d2d6305-2e10-4dc0-bd57-0f64f5c61811
     status: 200 OK
     code: 200
     duration: ""
@@ -2952,10 +2688,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.88.3/22","created_at":"2024-02-21T18:32:35.023360Z","id":"cbd2a836-9432-463e-bc18-bd5500965540","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:17","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:32:36.158076Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.36.3/22","created_at":"2024-02-23T14:05:28.122588Z","id":"6b6792d8-bed9-4cd6-b32d-b63ae7c4c8f7","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"437e0d18-ee40-47db-954a-a43176faa05d","mac_address":"02:00:00:18:94:E1","name":"read-replica-d9b1bbbd","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:05:29.133221Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "548"
@@ -2964,9 +2700,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:07 GMT
+      - Fri, 23 Feb 2024 14:05:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2974,12 +2710,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e86a08d-96ed-4f5f-b7ae-6acd754d5962
+      - 20bd6cee-cec3-4fcd-a089-a12e05ea2ca2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-intelligent-bouman","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    body: '{"name":"tf-pn-goofy-heyrovsky","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -2990,18 +2726,18 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-02-21T18:33:07.405006Z","dhcp_enabled":true,"id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","name":"tf-pn-intelligent-bouman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:33:07.405006Z","id":"65905f29-b8cb-4b1d-8180-771f8fde65c8","subnet":"172.16.104.0/22","updated_at":"2024-02-21T18:33:07.405006Z"},{"created_at":"2024-02-21T18:33:07.405006Z","id":"ada0c678-efd3-44a4-afdc-d6c754b83bae","subnet":"fd5f:519c:6d46:7636::/64","updated_at":"2024-02-21T18:33:07.405006Z"}],"tags":[],"updated_at":"2024-02-21T18:33:07.405006Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:06:00.106602Z","dhcp_enabled":true,"id":"15c23453-3acd-42b8-bc30-3b886ac85bea","name":"tf-pn-goofy-heyrovsky","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:06:00.106602Z","id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4","subnet":"172.16.8.0/22","updated_at":"2024-02-23T14:06:00.106602Z"},{"created_at":"2024-02-23T14:06:00.106602Z","id":"579bda71-cc35-4314-a786-4fbd749960ce","subnet":"fd63:256c:45f7:523c::/64","updated_at":"2024-02-23T14:06:00.106602Z"}],"tags":[],"updated_at":"2024-02-23T14:06:00.106602Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:07 GMT
+      - Fri, 23 Feb 2024 14:06:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3009,7 +2745,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3ff1193-947a-4a74-8b2b-c2515b4a3f4f
+      - 1e40ced9-d7c6-4508-87c3-ec8e59c2d365
     status: 200 OK
     code: 200
     duration: ""
@@ -3020,21 +2756,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b7b9c370-4bc5-4ddc-aaee-2813d8048b45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/15c23453-3acd-42b8-bc30-3b886ac85bea
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:33:07.405006Z","dhcp_enabled":true,"id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","name":"tf-pn-intelligent-bouman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:33:07.405006Z","id":"65905f29-b8cb-4b1d-8180-771f8fde65c8","subnet":"172.16.104.0/22","updated_at":"2024-02-21T18:33:07.405006Z"},{"created_at":"2024-02-21T18:33:07.405006Z","id":"ada0c678-efd3-44a4-afdc-d6c754b83bae","subnet":"fd5f:519c:6d46:7636::/64","updated_at":"2024-02-21T18:33:07.405006Z"}],"tags":[],"updated_at":"2024-02-21T18:33:07.405006Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:06:00.106602Z","dhcp_enabled":true,"id":"15c23453-3acd-42b8-bc30-3b886ac85bea","name":"tf-pn-goofy-heyrovsky","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:06:00.106602Z","id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4","subnet":"172.16.8.0/22","updated_at":"2024-02-23T14:06:00.106602Z"},{"created_at":"2024-02-23T14:06:00.106602Z","id":"579bda71-cc35-4314-a786-4fbd749960ce","subnet":"fd63:256c:45f7:523c::/64","updated_at":"2024-02-23T14:06:00.106602Z"}],"tags":[],"updated_at":"2024-02-23T14:06:00.106602Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:08 GMT
+      - Fri, 23 Feb 2024 14:06:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3042,7 +2778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 032da1eb-7c2f-4931-b771-e26a9f709cb8
+      - 6ed7702f-8be0-4f1e-a2f4-6d90938c1679
     status: 200 OK
     code: 200
     duration: ""
@@ -3053,10 +2789,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "392"
@@ -3065,9 +2801,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:10 GMT
+      - Fri, 23 Feb 2024 14:06:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3075,7 +2811,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f870bfc9-ff1f-47b9-8937-d6a91fb73b80
+      - 5f7ca634-be46-4414-a609-e68a9efe7c40
     status: 200 OK
     code: 200
     duration: ""
@@ -3086,7 +2822,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/13aabc68-d126-428a-a4d8-0da29c56caba
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/a3bbbe40-368e-4d67-8792-8b48824cee53
     method: DELETE
   response:
     body: ""
@@ -3096,9 +2832,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:15 GMT
+      - Fri, 23 Feb 2024 14:06:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3106,7 +2842,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8db55ee-683e-440a-bf66-bd2f97d2f9fa
+      - 3384856e-e21f-4c07-8e01-d793e5315e4f
     status: 204 No Content
     code: 204
     duration: ""
@@ -3117,10 +2853,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"13aabc68-d126-428a-a4d8-0da29c56caba","ip":"172.16.88.3","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"172.16.88.3/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[{"id":"a3bbbe40-368e-4d67-8792-8b48824cee53","ip":"172.16.36.3","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"172.16.36.3/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
       - "398"
@@ -3129,9 +2865,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:16 GMT
+      - Fri, 23 Feb 2024 14:06:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3139,7 +2875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a5bfe8e-aed7-49f2-adec-13d36aecd939
+      - 5bf8eb17-cd94-47b9-ad5f-81bacc66b2cc
     status: 200 OK
     code: 200
     duration: ""
@@ -3150,10 +2886,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -3162,9 +2898,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:50 GMT
+      - Fri, 23 Feb 2024 14:06:31 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3172,7 +2908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ca27db9-c623-4b4f-9ac5-d665687f6f46
+      - d6ba38ce-4732-417b-a3b2-384feb33637d
     status: 200 OK
     code: 200
     duration: ""
@@ -3183,10 +2919,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -3195,9 +2931,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:51 GMT
+      - Fri, 23 Feb 2024 14:06:31 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3205,12 +2941,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99dfc97a-ab99-4fc0-bdee-fe1e103aa61b
+      - 55d89b74-367f-4879-a133-bfe421b88729
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","ipam_config":{}}}]}'
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","ipam_config":{}}}]}'
     form: {}
     headers:
       Content-Type:
@@ -3218,21 +2954,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "401"
+      - "397"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:51 GMT
+      - Fri, 23 Feb 2024 14:06:32 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3240,7 +2976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f262877-687e-41a0-bec3-c0357827f0d2
+      - d4e5ac33-0b14-4625-9e31-e9a81d2d93ea
     status: 200 OK
     code: 200
     duration: ""
@@ -3251,21 +2987,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
-      - "401"
+      - "397"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:33:52 GMT
+      - Fri, 23 Feb 2024 14:06:32 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3273,7 +3009,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 711d5c1f-f522-4d75-966c-66418ffc4082
+      - ad9b54e9-5219-4c86-a583-53ce2b3c08c4
     status: 200 OK
     code: 200
     duration: ""
@@ -3284,21 +3020,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "394"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:22 GMT
+      - Fri, 23 Feb 2024 14:07:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3306,7 +3042,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b6844ac-d2c1-4f76-a91b-eb4b20dc5006
+      - edf5ecc9-4895-4be9-a9f0-0d3886d7398b
     status: 200 OK
     code: 200
     duration: ""
@@ -3317,21 +3053,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "394"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:24 GMT
+      - Fri, 23 Feb 2024 14:07:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3339,7 +3075,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 712e2870-dfa5-4f95-b5e7-1d9dbc416c21
+      - afb20a6b-929a-45ec-b171-85b9a2dc141d
     status: 200 OK
     code: 200
     duration: ""
@@ -3350,21 +3086,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.104.2/22","created_at":"2024-02-21T18:33:51.582006Z","id":"02fe5ab1-60ca-4748-a1ba-68777020d717","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:1A","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"65905f29-b8cb-4b1d-8180-771f8fde65c8"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:33:52.854506Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.8.2/22","created_at":"2024-02-23T14:06:31.759145Z","id":"7b80777b-977e-4b2f-8376-c55f2e7d87fb","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"437e0d18-ee40-47db-954a-a43176faa05d","mac_address":"02:00:00:18:94:E2","name":"read-replica-d9b1bbbd","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:06:32.895427Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "549"
+      - "547"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:24 GMT
+      - Fri, 23 Feb 2024 14:07:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3372,7 +3108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e519aa3-335e-4948-b899-fcb7b1d81406
+      - 42bfe045-03af-4566-b9c5-279e4fc2e05f
     status: 200 OK
     code: 200
     duration: ""
@@ -3383,21 +3119,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "394"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:24 GMT
+      - Fri, 23 Feb 2024 14:07:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3405,7 +3141,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f243649-fb0c-41fb-b397-9199e63e85b7
+      - 05b550ea-1cc6-438c-87e1-d7d867cce192
     status: 200 OK
     code: 200
     duration: ""
@@ -3416,21 +3152,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b7b9c370-4bc5-4ddc-aaee-2813d8048b45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/15c23453-3acd-42b8-bc30-3b886ac85bea
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:33:07.405006Z","dhcp_enabled":true,"id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","name":"tf-pn-intelligent-bouman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:33:07.405006Z","id":"65905f29-b8cb-4b1d-8180-771f8fde65c8","subnet":"172.16.104.0/22","updated_at":"2024-02-21T18:33:07.405006Z"},{"created_at":"2024-02-21T18:33:07.405006Z","id":"ada0c678-efd3-44a4-afdc-d6c754b83bae","subnet":"fd5f:519c:6d46:7636::/64","updated_at":"2024-02-21T18:33:07.405006Z"}],"tags":[],"updated_at":"2024-02-21T18:33:07.405006Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:06:00.106602Z","dhcp_enabled":true,"id":"15c23453-3acd-42b8-bc30-3b886ac85bea","name":"tf-pn-goofy-heyrovsky","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:06:00.106602Z","id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4","subnet":"172.16.8.0/22","updated_at":"2024-02-23T14:06:00.106602Z"},{"created_at":"2024-02-23T14:06:00.106602Z","id":"579bda71-cc35-4314-a786-4fbd749960ce","subnet":"fd63:256c:45f7:523c::/64","updated_at":"2024-02-23T14:06:00.106602Z"}],"tags":[],"updated_at":"2024-02-23T14:06:00.106602Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:24 GMT
+      - Fri, 23 Feb 2024 14:07:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3438,7 +3174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7da82bf8-90bc-4d22-820d-464e176f0668
+      - ae847113-655d-47a9-9195-8031d23015b6
     status: 200 OK
     code: 200
     duration: ""
@@ -3449,21 +3185,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:24 GMT
+      - Fri, 23 Feb 2024 14:07:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3471,7 +3207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 287921cd-a7af-40f2-b193-1d8c99c9a357
+      - 03554330-1b6a-4d8a-a6c4-6360bdd81ca4
     status: 200 OK
     code: 200
     duration: ""
@@ -3482,21 +3218,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1678"
+      - "1672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:24 GMT
+      - Fri, 23 Feb 2024 14:07:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3504,7 +3240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee48e834-b311-4c69-8831-f816d4f79240
+      - 6e60783b-123a-4957-8b9c-9d37d2fcb1c8
     status: 200 OK
     code: 200
     duration: ""
@@ -3515,21 +3251,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:25 GMT
+      - Fri, 23 Feb 2024 14:07:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3537,7 +3273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47ce9d74-b5c6-4497-8a28-46db7dd7c6e4
+      - 2ee482c2-305c-4c6b-91f1-ef4fa614efb0
     status: 200 OK
     code: 200
     duration: ""
@@ -3548,21 +3284,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.104.2/22","created_at":"2024-02-21T18:33:51.582006Z","id":"02fe5ab1-60ca-4748-a1ba-68777020d717","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:1A","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"65905f29-b8cb-4b1d-8180-771f8fde65c8"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:33:52.854506Z","zone":null}],"total_count":1}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "549"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:25 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3570,7 +3306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef597682-0ebc-411f-94a1-2c983f6272b9
+      - 1a349d1d-2de7-491d-a583-d377e0fd339b
     status: 200 OK
     code: 200
     duration: ""
@@ -3581,21 +3317,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"ips":[{"address":"172.16.8.2/22","created_at":"2024-02-23T14:06:31.759145Z","id":"7b80777b-977e-4b2f-8376-c55f2e7d87fb","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"437e0d18-ee40-47db-954a-a43176faa05d","mac_address":"02:00:00:18:94:E2","name":"read-replica-d9b1bbbd","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:06:32.895427Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "394"
+      - "547"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:25 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3603,7 +3339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a71fb40-8d8c-4c9d-b5a8-a89ded9a6118
+      - e7493fa2-e3b3-49ae-abbd-5ebb1d9ed2fc
     status: 200 OK
     code: 200
     duration: ""
@@ -3614,21 +3350,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/15c23453-3acd-42b8-bc30-3b886ac85bea
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.104.2/22","created_at":"2024-02-21T18:33:51.582006Z","id":"02fe5ab1-60ca-4748-a1ba-68777020d717","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:1A","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"65905f29-b8cb-4b1d-8180-771f8fde65c8"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:33:52.854506Z","zone":null}],"total_count":1}'
+    body: '{"created_at":"2024-02-23T14:06:00.106602Z","dhcp_enabled":true,"id":"15c23453-3acd-42b8-bc30-3b886ac85bea","name":"tf-pn-goofy-heyrovsky","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:06:00.106602Z","id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4","subnet":"172.16.8.0/22","updated_at":"2024-02-23T14:06:00.106602Z"},{"created_at":"2024-02-23T14:06:00.106602Z","id":"579bda71-cc35-4314-a786-4fbd749960ce","subnet":"fd63:256c:45f7:523c::/64","updated_at":"2024-02-23T14:06:00.106602Z"}],"tags":[],"updated_at":"2024-02-23T14:06:00.106602Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "549"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:25 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3636,7 +3372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 324d5e64-fd4f-4a16-9f17-fb1617e547b4
+      - b93ba536-77c8-4a17-9022-5e47e28b44fa
     status: 200 OK
     code: 200
     duration: ""
@@ -3647,21 +3383,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:25 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3669,7 +3405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b96d531-ae9c-4779-b015-371f616c18d9
+      - 0667edcb-e0f4-49c1-8e8b-a99c6f5d5aa0
     status: 200 OK
     code: 200
     duration: ""
@@ -3680,21 +3416,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b7b9c370-4bc5-4ddc-aaee-2813d8048b45
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:33:07.405006Z","dhcp_enabled":true,"id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","name":"tf-pn-intelligent-bouman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:33:07.405006Z","id":"65905f29-b8cb-4b1d-8180-771f8fde65c8","subnet":"172.16.104.0/22","updated_at":"2024-02-21T18:33:07.405006Z"},{"created_at":"2024-02-21T18:33:07.405006Z","id":"ada0c678-efd3-44a4-afdc-d6c754b83bae","subnet":"fd5f:519c:6d46:7636::/64","updated_at":"2024-02-21T18:33:07.405006Z"}],"tags":[],"updated_at":"2024-02-21T18:33:07.405006Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "726"
+      - "1672"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:25 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3702,7 +3438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e91cccac-9fd7-4c7d-b44b-f46c9d572588
+      - 3e6fcd83-12bf-4357-88ff-0bfebd7f5d9c
     status: 200 OK
     code: 200
     duration: ""
@@ -3713,21 +3449,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1678"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:25 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3735,7 +3471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e6ac610-0e5b-4a28-a514-c51830014620
+      - 76cd7599-6c90-4401-8e9c-a3a7c0a751e3
     status: 200 OK
     code: 200
     duration: ""
@@ -3746,21 +3482,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "2013"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:26 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3768,7 +3504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a4f3858-68e7-416c-8993-17a6c9133053
+      - b1a256f2-f3ca-421e-a5e8-00b5cbfff596
     status: 200 OK
     code: 200
     duration: ""
@@ -3779,21 +3515,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.104.2/22","created_at":"2024-02-21T18:33:51.582006Z","id":"02fe5ab1-60ca-4748-a1ba-68777020d717","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:1A","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"65905f29-b8cb-4b1d-8180-771f8fde65c8"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:33:52.854506Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.8.2/22","created_at":"2024-02-23T14:06:31.759145Z","id":"7b80777b-977e-4b2f-8376-c55f2e7d87fb","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"437e0d18-ee40-47db-954a-a43176faa05d","mac_address":"02:00:00:18:94:E2","name":"read-replica-d9b1bbbd","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:06:32.895427Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "549"
+      - "547"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:26 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3801,7 +3537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 896da16f-818c-4011-82ef-e45e8e7799b3
+      - f68b77ee-01a8-4559-9c3b-26887d9da4d4
     status: 200 OK
     code: 200
     duration: ""
@@ -3812,21 +3548,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
-      - "394"
+      - "390"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:26 GMT
+      - Fri, 23 Feb 2024 14:07:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3834,7 +3570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ba30cbc-e2f0-47e1-9cb5-8b591af9197c
+      - 3afce6f7-2ad8-41be-9697-8c74c15385d4
     status: 200 OK
     code: 200
     duration: ""
@@ -3845,73 +3581,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[{"address":"172.16.104.2/22","created_at":"2024-02-21T18:33:51.582006Z","id":"02fe5ab1-60ca-4748-a1ba-68777020d717","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"da68cc82-6010-4167-a577-034bee58968a","mac_address":"02:00:00:18:8A:1A","name":"read-replica-17f0cfa6","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"65905f29-b8cb-4b1d-8180-771f8fde65c8"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-21T18:33:52.854506Z","zone":null}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "549"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:34:26 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fe3330b0-c6b2-4662-8eaa-c39cca4c742b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "394"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:34:31 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 47b9e164-a00d-4704-b70c-cf2b2c818960
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/3783a293-9d1e-412a-971c-5b24fcdd56ce
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/8e6dd179-c00e-4eb0-a55e-7416d6b4e534
     method: DELETE
   response:
     body: ""
@@ -3921,9 +3591,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:31 GMT
+      - Fri, 23 Feb 2024 14:07:04 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3931,7 +3601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cf86d12-fa3e-4267-8eda-81cd763beab9
+      - b149d4fb-15bd-4fb7-aad8-f422c6352cfd
     status: 204 No Content
     code: 204
     duration: ""
@@ -3942,21 +3612,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"3783a293-9d1e-412a-971c-5b24fcdd56ce","ip":"172.16.104.2","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"172.16.104.2/22","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[{"id":"8e6dd179-c00e-4eb0-a55e-7416d6b4e534","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
-      - "400"
+      - "396"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:34:31 GMT
+      - Fri, 23 Feb 2024 14:07:04 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3964,7 +3634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7552839-146d-4d4b-bdba-177259596549
+      - 0df73104-3d19-4dc9-82e6-d441b02e8c2e
     status: 200 OK
     code: 200
     duration: ""
@@ -3975,10 +3645,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -3987,9 +3657,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:01 GMT
+      - Fri, 23 Feb 2024 14:07:34 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3997,7 +3667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 863dc7c6-d674-4459-aec0-7e76802521db
+      - 6495b162-0e4b-4cd6-9874-c70a377449aa
     status: 200 OK
     code: 200
     duration: ""
@@ -4008,10 +3678,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -4020,9 +3690,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:01 GMT
+      - Fri, 23 Feb 2024 14:07:34 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4030,12 +3700,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10ddaf42-fc2b-4e12-8f63-2e17bf19f5f3
+      - 88d399ad-b3e7-4f97-ab93-c19f069e039a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20"}}]}'
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20"}}]}'
     form: {}
     headers:
       Content-Type:
@@ -4043,10 +3713,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -4055,9 +3725,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:02 GMT
+      - Fri, 23 Feb 2024 14:07:34 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4065,7 +3735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b298b5a-32e8-4b03-add6-585fa674e17e
+      - 3451eb00-0a33-41f6-aff9-190b59789474
     status: 200 OK
     code: 200
     duration: ""
@@ -4076,10 +3746,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -4088,9 +3758,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:02 GMT
+      - Fri, 23 Feb 2024 14:07:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4098,7 +3768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ada72cf-5893-46b8-8062-c6df6c857a72
+      - 73cde6c4-4170-492b-a50a-1faa08fb1c33
     status: 200 OK
     code: 200
     duration: ""
@@ -4109,10 +3779,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -4121,9 +3791,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:33 GMT
+      - Fri, 23 Feb 2024 14:08:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4131,7 +3801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67a20242-5b16-4bb1-aaf2-34b090f0fc97
+      - f8973e64-e042-4411-b6cb-7d3ac749dbd1
     status: 200 OK
     code: 200
     duration: ""
@@ -4142,10 +3812,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -4154,9 +3824,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:33 GMT
+      - Fri, 23 Feb 2024 14:08:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4164,7 +3834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27ae4661-2aeb-4cf0-b47a-d47e39f4489c
+      - c7fc2836-589a-4240-bbe4-8535d55366da
     status: 200 OK
     code: 200
     duration: ""
@@ -4175,7 +3845,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -4187,9 +3857,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:33 GMT
+      - Fri, 23 Feb 2024 14:08:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4197,7 +3867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc4b4e02-c5e8-4ebf-ade3-385a64ea1d49
+      - 34f4abeb-c7f2-4a3c-932d-db49135d7b71
     status: 200 OK
     code: 200
     duration: ""
@@ -4208,10 +3878,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -4220,9 +3890,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:33 GMT
+      - Fri, 23 Feb 2024 14:08:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4230,7 +3900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b18f880-ef68-4be6-980e-14721180c3d7
+      - 0cbadb9d-af59-4463-b62e-7eda10013e76
     status: 200 OK
     code: 200
     duration: ""
@@ -4241,21 +3911,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b7b9c370-4bc5-4ddc-aaee-2813d8048b45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:33:07.405006Z","dhcp_enabled":true,"id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","name":"tf-pn-intelligent-bouman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:33:07.405006Z","id":"65905f29-b8cb-4b1d-8180-771f8fde65c8","subnet":"172.16.104.0/22","updated_at":"2024-02-21T18:33:07.405006Z"},{"created_at":"2024-02-21T18:33:07.405006Z","id":"ada0c678-efd3-44a4-afdc-d6c754b83bae","subnet":"fd5f:519c:6d46:7636::/64","updated_at":"2024-02-21T18:33:07.405006Z"}],"tags":[],"updated_at":"2024-02-21T18:33:07.405006Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:33 GMT
+      - Fri, 23 Feb 2024 14:08:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4263,7 +3933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aecdfc0f-a2c7-4db9-b88f-3f8fbb1c3d9b
+      - aeccf681-1521-42c3-ab8e-211d3e07ba86
     status: 200 OK
     code: 200
     duration: ""
@@ -4274,21 +3944,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/15c23453-3acd-42b8-bc30-3b886ac85bea
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:06:00.106602Z","dhcp_enabled":true,"id":"15c23453-3acd-42b8-bc30-3b886ac85bea","name":"tf-pn-goofy-heyrovsky","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:06:00.106602Z","id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4","subnet":"172.16.8.0/22","updated_at":"2024-02-23T14:06:00.106602Z"},{"created_at":"2024-02-23T14:06:00.106602Z","id":"579bda71-cc35-4314-a786-4fbd749960ce","subnet":"fd63:256c:45f7:523c::/64","updated_at":"2024-02-23T14:06:00.106602Z"}],"tags":[],"updated_at":"2024-02-23T14:06:00.106602Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:33 GMT
+      - Fri, 23 Feb 2024 14:08:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4296,7 +3966,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96045ffb-617b-433c-b711-ffba0c1e41ed
+      - 4e35194c-2aa4-4796-94cc-5aae10ac9f45
     status: 200 OK
     code: 200
     duration: ""
@@ -4307,21 +3977,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1672"
+      - "1670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
+      - Fri, 23 Feb 2024 14:08:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4329,7 +3999,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9824756-1352-433c-9798-4ce60121e9c3
+      - 1236d66f-0f05-4102-b7b7-02974ddb2951
     status: 200 OK
     code: 200
     duration: ""
@@ -4340,21 +4010,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
+      - Fri, 23 Feb 2024 14:08:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4362,7 +4032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4874146-3c77-4119-992d-4d4350ed809c
+      - d247ed39-f672-40d3-92cf-32ad43ba6d51
     status: 200 OK
     code: 200
     duration: ""
@@ -4373,7 +4043,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "388"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:08:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0994b5a-0c5b-40d4-b8a2-82aab3c1b72f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -4385,9 +4088,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
+      - Fri, 23 Feb 2024 14:08:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4395,7 +4098,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c81afe2-1e1e-4e7e-b8cf-7cd540e3ccf2
+      - bf04f7ec-0071-450b-a908-ec561fee409c
     status: 200 OK
     code: 200
     duration: ""
@@ -4406,10 +4109,142 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "718"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:08:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 104a3d50-2550-41b8-82fa-1dfa75e9ab96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/15c23453-3acd-42b8-bc30-3b886ac85bea
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T14:06:00.106602Z","dhcp_enabled":true,"id":"15c23453-3acd-42b8-bc30-3b886ac85bea","name":"tf-pn-goofy-heyrovsky","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:06:00.106602Z","id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4","subnet":"172.16.8.0/22","updated_at":"2024-02-23T14:06:00.106602Z"},{"created_at":"2024-02-23T14:06:00.106602Z","id":"579bda71-cc35-4314-a786-4fbd749960ce","subnet":"fd63:256c:45f7:523c::/64","updated_at":"2024-02-23T14:06:00.106602Z"}],"tags":[],"updated_at":"2024-02-23T14:06:00.106602Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "721"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:08:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1dec353e-d1ef-4d29-9f12-f03762ca4909
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:08:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14c8f54a-bdf7-42d4-9737-88b6aed6b1b1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2009"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:08:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ea5f6704-b6c5-4d3c-ba2d-c3c482df53b0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -4418,9 +4253,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
+      - Fri, 23 Feb 2024 14:08:17 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4428,7 +4263,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9ba950e-5f94-492e-a488-35f38a5288e2
+      - ad10dde6-f62c-4f51-bc06-b90e20d451cf
     status: 200 OK
     code: 200
     duration: ""
@@ -4439,7 +4274,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -4451,9 +4286,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
+      - Fri, 23 Feb 2024 14:08:17 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4461,7 +4296,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac0a2f67-9318-4934-864f-0582e17c44d1
+      - f551dded-e9aa-40f1-ac2f-8f55b5498a51
     status: 200 OK
     code: 200
     duration: ""
@@ -4472,175 +4307,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "722"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5466156d-0042-4db7-a578-e8065948760a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b7b9c370-4bc5-4ddc-aaee-2813d8048b45
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-21T18:33:07.405006Z","dhcp_enabled":true,"id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","name":"tf-pn-intelligent-bouman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:33:07.405006Z","id":"65905f29-b8cb-4b1d-8180-771f8fde65c8","subnet":"172.16.104.0/22","updated_at":"2024-02-21T18:33:07.405006Z"},{"created_at":"2024-02-21T18:33:07.405006Z","id":"ada0c678-efd3-44a4-afdc-d6c754b83bae","subnet":"fd5f:519c:6d46:7636::/64","updated_at":"2024-02-21T18:33:07.405006Z"}],"tags":[],"updated_at":"2024-02-21T18:33:07.405006Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "726"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2794db7b-9f83-46e3-9593-69e8a3b7117e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1672"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7ec392a5-945d-4117-9281-4058d0b0480c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "2013"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b1e7522e-8142-4c72-84ba-42bd54403353
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:35:34 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c0477430-a3da-46eb-9e9a-6c8d9f1025be
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -4649,9 +4319,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:35 GMT
+      - Fri, 23 Feb 2024 14:08:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4659,7 +4329,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96f026a2-faa7-4ac7-ac91-a60836874147
+      - da789a7b-1e00-4dc6-b6f4-6b2fe7c5370b
     status: 200 OK
     code: 200
     duration: ""
@@ -4670,73 +4340,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:35:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0d42c0bc-a273-4e95-9ff2-18d8375ead3b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "388"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:35:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f6c31ea2-fff2-4e00-9833-5067d72ebbed
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/751eff41-8e97-4643-9880-b5c1fd210f3c
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/7f808cfd-d816-4926-96e7-65ac39c4b4a8
     method: DELETE
   response:
     body: ""
@@ -4746,9 +4350,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:35 GMT
+      - Fri, 23 Feb 2024 14:08:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4756,7 +4360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52783590-8aef-4084-8c64-9c802424f4d8
+      - ef4a2616-18f9-4046-91a3-8dbe5c5a8444
     status: 204 No Content
     code: 204
     duration: ""
@@ -4767,10 +4371,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"751eff41-8e97-4643-9880-b5c1fd210f3c","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"configuring"}'
+    body: '{"endpoints":[{"id":"7f808cfd-d816-4926-96e7-65ac39c4b4a8","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"15c23453-3acd-42b8-bc30-3b886ac85bea","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"configuring"}'
     headers:
       Content-Length:
       - "394"
@@ -4779,9 +4383,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:35:35 GMT
+      - Fri, 23 Feb 2024 14:08:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4789,7 +4393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ce848b1-7f18-4eef-8dd3-aae7e54cc083
+      - d6d4aa8b-be45-470b-a114-0799673d1e79
     status: 200 OK
     code: 200
     duration: ""
@@ -4800,10 +4404,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -4812,9 +4416,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:05 GMT
+      - Fri, 23 Feb 2024 14:08:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4822,7 +4426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a31eae36-e85c-4b1e-929e-3f2ea1f93e3a
+      - fe4aad67-8616-4d14-8826-c15f8256f9b3
     status: 200 OK
     code: 200
     duration: ""
@@ -4833,10 +4437,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "170"
@@ -4845,9 +4449,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:06 GMT
+      - Fri, 23 Feb 2024 14:08:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4855,12 +4459,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fdb0045d-151c-4373-93ff-8acddfaa5b2b
+      - 53f04fb5-5d77-4083-b1f5-f342c174d02c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20"}}]}'
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20"}}]}'
     form: {}
     headers:
       Content-Type:
@@ -4868,10 +4472,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31/endpoints
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd/endpoints
     method: POST
   response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -4880,9 +4484,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:06 GMT
+      - Fri, 23 Feb 2024 14:08:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4890,7 +4494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43cb2ace-7be2-4621-9f82-225f8ef9ae4d
+      - 92971ec5-8e2c-4bfe-a651-19841938c24c
     status: 200 OK
     code: 200
     duration: ""
@@ -4901,10 +4505,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"initializing"}'
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"initializing"}'
     headers:
       Content-Length:
       - "395"
@@ -4913,9 +4517,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:07 GMT
+      - Fri, 23 Feb 2024 14:08:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4923,7 +4527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23dab4bd-bed1-4e38-a030-117348c14b0a
+      - 28dbb683-d88a-4212-8790-b8bce7391360
     status: 200 OK
     code: 200
     duration: ""
@@ -4934,10 +4538,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -4946,9 +4550,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:37 GMT
+      - Fri, 23 Feb 2024 14:09:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge01)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4956,7 +4560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98be476b-3b74-4212-8c6d-300767640b69
+      - c7524b07-2c49-4564-afce-fe84e70c696e
     status: 200 OK
     code: 200
     duration: ""
@@ -4967,10 +4571,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -4979,9 +4583,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:37 GMT
+      - Fri, 23 Feb 2024 14:09:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4989,7 +4593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4e08fff-e9cd-463e-882b-55a3d88607e4
+      - 86d64082-dcf8-41bd-967a-d9cfdbeca59e
     status: 200 OK
     code: 200
     duration: ""
@@ -5000,7 +4604,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -5012,9 +4616,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:37 GMT
+      - Fri, 23 Feb 2024 14:09:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5022,7 +4626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e50f7675-4a00-46bb-a139-7ff73b03d735
+      - 8548d069-d25c-49ea-a550-2f4dae951528
     status: 200 OK
     code: 200
     duration: ""
@@ -5033,10 +4637,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -5045,9 +4649,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:37 GMT
+      - Fri, 23 Feb 2024 14:09:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5055,7 +4659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d94047b-4d2a-4386-afb2-1b2967b2bcab
+      - 7907dd99-a3b0-4648-a75b-1d2b2c9cfcbb
     status: 200 OK
     code: 200
     duration: ""
@@ -5066,21 +4670,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:30:59.742981Z","dhcp_enabled":true,"id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","name":"tf-pn-quizzical-tharp","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:30:59.742981Z","id":"8f912a14-6ac8-4b70-b0ab-eee8d45ca20c","subnet":"172.16.88.0/22","updated_at":"2024-02-21T18:30:59.742981Z"},{"created_at":"2024-02-21T18:30:59.742981Z","id":"ea201f06-d19f-4f6f-a3d8-7d061a4bfe58","subnet":"fd5f:519c:6d46:5c44::/64","updated_at":"2024-02-21T18:30:59.742981Z"}],"tags":[],"updated_at":"2024-02-21T18:30:59.742981Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:03:49.492966Z","dhcp_enabled":true,"id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","name":"tf-pn-great-hugle","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:03:49.492966Z","id":"ec19860c-ef49-4cda-b9e8-a44ac25238d4","subnet":"172.16.36.0/22","updated_at":"2024-02-23T14:03:49.492966Z"},{"created_at":"2024-02-23T14:03:49.492966Z","id":"9d4ddffe-fe65-4d0e-9a98-ae208ff08b8c","subnet":"fd63:256c:45f7:4300::/64","updated_at":"2024-02-23T14:03:49.492966Z"}],"tags":[],"updated_at":"2024-02-23T14:03:49.492966Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "722"
+      - "718"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:37 GMT
+      - Fri, 23 Feb 2024 14:09:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5088,7 +4692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f250332-a5f2-46d9-89f9-50457bf41633
+      - 05722d9b-1a24-4a06-80f3-0f1a57f5bc05
     status: 200 OK
     code: 200
     duration: ""
@@ -5099,21 +4703,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b7b9c370-4bc5-4ddc-aaee-2813d8048b45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/15c23453-3acd-42b8-bc30-3b886ac85bea
     method: GET
   response:
-    body: '{"created_at":"2024-02-21T18:33:07.405006Z","dhcp_enabled":true,"id":"b7b9c370-4bc5-4ddc-aaee-2813d8048b45","name":"tf-pn-intelligent-bouman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T18:33:07.405006Z","id":"65905f29-b8cb-4b1d-8180-771f8fde65c8","subnet":"172.16.104.0/22","updated_at":"2024-02-21T18:33:07.405006Z"},{"created_at":"2024-02-21T18:33:07.405006Z","id":"ada0c678-efd3-44a4-afdc-d6c754b83bae","subnet":"fd5f:519c:6d46:7636::/64","updated_at":"2024-02-21T18:33:07.405006Z"}],"tags":[],"updated_at":"2024-02-21T18:33:07.405006Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-23T14:06:00.106602Z","dhcp_enabled":true,"id":"15c23453-3acd-42b8-bc30-3b886ac85bea","name":"tf-pn-goofy-heyrovsky","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T14:06:00.106602Z","id":"cc32d8ce-0b38-49dc-9b6a-21ac6c06eeb4","subnet":"172.16.8.0/22","updated_at":"2024-02-23T14:06:00.106602Z"},{"created_at":"2024-02-23T14:06:00.106602Z","id":"579bda71-cc35-4314-a786-4fbd749960ce","subnet":"fd63:256c:45f7:523c::/64","updated_at":"2024-02-23T14:06:00.106602Z"}],"tags":[],"updated_at":"2024-02-23T14:06:00.106602Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
     headers:
       Content-Length:
-      - "726"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:37 GMT
+      - Fri, 23 Feb 2024 14:09:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5121,7 +4725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a1cd1d7-4acb-4144-b2d7-21b5d3904ae1
+      - d30343cd-2ded-4378-be31-eb132dead62a
     status: 200 OK
     code: 200
     duration: ""
@@ -5132,21 +4736,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1672"
+      - "1670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:38 GMT
+      - Fri, 23 Feb 2024 14:09:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5154,7 +4758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bb4530b-a3c7-4d13-8f78-07f6924052f7
+      - a24f9f69-c954-466b-b149-3f45f23c8422
     status: 200 OK
     code: 200
     duration: ""
@@ -5165,21 +4769,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVR0lzRDQzOUNtVDBZZ0dGWVU2TVZlMmJUVFlnd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPUzR5TURjdU1UUTRNQjRYCkRUSTBNREl5TVRFNE1qZ3pNMW9YRFRNME1ESXhPREU0TWpnek0xb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9TNHlNRGN1TVRRNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXZXeXltRlRFaVhyeC9zWFhtdHVlU3BVTEl6anAzTkN4MGpWR1ZSYlNVUk9ZdlRKMEs3TFYKOVdyYVUvWVhvVTZXdG1TQXZYQWhpS1NVRkVxczJFdE1JMm5ZbGRTenVqSW9yVVVXRUQwcW5BVm5WMkhlSlEraApNOS9NM3oxWmliY0pKVGtVbWkySXhzTXNCeUxkSGF0LzcybTRmTFN2MTUrSEVHUWw0QmdNMVFacWk4R2I2Vk5ZClpEd0QvNDRvek5mVG5DTVhHK2RCb1RRVnhxWklydm1MdVcySDdWTGVPYWVuNExkQm1rVWNXdWFDYmdCdXFicFkKSjk5N1ovM0REMXBxKzFIbW9OSi9mYk9Ub3YwNE52Q001cnpPcmRQSVgvY2ZvNkJNWmZkdTZOR2psNjh0TGVUaQpHbWNLS0tBQ2taK3ZFNkJMV1JHWTR3QjVpRnhEYjlvR3Z3SURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9TNHlNRGN1TVRRNGdqeHlkeTFrWVRZNFkyTTRNaTAyTURFd0xUUXhOamN0WVRVM055MHcKTXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5TFhCaGNpNXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9TNHlNRGN1TVRRNApnanh5ZHkxa1lUWTRZMk00TWkwMk1ERXdMVFF4TmpjdFlUVTNOeTB3TXpSaVpXVTFPRGsyT0dFdWNtUmlMbVp5CkxYQmhjaTV6WTNjdVkyeHZkV1NIQk5RdjlZK0hCRE9mejVTSEJET2Z6NVF3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFDbDVYckJoZXNwR1pSSzZvaGxxWWtXOGY4QnVGYXNJODJDbHhTZ2g5SHJwM25RTXhWMUpnS3BwR05sZgpiTXZqM21OTGZwTkdhb2VTWi9yNkM2UjZ4Q3IreW5SQ05UWmpteEtsdk5PaG0zTHlVbks5SnpkRkFIbkcxY3MrCmU5UjVrUUNRZ0grVjlTZnFiM3hxUDQydGc2Z25jWHpRZ09SYzRMdWhhVDlIbStROFcvZEpJMjcrbHNxZ1k3MXUKaFM3SlVRdXpCNS9CaExLRWx6ZE91U3N1TnY1N3NGa1FRdU9NWUZHQWp3VDZteVZYQTRmclRPdkFmVUNjUitWSwpPdVViM0k5dEZBc1R5ZjN3K2J5S0RoaEZBVTk4MXBuNkhyTDZ1Mm1kK3kzczBwWUZsVkV6NVdpK3Z3UUgrR1A4CmV4MWg3ZkpoOU5VMWVPQ2FEMTR3eDMxUVpsQT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVQ1A5enNYaXA4dzQvS3hUZys5QkYxQUx6V0RFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPUzR4TUM0eE9URXdIaGNOCk1qUXdNakl6TVRNMU9UUTNXaGNOTXpRd01qSXdNVE0xT1RRM1dqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNUxqRXdMakU1TVRDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5mSWNZZElkK3dwYUlOYnRPcGxMUGJnL1p1OXVjeWd3SzRSdEZqeXdCT2oxaUdaUkdmSHMxRUEKY0FiZmEvWFlIUU13d1N0N0ZoOG5FTnZMR1dUc1c1Z2RicFpGelBNTTN5MjV3S1NNZ1BoT1pobVQ3N0tvRWZMdQpmRnExVm5jVmxQejZKZlA4MVV1MEI2KzNyeUE3dERMdUs2Q09Ga2lrdGNodEdvUDcvbDBPdzZKUHkvd3d6KzlxCkVzQ05wMzQyWldUOTdjcWdXWkw1MEV5Q2U1cTRpY2NnN29FeGJjQlVtSEM5S3FHT0NQSUtlVlFVR1pYSi9EVTEKN211ZzdKR2lIb2VrbklpRXozVHpQWU1UMnpUdXBvbmxIdjM2TXZITGRpaElKMVFzVWxFYjJSanBvV3FwMWhTSApFUytVVE1udDJ3OVh6RnhNWDRKSkluYUZmZGJJRGs4Q0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRrdU1UQXVNVGt4Z2p4eWR5MDBNemRsTUdReE9DMWxaVFF3TFRRM1pHSXRPVFUwWVMxaE5ETXgKTnpabVlXRXdOV1F1Y21SaUxtWnlMWEJoY2k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT1M0eE1DNHhPVEdDUEhKMwpMVFF6TjJVd1pERTRMV1ZsTkRBdE5EZGtZaTA1TlRSaExXRTBNekUzTm1aaFlUQTFaQzV5WkdJdVpuSXRjR0Z5CkxuTmpkeTVqYkc5MVpJY0VvNnk3YzRjRU01OEt2NGNFTTU4S3Z6QU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWjhtRXV6RW5jcUp1UXl4cnpwbEZLcFdXalpRY245ZkhhUjg4MU9rRU92WHVQcS9qSGVPOThhZ1ZTWkV6NHo2Rwp1T3dUMnRqOFNRZzhRaTl6YjVXS3N2YlRFYmprOUpxU1NFOTdvanpOMU5Za3YvYzFmVUV3OTNvT3lhMzRBQUdXCmJyOWpsVDhjOUwza3FHOHNZQ1M1a1c4QnFlYVdPOFd2bkM4OFhZV0oycndXSWZUK2hsSXRWbnJpYkQ0cmxtYWcKWHlQRGg3bXo0emhteEw2bW9HdGx4Y0d5VFkzZGxHbDJ4YmxJSDhHR0VWa3pLeWxLbUxJZTBTc3dYdGdyV2RUcQpTYUlDaDBxQ1Yzb2dkNXRCNHRKWkZ4cXREeVBLOWpiMndPcVFrVE9Vb3gvV2Fpd2VtVTYxSFU5WGhKNGIvaUVnCi9kM2RyNXdjYXJyWTRBaHJ3VVNRVkE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2013"
+      - "2009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:38 GMT
+      - Fri, 23 Feb 2024 14:09:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5187,7 +4791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b058afb9-8644-44e6-a94d-246e56e67d09
+      - f434e621-d027-44e7-a5e5-6b4e593c7e50
     status: 200 OK
     code: 200
     duration: ""
@@ -5198,7 +4802,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "388"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:09:28 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 41336ea8-c1dd-43cf-84ec-49c4834ab9d4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=437e0d18-ee40-47db-954a-a43176faa05d&resource_type=rdb_instance
     method: GET
   response:
     body: '{"ips":[],"total_count":0}'
@@ -5210,9 +4847,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:38 GMT
+      - Fri, 23 Feb 2024 14:09:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5220,7 +4857,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 158dbdfa-35ab-4c3e-bad5-06814d2f3442
+      - 591da854-9911-40c2-bcf4-fadca299daf8
     status: 200 OK
     code: 200
     duration: ""
@@ -5231,10 +4868,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"ready"}'
     headers:
       Content-Length:
       - "388"
@@ -5243,9 +4880,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:38 GMT
+      - Fri, 23 Feb 2024 14:09:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5253,7 +4890,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd98a151-4124-4685-956d-aa3b7d94e15b
+      - d532e109-7c62-4d80-bf7d-3561d1d6a619
     status: 200 OK
     code: 200
     duration: ""
@@ -5264,76 +4901,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=da68cc82-6010-4167-a577-034bee58968a&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:36:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be3acca0-efd5-4d7b-9913-7f5579fb8249
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
-    method: GET
-  response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"ready"}'
-    headers:
-      Content-Length:
-      - "388"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:36:38 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0317abc9-b15d-41ff-a93e-d799d42dd569
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: DELETE
   response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "391"
@@ -5342,9 +4913,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:39 GMT
+      - Fri, 23 Feb 2024 14:09:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5352,7 +4923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 632d3408-3d0d-4241-aca1-25433f7eb576
+      - fef3bcac-5c64-4492-b659-a8ae77caa9b9
     status: 200 OK
     code: 200
     duration: ""
@@ -5363,10 +4934,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"endpoints":[{"id":"49037540-9a1c-4641-921f-26cdc979a8ce","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"a8e90846-d514-4239-bbe9-563ff6a55a8f","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","instance_id":"da68cc82-6010-4167-a577-034bee58968a","region":"fr-par","same_zone":true,"status":"deleting"}'
+    body: '{"endpoints":[{"id":"8528f0bf-bdb7-40f9-89b8-18c7a21b23f9","ip":"10.12.1.0","name":null,"port":5432,"private_network":{"private_network_id":"3279e5f5-1eb0-4b85-8bde-8d05b30bd863","service_ip":"10.12.1.0/20","zone":"fr-par-1"}}],"id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","instance_id":"437e0d18-ee40-47db-954a-a43176faa05d","region":"fr-par","same_zone":true,"status":"deleting"}'
     headers:
       Content-Length:
       - "391"
@@ -5375,9 +4946,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:39 GMT
+      - Fri, 23 Feb 2024 14:09:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5385,7 +4956,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a79ae37f-7068-42d9-8812-d1e4f21bd80a
+      - ba971e8e-3e40-4f3d-9a61-3015c0637ee3
     status: 200 OK
     code: 200
     duration: ""
@@ -5396,7 +4967,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b7b9c370-4bc5-4ddc-aaee-2813d8048b45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/15c23453-3acd-42b8-bc30-3b886ac85bea
     method: DELETE
   response:
     body: ""
@@ -5406,9 +4977,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:36:39 GMT
+      - Fri, 23 Feb 2024 14:09:30 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5416,7 +4987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b58244d3-c87f-4bf6-ae2b-b0fc4bbfea79
+      - 509f23be-a7e2-486b-8a01-9ab0b0f9a50a
     status: 204 No Content
     code: 204
     duration: ""
@@ -5427,10 +4998,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -5439,9 +5010,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:37:12 GMT
+      - Fri, 23 Feb 2024 14:09:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5449,7 +5020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7849d440-ff78-4cf4-8c5c-6f6bb49ee9eb
+      - c52f54e8-3ea0-4420-b14d-a912f13ff4a8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5460,21 +5031,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1284"
+      - "1282"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:37:13 GMT
+      - Fri, 23 Feb 2024 14:09:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5482,7 +5053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07c77597-764f-425a-be21-6e6103f4388c
+      - 1c3a5a86-70ce-41a7-bc69-f3ddb402218f
     status: 200 OK
     code: 200
     duration: ""
@@ -5493,7 +5064,73 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/a8e90846-d514-4239-bbe9-563ff6a55a8f
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1285"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:10:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e050ef18-9d32-4e60-a775-db53ce87a87d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:35.308478Z","endpoint":{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720},"endpoints":[{"id":"d9ae927c-8e31-46a9-958c-a609c318d0fc","ip":"51.159.10.191","load_balancer":{},"name":null,"port":23720}],"engine":"PostgreSQL-15","id":"437e0d18-ee40-47db-954a-a43176faa05d","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1285"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:10:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cfe3c95b-da39-4be0-8c54-2f103bfbe21b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3279e5f5-1eb0-4b85-8bde-8d05b30bd863
     method: DELETE
   response:
     body: ""
@@ -5503,9 +5140,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:37:14 GMT
+      - Fri, 23 Feb 2024 14:10:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5513,7 +5150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04121c80-88f0-4ba0-888e-b85684bd916f
+      - 40b1b20b-39fc-4c1f-9acb-f174353fbf62
     status: 204 No Content
     code: 204
     duration: ""
@@ -5524,76 +5161,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
-    method: DELETE
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1287"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:37:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 93b453fe-f864-428a-b2ee-89e29626cc16
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-21T18:24:52.077227Z","endpoint":{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755},"endpoints":[{"id":"84cd78bd-27b2-4b62-b8bb-4559dc6ba956","ip":"51.159.207.148","load_balancer":{},"name":null,"port":17755}],"engine":"PostgreSQL-15","id":"da68cc82-6010-4167-a577-034bee58968a","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-update","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","update"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1287"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Feb 2024 18:37:15 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f001ffa5-7db0-4656-8b21-2b5571e3a0e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"da68cc82-6010-4167-a577-034bee58968a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"437e0d18-ee40-47db-954a-a43176faa05d","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -5602,9 +5173,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:37:46 GMT
+      - Fri, 23 Feb 2024 14:10:30 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5612,7 +5183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a66c32f-7af1-42f8-9303-0af472f7379b
+      - b41d824e-3ee9-43ee-844b-85aa3bdce0c9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5623,10 +5194,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/da68cc82-6010-4167-a577-034bee58968a
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/437e0d18-ee40-47db-954a-a43176faa05d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"da68cc82-6010-4167-a577-034bee58968a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"437e0d18-ee40-47db-954a-a43176faa05d","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -5635,9 +5206,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:37:46 GMT
+      - Fri, 23 Feb 2024 14:10:30 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5645,7 +5216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1011a1f-da37-4cc4-9ee6-a4009339d959
+      - 76b86ffd-033c-4e60-a4cf-3fff24c68261
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5656,10 +5227,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"17f0cfa6-f4b0-4f34-b0f7-9fb435ba6f31","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"d9b1bbbd-da1b-4d6d-b625-6e3cfba0bacd","type":"not_found"}'
     headers:
       Content-Length:
       - "133"
@@ -5668,9 +5239,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 21 Feb 2024 18:37:46 GMT
+      - Fri, 23 Feb 2024 14:10:30 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5678,7 +5249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23504a4c-3013-42ea-bb2c-635d84f8235e
+      - 6e7242a2-7cd5-436e-869b-f8fb0376bc47
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/rdb-read-replica-with-instance-also-in-private-network.cassette.yaml
+++ b/scaleway/testdata/rdb-read-replica-with-instance-also-in-private-network.cassette.yaml
@@ -1,0 +1,2616 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"name":"test-rdb-rr-instance-in-pn2","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.030713Z","dhcp_enabled":true,"id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","name":"test-rdb-rr-instance-in-pn2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.030713Z","id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09","subnet":"172.16.8.0/22","updated_at":"2024-02-23T13:56:35.030713Z"},{"created_at":"2024-02-23T13:56:35.030713Z","id":"d8fe5e0b-8d3a-4fe7-8c19-57483aa63f6e","subnet":"fd63:256c:45f7:329f::/64","updated_at":"2024-02-23T13:56:35.030713Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.030713Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "727"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:56:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5e0aa57a-8476-4bde-8945-0204998a6cde
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/673b3539-d4f0-4d5b-9094-1cf8fd3924c6
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.030713Z","dhcp_enabled":true,"id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","name":"test-rdb-rr-instance-in-pn2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.030713Z","id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09","subnet":"172.16.8.0/22","updated_at":"2024-02-23T13:56:35.030713Z"},{"created_at":"2024-02-23T13:56:35.030713Z","id":"d8fe5e0b-8d3a-4fe7-8c19-57483aa63f6e","subnet":"fd63:256c:45f7:329f::/64","updated_at":"2024-02-23T13:56:35.030713Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.030713Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "727"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:56:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f6c9cfbc-75bd-4f1f-bb9d-6a3247ac5e33
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"test-rdb-rr-instance-in-pn1","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.266951Z","dhcp_enabled":true,"id":"369d921d-b3a2-46e9-b51a-9161f208a723","name":"test-rdb-rr-instance-in-pn1","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.266951Z","id":"bf8766c2-778f-4ae2-957c-36918c60fa28","subnet":"172.16.20.0/22","updated_at":"2024-02-23T13:56:35.266951Z"},{"created_at":"2024-02-23T13:56:35.266951Z","id":"77fa7661-9a22-40a1-9b68-fb9bd09713cf","subnet":"fd63:256c:45f7:335e::/64","updated_at":"2024-02-23T13:56:35.266951Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.266951Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "728"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:56:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1665370c-09d0-42c1-8cd8-ab1e03f5b057
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/369d921d-b3a2-46e9-b51a-9161f208a723
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.266951Z","dhcp_enabled":true,"id":"369d921d-b3a2-46e9-b51a-9161f208a723","name":"test-rdb-rr-instance-in-pn1","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.266951Z","id":"bf8766c2-778f-4ae2-957c-36918c60fa28","subnet":"172.16.20.0/22","updated_at":"2024-02-23T13:56:35.266951Z"},{"created_at":"2024-02-23T13:56:35.266951Z","id":"77fa7661-9a22-40a1-9b68-fb9bd09713cf","subnet":"fd63:256c:45f7:335e::/64","updated_at":"2024-02-23T13:56:35.266951Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.266951Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "728"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:56:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fa89e2c4-ca64-40b3-95c4-961d257e0ea3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test-rdb-rr-instance-in-pn","engine":"PostgreSQL-15","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","node_type":"db-dev-s","is_ha_cluster":false,"disable_backup":true,"tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"init_settings":null,"volume_type":"lssd","volume_size":0,"init_endpoints":[{"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","ipam_config":{}}}],"backup_same_region":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances
+    method: POST
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1033"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:56:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b3bb142f-db26-4e6b-b767-3d08d8fce5be
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1033"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:56:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b858077-98e2-4aa2-a282-8e928d3ba33d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1033"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:57:11 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fa74c890-ef09-4477-9248-dc6acb54e24d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1033"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:57:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec746ed0-a175-4ac6-b989-91826a716781
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1033"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:58:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 199311f1-70f1-4101-9259-b7397a566a96
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1033"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:58:48 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9fc80320-ca2e-4a52-b6f7-a6a5f05b1edd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1301"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ba232c96-4bfd-4016-91fb-b52b6744616c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVUmlrL1g3MzlGZlRkd0tRUTdOVlZPdUNLeE9Nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TUM0eU1CNFhEVEkwCk1ESXlNekV6TlRjME5Wb1hEVE0wTURJeU1ERXpOVGMwTlZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU1DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxbGlYUGJqSTZEb3JWL25XVDVQSEJhakprYnUwSmt4aTNhQy8ybDBpayswTFU0OHJmNC9oOTNQZ2hSS0IKVCsxZTZITHVKSUtCMlcrZ0dTbnJPb1Y3WGpIMjBXUkU0MEpLckpZRUxZdjh2WXRyK1RkLzh1MWdBQzFEYUVOTgpKOGNrakJpWWtzN2t1YkN0c3FXS0FXNkY1ZUd4Zjl3UGtaZ0k2Y0VXZERmRkYybmYzemV5QW90aVNZNVcvbFpUCmcrV2pOV1Q4THJ5OEprc2pPd0YvSFBQdTVHK2NCbWlwUGtTSzYyRVYyUXFjejY5V09JVGdlL0FEYnJ2cG1TazMKWTBGZ05Zb3ZUZFJwT3Fkb2hScm4rVVpOcXp5VFV2NHF4OHZmOEVFN25DWDFZanJsNmRJSHAwSmlMY1prYjdJcgpkRnJrN1ZTT29XdkFwM2R3azl5cmhmUG1Md0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qQXVNb2NFbzZ5ekhJY0VyQkFVQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVdac05ENElkbjg5a2JXUzIKSHNQeGd4QnpURFBLZzNpV09XbU9QVmtrbjZnRVBNV2RVMGpHQmdlL0JlSFQ0MURZb0l2alZ5a3dxSVJudGw3QgpZT0hVT3Vab2xmZGJxU1lhZkhWN05lWlBGSFh1bzlsUWF3ZC9JSUxkcEljTnNIN2RQQlg4QUZvdFJWcmV3RERkCnFFNlEwdlBnbEloTzVBMDAvWDgyb3JkdnJhQnZpZks5MlpKSURqdG9mWVlFVHVkZFBBKzF5dWs4LzZ2dDJjMXoKcjJHRlpxSkYydVhTcDB0NnN1ZFlMNHAvOS9wNHV3UFhrbTZoanphclVnK1pVTm1xajRIVGphWDJKWTBPSTNFdApRTCt0UWdIamk0dktCZnd5MExNNks4cTFZRkg5eURFdkpPTXJoRExLSkZFbVBNYjF0S0dZQksrQ24waWwydmFUClNNTXRPUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8d2364cf-da4c-4d0a-8c65-3e9c939af674
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.20.2/22","created_at":"2024-02-23T13:56:36.445430Z","id":"5fa5e640-25cf-4173-b756-85570f4d1f89","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CA","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:57:13.367542Z","zone":null}],"total_count":1}'
+    headers:
+      Content-Length:
+      - "553"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c3c6cfb3-7122-4dc8-be86-88fc256a75f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","endpoint_spec":[{"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","ipam_config":{}}}],"same_zone":true}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas
+    method: POST
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    headers:
+      Content-Length:
+      - "399"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1a351849-5c43-4e48-b3db-20a319156307
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    headers:
+      Content-Length:
+      - "399"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8e3fa25e-647f-42a7-bd80-f2b9c9411100
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    headers:
+      Content-Length:
+      - "399"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 13:59:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f14727ae-fb5a-41d9-9b81-f83045f00321
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"provisioning"}'
+    headers:
+      Content-Length:
+      - "399"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:00:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 368e6d26-5641-4e69-b196-6a020f75a20b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "399"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:00:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 084b6d2a-0c64-4b13-a493-ea068c0a64d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "399"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d4dd9a83-a30d-4a88-aab5-cc7be78cb072
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "392"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a6ff9515-254a-426f-a416-e63180326f5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "392"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4ea570ec-9869-40c1-87fa-8abbac6f919d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.20.3/22","created_at":"2024-02-23T13:59:19.987182Z","id":"9900c807-d334-472b-bd90-ba222b7d877e","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CD","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:59:52.026946Z","zone":null},{"address":"172.16.20.2/22","created_at":"2024-02-23T13:56:36.445430Z","id":"5fa5e640-25cf-4173-b756-85570f4d1f89","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CA","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:57:13.367542Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1076"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8c85716e-7673-4e3f-b971-ede11e568497
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "392"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c220bc5-1758-4fad-beb6-9d78c11cc681
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/673b3539-d4f0-4d5b-9094-1cf8fd3924c6
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.030713Z","dhcp_enabled":true,"id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","name":"test-rdb-rr-instance-in-pn2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.030713Z","id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09","subnet":"172.16.8.0/22","updated_at":"2024-02-23T13:56:35.030713Z"},{"created_at":"2024-02-23T13:56:35.030713Z","id":"d8fe5e0b-8d3a-4fe7-8c19-57483aa63f6e","subnet":"fd63:256c:45f7:329f::/64","updated_at":"2024-02-23T13:56:35.030713Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.030713Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "727"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6bb7ffc6-03b6-4f48-af7e-c08dd914f5b8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/369d921d-b3a2-46e9-b51a-9161f208a723
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.266951Z","dhcp_enabled":true,"id":"369d921d-b3a2-46e9-b51a-9161f208a723","name":"test-rdb-rr-instance-in-pn1","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.266951Z","id":"bf8766c2-778f-4ae2-957c-36918c60fa28","subnet":"172.16.20.0/22","updated_at":"2024-02-23T13:56:35.266951Z"},{"created_at":"2024-02-23T13:56:35.266951Z","id":"77fa7661-9a22-40a1-9b68-fb9bd09713cf","subnet":"fd63:256c:45f7:335e::/64","updated_at":"2024-02-23T13:56:35.266951Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.266951Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "728"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5869dcf6-636d-4c9b-a648-5622c61e2573
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1693"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a5ed49c-ce54-4021-a198-b2827b9a8754
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVUmlrL1g3MzlGZlRkd0tRUTdOVlZPdUNLeE9Nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TUM0eU1CNFhEVEkwCk1ESXlNekV6TlRjME5Wb1hEVE0wTURJeU1ERXpOVGMwTlZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU1DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxbGlYUGJqSTZEb3JWL25XVDVQSEJhakprYnUwSmt4aTNhQy8ybDBpayswTFU0OHJmNC9oOTNQZ2hSS0IKVCsxZTZITHVKSUtCMlcrZ0dTbnJPb1Y3WGpIMjBXUkU0MEpLckpZRUxZdjh2WXRyK1RkLzh1MWdBQzFEYUVOTgpKOGNrakJpWWtzN2t1YkN0c3FXS0FXNkY1ZUd4Zjl3UGtaZ0k2Y0VXZERmRkYybmYzemV5QW90aVNZNVcvbFpUCmcrV2pOV1Q4THJ5OEprc2pPd0YvSFBQdTVHK2NCbWlwUGtTSzYyRVYyUXFjejY5V09JVGdlL0FEYnJ2cG1TazMKWTBGZ05Zb3ZUZFJwT3Fkb2hScm4rVVpOcXp5VFV2NHF4OHZmOEVFN25DWDFZanJsNmRJSHAwSmlMY1prYjdJcgpkRnJrN1ZTT29XdkFwM2R3azl5cmhmUG1Md0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qQXVNb2NFbzZ5ekhJY0VyQkFVQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVdac05ENElkbjg5a2JXUzIKSHNQeGd4QnpURFBLZzNpV09XbU9QVmtrbjZnRVBNV2RVMGpHQmdlL0JlSFQ0MURZb0l2alZ5a3dxSVJudGw3QgpZT0hVT3Vab2xmZGJxU1lhZkhWN05lWlBGSFh1bzlsUWF3ZC9JSUxkcEljTnNIN2RQQlg4QUZvdFJWcmV3RERkCnFFNlEwdlBnbEloTzVBMDAvWDgyb3JkdnJhQnZpZks5MlpKSURqdG9mWVlFVHVkZFBBKzF5dWs4LzZ2dDJjMXoKcjJHRlpxSkYydVhTcDB0NnN1ZFlMNHAvOS9wNHV3UFhrbTZoanphclVnK1pVTm1xajRIVGphWDJKWTBPSTNFdApRTCt0UWdIamk0dktCZnd5MExNNks4cTFZRkg5eURFdkpPTXJoRExLSkZFbVBNYjF0S0dZQksrQ24waWwydmFUClNNTXRPUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 692a3b60-6a49-47ab-a2b0-1a7ef3d88791
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.20.3/22","created_at":"2024-02-23T13:59:19.987182Z","id":"9900c807-d334-472b-bd90-ba222b7d877e","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CD","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:59:52.026946Z","zone":null},{"address":"172.16.20.2/22","created_at":"2024-02-23T13:56:36.445430Z","id":"5fa5e640-25cf-4173-b756-85570f4d1f89","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CA","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:57:13.367542Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1076"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d095f3c9-5726-46cf-b2da-ec4ec26b71b7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "392"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c13e6998-ecf6-42bc-a2b7-7451a730fa73
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.20.3/22","created_at":"2024-02-23T13:59:19.987182Z","id":"9900c807-d334-472b-bd90-ba222b7d877e","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CD","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:59:52.026946Z","zone":null},{"address":"172.16.20.2/22","created_at":"2024-02-23T13:56:36.445430Z","id":"5fa5e640-25cf-4173-b756-85570f4d1f89","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CA","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:57:13.367542Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1076"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d30c9ee9-a92c-46b5-b8d0-311d085f5ee5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/673b3539-d4f0-4d5b-9094-1cf8fd3924c6
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.030713Z","dhcp_enabled":true,"id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","name":"test-rdb-rr-instance-in-pn2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.030713Z","id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09","subnet":"172.16.8.0/22","updated_at":"2024-02-23T13:56:35.030713Z"},{"created_at":"2024-02-23T13:56:35.030713Z","id":"d8fe5e0b-8d3a-4fe7-8c19-57483aa63f6e","subnet":"fd63:256c:45f7:329f::/64","updated_at":"2024-02-23T13:56:35.030713Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.030713Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "727"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 221154f1-b26c-4ef7-b809-6235006daceb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/369d921d-b3a2-46e9-b51a-9161f208a723
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.266951Z","dhcp_enabled":true,"id":"369d921d-b3a2-46e9-b51a-9161f208a723","name":"test-rdb-rr-instance-in-pn1","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.266951Z","id":"bf8766c2-778f-4ae2-957c-36918c60fa28","subnet":"172.16.20.0/22","updated_at":"2024-02-23T13:56:35.266951Z"},{"created_at":"2024-02-23T13:56:35.266951Z","id":"77fa7661-9a22-40a1-9b68-fb9bd09713cf","subnet":"fd63:256c:45f7:335e::/64","updated_at":"2024-02-23T13:56:35.266951Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.266951Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "728"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0c512f5c-9369-4d09-bbb5-700023416a02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1693"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9e4f949d-65ad-4e57-9682-de6362c2f9ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVUmlrL1g3MzlGZlRkd0tRUTdOVlZPdUNLeE9Nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TUM0eU1CNFhEVEkwCk1ESXlNekV6TlRjME5Wb1hEVE0wTURJeU1ERXpOVGMwTlZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU1DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxbGlYUGJqSTZEb3JWL25XVDVQSEJhakprYnUwSmt4aTNhQy8ybDBpayswTFU0OHJmNC9oOTNQZ2hSS0IKVCsxZTZITHVKSUtCMlcrZ0dTbnJPb1Y3WGpIMjBXUkU0MEpLckpZRUxZdjh2WXRyK1RkLzh1MWdBQzFEYUVOTgpKOGNrakJpWWtzN2t1YkN0c3FXS0FXNkY1ZUd4Zjl3UGtaZ0k2Y0VXZERmRkYybmYzemV5QW90aVNZNVcvbFpUCmcrV2pOV1Q4THJ5OEprc2pPd0YvSFBQdTVHK2NCbWlwUGtTSzYyRVYyUXFjejY5V09JVGdlL0FEYnJ2cG1TazMKWTBGZ05Zb3ZUZFJwT3Fkb2hScm4rVVpOcXp5VFV2NHF4OHZmOEVFN25DWDFZanJsNmRJSHAwSmlMY1prYjdJcgpkRnJrN1ZTT29XdkFwM2R3azl5cmhmUG1Md0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qQXVNb2NFbzZ5ekhJY0VyQkFVQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVdac05ENElkbjg5a2JXUzIKSHNQeGd4QnpURFBLZzNpV09XbU9QVmtrbjZnRVBNV2RVMGpHQmdlL0JlSFQ0MURZb0l2alZ5a3dxSVJudGw3QgpZT0hVT3Vab2xmZGJxU1lhZkhWN05lWlBGSFh1bzlsUWF3ZC9JSUxkcEljTnNIN2RQQlg4QUZvdFJWcmV3RERkCnFFNlEwdlBnbEloTzVBMDAvWDgyb3JkdnJhQnZpZks5MlpKSURqdG9mWVlFVHVkZFBBKzF5dWs4LzZ2dDJjMXoKcjJHRlpxSkYydVhTcDB0NnN1ZFlMNHAvOS9wNHV3UFhrbTZoanphclVnK1pVTm1xajRIVGphWDJKWTBPSTNFdApRTCt0UWdIamk0dktCZnd5MExNNks4cTFZRkg5eURFdkpPTXJoRExLSkZFbVBNYjF0S0dZQksrQ24waWwydmFUClNNTXRPUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6dd157ee-309b-4e58-9db0-02322e8a75a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.20.3/22","created_at":"2024-02-23T13:59:19.987182Z","id":"9900c807-d334-472b-bd90-ba222b7d877e","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CD","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:59:52.026946Z","zone":null},{"address":"172.16.20.2/22","created_at":"2024-02-23T13:56:36.445430Z","id":"5fa5e640-25cf-4173-b756-85570f4d1f89","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CA","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:57:13.367542Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1076"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 836bee4b-6fcc-451e-99bb-c9a87e31fcc2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "392"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cc2a9338-0ea6-47d8-9476-dfeb23814785
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.20.3/22","created_at":"2024-02-23T13:59:19.987182Z","id":"9900c807-d334-472b-bd90-ba222b7d877e","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CD","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:59:52.026946Z","zone":null},{"address":"172.16.20.2/22","created_at":"2024-02-23T13:56:36.445430Z","id":"5fa5e640-25cf-4173-b756-85570f4d1f89","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CA","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:57:13.367542Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1076"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - da6f2f99-7865-4582-a3c7-761774fef813
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1693"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0df2d870-9aec-445f-9d67-7a8f46f40d37
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1693"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c640d56-42a2-4768-8b02-34e8b6200126
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: PATCH
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1693"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4ea73a05-11ac-49ff-ae76-537367068c40
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1693"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d5eaf3ed-77bd-4075-8821-f00908ce2a37
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/3874d98b-2729-439b-8d11-75ed03c8821a
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df1878b8-6a13-49b1-9a8e-a241fa637882
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"3874d98b-2729-439b-8d11-75ed03c8821a","ip":"172.16.20.2","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"configuring","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1699"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:01:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56c8b442-5e61-4caf-873e-4c464cdbc49e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1471"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3b586554-2d30-4aa9-b7e4-1789370b0f34
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":{"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","ipam_config":{}}}}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2/endpoints
+    method: POST
+  response:
+    body: '{"id":"b139c1f5-40ac-4685-81bb-3588b24c97e9","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "220"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8fd65959-0e0a-406b-a110-2b55337bea6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"b139c1f5-40ac-4685-81bb-3588b24c97e9","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1698"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8d670386-98e2-4ef0-ae9d-accb75301a77
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"b139c1f5-40ac-4685-81bb-3588b24c97e9","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1691"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c07f38a1-9c1e-414d-8fa6-3079b07235d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVUmlrL1g3MzlGZlRkd0tRUTdOVlZPdUNLeE9Nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TUM0eU1CNFhEVEkwCk1ESXlNekV6TlRjME5Wb1hEVE0wTURJeU1ERXpOVGMwTlZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU1DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxbGlYUGJqSTZEb3JWL25XVDVQSEJhakprYnUwSmt4aTNhQy8ybDBpayswTFU0OHJmNC9oOTNQZ2hSS0IKVCsxZTZITHVKSUtCMlcrZ0dTbnJPb1Y3WGpIMjBXUkU0MEpLckpZRUxZdjh2WXRyK1RkLzh1MWdBQzFEYUVOTgpKOGNrakJpWWtzN2t1YkN0c3FXS0FXNkY1ZUd4Zjl3UGtaZ0k2Y0VXZERmRkYybmYzemV5QW90aVNZNVcvbFpUCmcrV2pOV1Q4THJ5OEprc2pPd0YvSFBQdTVHK2NCbWlwUGtTSzYyRVYyUXFjejY5V09JVGdlL0FEYnJ2cG1TazMKWTBGZ05Zb3ZUZFJwT3Fkb2hScm4rVVpOcXp5VFV2NHF4OHZmOEVFN25DWDFZanJsNmRJSHAwSmlMY1prYjdJcgpkRnJrN1ZTT29XdkFwM2R3azl5cmhmUG1Md0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qQXVNb2NFbzZ5ekhJY0VyQkFVQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVdac05ENElkbjg5a2JXUzIKSHNQeGd4QnpURFBLZzNpV09XbU9QVmtrbjZnRVBNV2RVMGpHQmdlL0JlSFQ0MURZb0l2alZ5a3dxSVJudGw3QgpZT0hVT3Vab2xmZGJxU1lhZkhWN05lWlBGSFh1bzlsUWF3ZC9JSUxkcEljTnNIN2RQQlg4QUZvdFJWcmV3RERkCnFFNlEwdlBnbEloTzVBMDAvWDgyb3JkdnJhQnZpZks5MlpKSURqdG9mWVlFVHVkZFBBKzF5dWs4LzZ2dDJjMXoKcjJHRlpxSkYydVhTcDB0NnN1ZFlMNHAvOS9wNHV3UFhrbTZoanphclVnK1pVTm1xajRIVGphWDJKWTBPSTNFdApRTCt0UWdIamk0dktCZnd5MExNNks4cTFZRkg5eURFdkpPTXJoRExLSkZFbVBNYjF0S0dZQksrQ24waWwydmFUClNNTXRPUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c31618a8-94dd-4602-bfd4-ccedac0ea889
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.8.2/22","created_at":"2024-02-23T14:02:26.973020Z","id":"0b360a5e-4321-4f9a-8234-58e9a54641a1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:D7","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:02:28.356441Z","zone":null},{"address":"172.16.20.3/22","created_at":"2024-02-23T13:59:19.987182Z","id":"9900c807-d334-472b-bd90-ba222b7d877e","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:CD","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"bf8766c2-778f-4ae2-957c-36918c60fa28"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T13:59:52.026946Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1075"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ce9929bb-0a82-4951-a2a0-dbbb3ef9aa72
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "392"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2466e54c-cf96-4ed8-af4d-0fce21994338
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/endpoints/abb3b178-89cb-4ae7-83cc-7e8fd8402f6c
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b3294e9-78ad-4a5d-95b8-1cd053405212
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"abb3b178-89cb-4ae7-83cc-7e8fd8402f6c","ip":"172.16.20.3","name":null,"port":5432,"private_network":{"private_network_id":"369d921d-b3a2-46e9-b51a-9161f208a723","service_ip":"172.16.20.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"configuring"}'
+    headers:
+      Content-Length:
+      - "398"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:02:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 32546ebd-18d5-41ea-9af4-fa600b6a055b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "170"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:28 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6e600829-dd45-4e02-b587-83d70b8cebbe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "170"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:28 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4beebb25-6016-4697-a37b-615a8311af2c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"endpoint_spec":[{"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","ipam_config":{}}}]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e/endpoints
+    method: POST
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 24d310b4-c7e0-4ddb-bf29-859ed6f9540f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"initializing"}'
+    headers:
+      Content-Length:
+      - "397"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e6ff4c1d-1b9e-424b-869d-f14114b4ddfc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "390"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dee7f466-e742-404a-a0c4-4fd9637e377f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "390"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6019b589-ad0c-412c-9c4d-6eb87a839828
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.8.3/22","created_at":"2024-02-23T14:03:28.805047Z","id":"869e0913-9e3f-4e96-8687-c95ab8ef82ea","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:D8","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:03:30.124763Z","zone":null},{"address":"172.16.8.2/22","created_at":"2024-02-23T14:02:26.973020Z","id":"0b360a5e-4321-4f9a-8234-58e9a54641a1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:D7","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:02:28.356441Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1074"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 286b2cb6-1959-4024-894e-7202dca94d98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "390"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c1b3ba05-b969-4e61-82ab-b0b49b9dd668
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/369d921d-b3a2-46e9-b51a-9161f208a723
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.266951Z","dhcp_enabled":true,"id":"369d921d-b3a2-46e9-b51a-9161f208a723","name":"test-rdb-rr-instance-in-pn1","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.266951Z","id":"bf8766c2-778f-4ae2-957c-36918c60fa28","subnet":"172.16.20.0/22","updated_at":"2024-02-23T13:56:35.266951Z"},{"created_at":"2024-02-23T13:56:35.266951Z","id":"77fa7661-9a22-40a1-9b68-fb9bd09713cf","subnet":"fd63:256c:45f7:335e::/64","updated_at":"2024-02-23T13:56:35.266951Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.266951Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "728"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ee9497f6-c3cf-4ebc-9e5f-a68d8332d2e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/673b3539-d4f0-4d5b-9094-1cf8fd3924c6
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-23T13:56:35.030713Z","dhcp_enabled":true,"id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","name":"test-rdb-rr-instance-in-pn2","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-23T13:56:35.030713Z","id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09","subnet":"172.16.8.0/22","updated_at":"2024-02-23T13:56:35.030713Z"},{"created_at":"2024-02-23T13:56:35.030713Z","id":"d8fe5e0b-8d3a-4fe7-8c19-57483aa63f6e","subnet":"fd63:256c:45f7:329f::/64","updated_at":"2024-02-23T13:56:35.030713Z"}],"tags":[],"updated_at":"2024-02-23T13:56:35.030713Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    headers:
+      Content-Length:
+      - "727"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 518c289f-aae3-4012-b9ac-59d61b2f7b98
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"b139c1f5-40ac-4685-81bb-3588b24c97e9","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1689"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:03:59 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 45c86ada-b60a-4f0b-be80-8c503c45a56a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVUmlrL1g3MzlGZlRkd0tRUTdOVlZPdUNLeE9Nd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBU0JnTlZCQU1NQ3pFM01pNHhOaTR5TUM0eU1CNFhEVEkwCk1ESXlNekV6TlRjME5Wb1hEVE0wTURJeU1ERXpOVGMwTlZvd1ZqRUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlYKQkFnTUJWQmhjbWx6TVE0d0RBWURWUVFIREFWUVlYSnBjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RkRBUwpCZ05WQkFNTUN6RTNNaTR4Tmk0eU1DNHlNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDCkFRRUFxbGlYUGJqSTZEb3JWL25XVDVQSEJhakprYnUwSmt4aTNhQy8ybDBpayswTFU0OHJmNC9oOTNQZ2hSS0IKVCsxZTZITHVKSUtCMlcrZ0dTbnJPb1Y3WGpIMjBXUkU0MEpLckpZRUxZdjh2WXRyK1RkLzh1MWdBQzFEYUVOTgpKOGNrakJpWWtzN2t1YkN0c3FXS0FXNkY1ZUd4Zjl3UGtaZ0k2Y0VXZERmRkYybmYzemV5QW90aVNZNVcvbFpUCmcrV2pOV1Q4THJ5OEprc2pPd0YvSFBQdTVHK2NCbWlwUGtTSzYyRVYyUXFjejY5V09JVGdlL0FEYnJ2cG1TazMKWTBGZ05Zb3ZUZFJwT3Fkb2hScm4rVVpOcXp5VFV2NHF4OHZmOEVFN25DWDFZanJsNmRJSHAwSmlMY1prYjdJcgpkRnJrN1ZTT29XdkFwM2R3azl5cmhmUG1Md0lEQVFBQm95WXdKREFpQmdOVkhSRUVHekFaZ2dzeE56SXVNVFl1Ck1qQXVNb2NFbzZ5ekhJY0VyQkFVQWpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVdac05ENElkbjg5a2JXUzIKSHNQeGd4QnpURFBLZzNpV09XbU9QVmtrbjZnRVBNV2RVMGpHQmdlL0JlSFQ0MURZb0l2alZ5a3dxSVJudGw3QgpZT0hVT3Vab2xmZGJxU1lhZkhWN05lWlBGSFh1bzlsUWF3ZC9JSUxkcEljTnNIN2RQQlg4QUZvdFJWcmV3RERkCnFFNlEwdlBnbEloTzVBMDAvWDgyb3JkdnJhQnZpZks5MlpKSURqdG9mWVlFVHVkZFBBKzF5dWs4LzZ2dDJjMXoKcjJHRlpxSkYydVhTcDB0NnN1ZFlMNHAvOS9wNHV3UFhrbTZoanphclVnK1pVTm1xajRIVGphWDJKWTBPSTNFdApRTCt0UWdIamk0dktCZnd5MExNNks4cTFZRkg5eURFdkpPTXJoRExLSkZFbVBNYjF0S0dZQksrQ24waWwydmFUClNNTXRPUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - df5d3003-c308-47df-b2fc-fab9cb86f088
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.8.3/22","created_at":"2024-02-23T14:03:28.805047Z","id":"869e0913-9e3f-4e96-8687-c95ab8ef82ea","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:D8","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:03:30.124763Z","zone":null},{"address":"172.16.8.2/22","created_at":"2024-02-23T14:02:26.973020Z","id":"0b360a5e-4321-4f9a-8234-58e9a54641a1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:D7","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:02:28.356441Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1074"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 21b35bed-652f-464b-a8cf-b193658b5318
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "390"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85ae9c6e-bbce-4a01-aa91-9099e7068bca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=a93e1a4b-a062-4dc2-9f78-37f17efd27a2&resource_type=rdb_instance
+    method: GET
+  response:
+    body: '{"ips":[{"address":"172.16.8.3/22","created_at":"2024-02-23T14:03:28.805047Z","id":"869e0913-9e3f-4e96-8687-c95ab8ef82ea","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:D8","name":"read-replica-ecfe7ebe","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:03:30.124763Z","zone":null},{"address":"172.16.8.2/22","created_at":"2024-02-23T14:02:26.973020Z","id":"0b360a5e-4321-4f9a-8234-58e9a54641a1","is_ipv6":false,"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","resource":{"id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","mac_address":"02:00:00:18:94:D7","name":"test-rdb-rr-instance-in-pn","type":"rdb_instance"},"reverses":[],"source":{"subnet_id":"a97b0b9d-0bff-4802-90db-e5e648bb6a09"},"tags":["managed","scwdbaas"],"updated_at":"2024-02-23T14:02:28.356441Z","zone":null}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1074"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6233d755-fac6-49ec-9326-becb1d009b6c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"ready"}'
+    headers:
+      Content-Length:
+      - "390"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d11b62b8-378a-4149-8d38-cb86c354239a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: DELETE
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"deleting"}'
+    headers:
+      Content-Length:
+      - "393"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fc67c01c-e0ad-428c-9886-f8dabbb4ebe5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"endpoints":[{"id":"7fb2b6c5-101b-41a9-b5c0-0ddd172fd10d","ip":"172.16.8.3","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.3/22","zone":"fr-par-1"}}],"id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","instance_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","region":"fr-par","same_zone":true,"status":"deleting"}'
+    headers:
+      Content-Length:
+      - "393"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25e03906-3f86-4e6a-a5c3-c6f46ce13b55
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/369d921d-b3a2-46e9-b51a-9161f208a723
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a0e0a895-1428-425c-9f9c-d1f993f0a7c6
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "133"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cb2249dc-132f-4332-8109-3d39bb0f4fde
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"b139c1f5-40ac-4685-81bb-3588b24c97e9","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7fa18423-6cec-4d00-81b4-53f8da78eed9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: DELETE
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"b139c1f5-40ac-4685-81bb-3588b24c97e9","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1302"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 780f2dcd-ab8b-4c04-8cf6-1207f68f1f11
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-02-23T13:56:36.058349Z","endpoint":null,"endpoints":[{"id":"b139c1f5-40ac-4685-81bb-3588b24c97e9","ip":"172.16.8.2","name":null,"port":5432,"private_network":{"private_network_id":"673b3539-d4f0-4d5b-9094-1cf8fd3924c6","service_ip":"172.16.8.2/22","zone":"fr-par-1"}}],"engine":"PostgreSQL-15","id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-rr-instance-in-pn","node_type":"db-dev-s","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","read_replicas":[],"region":"fr-par","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_read_replica","instance-also-in-pn"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1302"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:04:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1bd553b5-23da-4a18-9c63-f039ed90a911
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:05:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ef69ee45-eb95-4b80-a306-ab79b4e51ccb
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/673b3539-d4f0-4d5b-9094-1cf8fd3924c6
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:05:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 587837c9-c454-4dbf-8482-e2024cfa4b8f
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/instances/a93e1a4b-a062-4dc2-9f78-37f17efd27a2
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a93e1a4b-a062-4dc2-9f78-37f17efd27a2","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "129"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:05:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d86cb95b-33ae-42c9-9f8e-b8537d0c8225
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/fr-par/read-replicas/ecfe7ebe-c2cb-4544-bc29-11a0f822a11e
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"read_replica","resource_id":"ecfe7ebe-c2cb-4544-bc29-11a0f822a11e","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "133"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 23 Feb 2024 14:05:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ec87a495-1ffd-4a9d-b3a6-f867eaebf25b
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
This PR renders the choice between a static configuration (with given IPs) and IPAM configuration explicit when creating a private endpoint for Read Replicas and Instances.
It also fixes the error `expected no more than 1 IP for instance, got 2` which occurred when more than 1 RDB resource (for example 1 Instance + 1 Read Replica) was attached to the same Private Network.

Closes #2399 